### PR TITLE
refactor(misc): Use RwLock instead of Mutex

### DIFF
--- a/extensions/warp-fs-memory/src/native.rs
+++ b/extensions/warp-fs-memory/src/native.rs
@@ -51,7 +51,7 @@ impl Constellation for MemorySystem {
         file.hash_mut().hash_from_file(path)?;
 
         self.current_directory_mut()?.add_item(file.clone())?;
-        if let Ok(mut cache) = self.get_cache() {
+        if let Ok(mut cache) = self.get_cache_mut() {
             let data = Sata::default().encode(warp::sata::libipld::IpldCodec::DagCbor, warp::sata::Kind::Reference, DimensionData::from(PathBuf::from(path)))?;
             cache.add_data(DataType::from(Module::FileSystem), &data)?;
         }
@@ -110,7 +110,7 @@ impl Constellation for MemorySystem {
         file.hash_mut().hash_from_slice(buf)?;
 
         self.current_directory_mut()?.add_item(file.clone())?;
-        if let Ok(mut cache) = self.get_cache() {
+        if let Ok(mut cache) = self.get_cache_mut() {
             let data = Sata::default().encode(warp::sata::libipld::IpldCodec::DagCbor, warp::sata::Kind::Reference, DimensionData::from_buffer(name, buf))?;
             cache.add_data(DataType::from(Module::FileSystem), &data)?;
         }

--- a/extensions/warp-fs-memory/src/wasm.rs
+++ b/extensions/warp-fs-memory/src/wasm.rs
@@ -6,7 +6,7 @@ use warp::pocket_dimension::query::QueryBuilder;
 use warp::pocket_dimension::DimensionData;
 use wasm_bindgen::JsValue;
 
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 
 use crate::{item, MemorySystem, Result};
 use warp::constellation::directory::Directory;
@@ -58,7 +58,7 @@ impl Constellation for MemorySystem {
         file.hash_mut().hash_from_slice(buf)?;
 
         self.current_directory_mut()?.add_item(file.clone())?;
-        if let Ok(mut cache) = self.get_cache() {
+        if let Ok(mut cache) = self.get_cache_mut() {
             let mut data = DataObject::default();
             data.set_size(bytes as u64);
             data.set_payload(
@@ -163,5 +163,5 @@ impl Constellation for MemorySystem {
 
 #[wasm_bindgen]
 pub fn constellation_fs_memory() -> ConstellationAdapter {
-    ConstellationAdapter::new(Arc::new(Mutex::new(Box::new(MemorySystem::new()))))
+    ConstellationAdapter::new(Arc::new(RwLock::new(Box::new(MemorySystem::new()))))
 }

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -17,7 +17,7 @@ async fn account(username: Option<&str>) -> anyhow::Result<Box<dyn MultiPass>> {
     //      The internal store will broadcast at 5ms but ideally it would want to be set to 100ms
     let config = MpIpfsConfig {
         store_setting: StoreSetting {
-            broadcast_interval: 1000,
+            broadcast_interval: 100,
             broadcast_with_connection: true,
             discovery: false,
         },

--- a/extensions/warp-mp-solana/examples/solana-friends.rs
+++ b/extensions/warp-mp-solana/examples/solana-friends.rs
@@ -2,7 +2,7 @@ use warp::crypto::rand::{self, prelude::*};
 use warp::multipass::identity::{Identifier, Identity};
 use warp::multipass::{Friends, MultiPass};
 use warp::pocket_dimension::PocketDimension;
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_solana::{SolanaAccount, Temporary};
 use warp_pd_flatfile::FlatfileStorage;
@@ -23,7 +23,7 @@ use warp_pd_flatfile::FlatfileStorage;
 // }
 
 #[allow(unused)]
-fn cache_setup() -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
+fn cache_setup() -> anyhow::Result<Arc<RwLock<Box<dyn PocketDimension>>>> {
     let mut root = std::env::temp_dir();
     root.push("pd-cache");
 
@@ -36,7 +36,7 @@ fn cache_setup() -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
 
     let storage = FlatfileStorage::new_with_index_file(root, index)?;
 
-    Ok(Arc::new(Mutex::new(Box::new(storage))))
+    Ok(Arc::new(RwLock::new(Box::new(storage))))
 }
 
 fn account() -> anyhow::Result<SolanaAccount<Temporary>> {

--- a/extensions/warp-mp-solana/examples/solana-identity.rs
+++ b/extensions/warp-mp-solana/examples/solana-identity.rs
@@ -1,7 +1,7 @@
 use warp::multipass::identity::IdentityUpdate;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_solana::solana::wallet::SolanaWallet;
 use warp_mp_solana::{SolanaAccount, Temporary};
@@ -32,7 +32,7 @@ fn generated_wallet() -> anyhow::Result<SolanaWallet> {
     .map_err(anyhow::Error::from)
 }
 
-fn cache_setup() -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
+fn cache_setup() -> anyhow::Result<Arc<RwLock<Box<dyn PocketDimension>>>> {
     let mut root = std::env::temp_dir();
     root.push("pd-cache");
 
@@ -45,7 +45,7 @@ fn cache_setup() -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
 
     let storage = FlatfileStorage::new_with_index_file(root, index)?;
 
-    Ok(Arc::new(Mutex::new(Box::new(storage))))
+    Ok(Arc::new(RwLock::new(Box::new(storage))))
 }
 
 fn main() -> anyhow::Result<()> {

--- a/extensions/warp-pd-flatfile/src/lib.rs
+++ b/extensions/warp-pd-flatfile/src/lib.rs
@@ -629,7 +629,7 @@ pub mod ffi {
     use warp::error::Error;
     use warp::ffi::FFIResult;
     use warp::pocket_dimension::PocketDimensionAdapter;
-    use warp::sync::{Arc, Mutex};
+    use warp::sync::{Arc, RwLock};
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
@@ -649,7 +649,7 @@ pub mod ffi {
         };
 
         match FlatfileStorage::new_with_index_file(path, index_file) {
-            Ok(flatfile) => FFIResult::ok(PocketDimensionAdapter::new(Arc::new(Mutex::new(
+            Ok(flatfile) => FFIResult::ok(PocketDimensionAdapter::new(Arc::new(RwLock::new(
                 Box::new(flatfile),
             )))),
             Err(e) => FFIResult::err(e),

--- a/extensions/warp-pd-memory/src/lib.rs
+++ b/extensions/warp-pd-memory/src/lib.rs
@@ -218,19 +218,19 @@ pub(crate) fn execute(data: &[Sata], query: &QueryBuilder) -> Result<Vec<Sata>> 
 pub fn pocketdimension_pd_memory() -> warp::pocket_dimension::PocketDimensionAdapter {
     let client = MemoryClient::new();
     warp::pocket_dimension::PocketDimensionAdapter::new(warp::sync::Arc::new(
-        warp::sync::Mutex::new(Box::new(client)),
+        warp::sync::RwLock::new(Box::new(client)),
     ))
 }
 
 pub mod ffi {
     use crate::MemoryClient;
     use warp::pocket_dimension::PocketDimensionAdapter;
-    use warp::sync::{Arc, Mutex};
+    use warp::sync::{Arc, RwLock};
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
     pub unsafe extern "C" fn pocketdimension_memory_new() -> *mut PocketDimensionAdapter {
-        let obj = Box::new(PocketDimensionAdapter::new(Arc::new(Mutex::new(Box::new(
+        let obj = Box::new(PocketDimensionAdapter::new(Arc::new(RwLock::new(Box::new(
             MemoryClient::new(),
         )))));
         Box::into_raw(obj) as *mut PocketDimensionAdapter

--- a/extensions/warp-pd-stretto/src/lib.rs
+++ b/extensions/warp-pd-stretto/src/lib.rs
@@ -301,13 +301,13 @@ mod test {
 pub mod ffi {
     use crate::StrettoClient;
     use warp::pocket_dimension::PocketDimensionAdapter;
-    use warp::sync::{Arc, Mutex};
+    use warp::sync::{Arc, RwLock};
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
     pub unsafe extern "C" fn pocketdimension_stretto_new() -> *mut PocketDimensionAdapter {
         let client = match StrettoClient::new() {
-            Ok(client) => PocketDimensionAdapter::new(Arc::new(Mutex::new(Box::new(client)))),
+            Ok(client) => PocketDimensionAdapter::new(Arc::new(RwLock::new(Box::new(client)))),
             Err(_) => return std::ptr::null_mut(),
         };
 

--- a/extensions/warp-rg-ipfs/examples/ipfs_messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/ipfs_messenger.rs
@@ -11,7 +11,7 @@ use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
 use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, SenderId};
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_ipfs::config::{Autonat, Dcutr, IpfsSetting, RelayClient, StoreSetting};
 use warp_mp_ipfs::ipfs_identity_temporary;
@@ -19,14 +19,14 @@ use warp_pd_stretto::StrettoClient;
 use warp_rg_ipfs::IpfsMessaging;
 use warp_rg_ipfs::Temporary;
 
-fn cache_setup() -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
+fn cache_setup() -> anyhow::Result<Arc<RwLock<Box<dyn PocketDimension>>>> {
     let storage = StrettoClient::new()?;
-    Ok(Arc::new(Mutex::new(Box::new(storage))))
+    Ok(Arc::new(RwLock::new(Box::new(storage))))
 }
 
 async fn create_account(
-    cache: Arc<Mutex<Box<dyn PocketDimension>>>,
-) -> anyhow::Result<Arc<Mutex<Box<dyn MultiPass>>>> {
+    cache: Arc<RwLock<Box<dyn PocketDimension>>>,
+) -> anyhow::Result<Arc<RwLock<Box<dyn MultiPass>>>> {
     let mut tesseract = Tesseract::default();
     tesseract
         .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
@@ -56,17 +56,17 @@ async fn create_account(
     let mut account = ipfs_identity_temporary(Some(config), tesseract, Some(cache)).await?;
 
     account.create_identity(None, None)?;
-    Ok(Arc::new(Mutex::new(Box::new(account))))
+    Ok(Arc::new(RwLock::new(Box::new(account))))
 }
 
 #[allow(dead_code)]
-async fn create_rg(account: Arc<Mutex<Box<dyn MultiPass>>>) -> anyhow::Result<Box<dyn RayGun>> {
+async fn create_rg(account: Arc<RwLock<Box<dyn MultiPass>>>) -> anyhow::Result<Box<dyn RayGun>> {
     let p2p_chat = create_rg_direct(account).await?;
     Ok(Box::new(p2p_chat))
 }
 
 async fn create_rg_direct(
-    account: Arc<Mutex<Box<dyn MultiPass>>>,
+    account: Arc<RwLock<Box<dyn MultiPass>>>,
 ) -> anyhow::Result<IpfsMessaging<Temporary>> {
     IpfsMessaging::new(None, account, None)
         .await
@@ -83,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
     let mut chat = create_rg(new_account.clone()).await?;
 
     println!("Obtaining identity....");
-    let identity = new_account.lock().get_own_identity()?;
+    let identity = new_account.read().get_own_identity()?;
     println!(
         "Registered user {}#{}",
         identity.username(),
@@ -421,14 +421,14 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_username(account: Arc<Mutex<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
+fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
     if let Some(id) = id.get_id() {
         //if for some reason uuid is used, we can just return that instead as a string
         return Ok(id.to_string());
     }
 
     if let Some(pubkey) = id.get_did_key() {
-        let account = account.lock();
+        let account = account.read();
         let identity = account.get_identity(Identifier::did_key(pubkey))?;
         return Ok(format!("{}#{}", identity.username(), identity.short_id()));
     }

--- a/extensions/warp-rg-ipfs/examples/rg_messenger_persistent.rs
+++ b/extensions/warp-rg-ipfs/examples/rg_messenger_persistent.rs
@@ -13,7 +13,7 @@ use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
 use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, SenderId};
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_ipfs::{ipfs_identity_persistent, Persistent};
 use warp_pd_flatfile::FlatfileStorage;
@@ -30,15 +30,15 @@ struct Opt {
 fn cache_setup<P: AsRef<Path>>(
     root: P,
     index: P,
-) -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
+) -> anyhow::Result<Arc<RwLock<Box<dyn PocketDimension>>>> {
     let storage = FlatfileStorage::new_with_index_file(root, index)?;
-    Ok(Arc::new(Mutex::new(Box::new(storage))))
+    Ok(Arc::new(RwLock::new(Box::new(storage))))
 }
 
 async fn create_or_load_account(
     path: PathBuf,
-    cache: Arc<Mutex<Box<dyn PocketDimension>>>,
-) -> anyhow::Result<Arc<Mutex<Box<dyn MultiPass>>>> {
+    cache: Arc<RwLock<Box<dyn PocketDimension>>>,
+) -> anyhow::Result<Arc<RwLock<Box<dyn MultiPass>>>> {
     let mut tesseract = Tesseract::from_file(path.join("tesseract_store")).unwrap_or_default();
     tesseract
         .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
@@ -52,13 +52,13 @@ async fn create_or_load_account(
     if account.get_own_identity().is_err() {
         account.create_identity(None, None)?;
     }
-    Ok(Arc::new(Mutex::new(Box::new(account))))
+    Ok(Arc::new(RwLock::new(Box::new(account))))
 }
 
 #[allow(dead_code)]
 async fn create_rg(
     path: PathBuf,
-    account: Arc<Mutex<Box<dyn MultiPass>>>,
+    account: Arc<RwLock<Box<dyn MultiPass>>>,
 ) -> anyhow::Result<Box<dyn RayGun>> {
     let p2p_chat = create_rg_direct(path, account).await?;
     Ok(Box::new(p2p_chat))
@@ -66,7 +66,7 @@ async fn create_rg(
 
 async fn create_rg_direct(
     path: PathBuf,
-    account: Arc<Mutex<Box<dyn MultiPass>>>,
+    account: Arc<RwLock<Box<dyn MultiPass>>>,
 ) -> anyhow::Result<IpfsMessaging<Persistent>> {
     let config = RgIpfsConfig::production(path);
     IpfsMessaging::new(Some(config), account, None)
@@ -85,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
     let mut chat = create_rg_direct(opt.path, new_account.clone()).await?;
 
     println!("Obtaining identity....");
-    let identity = new_account.lock().get_own_identity()?;
+    let identity = new_account.read().get_own_identity()?;
     println!(
         "Registered user {}#{}",
         identity.username(),
@@ -425,14 +425,14 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_username(account: Arc<Mutex<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
+fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
     if let Some(id) = id.get_id() {
         //if for some reason uuid is used, we can just return that instead as a string
         return Ok(id.to_string());
     }
 
     if let Some(pubkey) = id.get_did_key() {
-        let account = account.lock();
+        let account = account.read();
         let identity = account.get_identity(Identifier::did_key(pubkey))?;
         return Ok(format!("{}#{}", identity.username(), identity.short_id()));
     }

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -43,7 +43,7 @@ pub struct DirectMessageStore<T: IpfsTypes> {
     direct_conversation: Arc<RwLock<Vec<DirectConversation>>>,
 
     // account instance
-    account: Arc<Mutex<Box<dyn MultiPass>>>,
+    account: Arc<RwLock<Box<dyn MultiPass>>>,
 
     // Queue
     queue: Arc<RwLock<Vec<Queue>>>,
@@ -155,7 +155,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
     pub async fn new(
         ipfs: Ipfs<T>,
         path: Option<PathBuf>,
-        account: Arc<Mutex<Box<dyn MultiPass>>>,
+        account: Arc<RwLock<Box<dyn MultiPass>>>,
         discovery: bool,
         interval_ms: u64,
     ) -> anyhow::Result<Self> {
@@ -171,7 +171,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         }
         let direct_conversation = Arc::new(Default::default());
         let queue = Arc::new(Default::default());
-        let did = Arc::new(account.lock().decrypt_private_key(None)?);
+        let did = Arc::new(account.read().decrypt_private_key(None)?);
         let store = Self {
             path,
             ipfs,
@@ -258,7 +258,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
                                                     }
                                                 };
 
-                                                if let Ok(list) = store.account.lock().block_list() {
+                                                if let Ok(list) = store.account.read().block_list() {
                                                     if list.contains(&*peer) {
                                                         continue
                                                     }
@@ -379,7 +379,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         // maybe only start conversation with one we are friends with?
         // self.account.lock().has_friend(did_key)?;
 
-        if let Ok(list) = self.account.lock().block_list() {
+        if let Ok(list) = self.account.read().block_list() {
             if list.contains(did_key) {
                 anyhow::bail!(Error::PublicKeyIsBlocked);
             }

--- a/warp-bin/src/http/rocket/constellation.rs
+++ b/warp-bin/src/http/rocket/constellation.rs
@@ -5,14 +5,14 @@ use std::path::PathBuf;
 use warp::constellation::directory::Directory;
 use warp::constellation::{Constellation, ConstellationDataType};
 use warp::data::{DataObject, DataType};
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 
 use base64;
 
-pub struct FsSystem(pub Arc<Mutex<Box<dyn Constellation>>>);
+pub struct FsSystem(pub Arc<RwLock<Box<dyn Constellation>>>);
 
-impl AsRef<Arc<Mutex<Box<dyn Constellation>>>> for FsSystem {
-    fn as_ref(&self) -> &Arc<Mutex<Box<dyn Constellation>>> {
+impl AsRef<Arc<RwLock<Box<dyn Constellation>>>> for FsSystem {
+    fn as_ref(&self) -> &Arc<RwLock<Box<dyn Constellation>>> {
         &self.0
     }
 }
@@ -35,7 +35,7 @@ pub struct ConstellationStatus {
 /// Return the active constellation stats
 #[get("/constellation/status")]
 pub fn version(state: &State<FsSystem>) -> Json<Value> {
-    let fs = state.as_ref().lock();
+    let fs = state.as_ref().read();
 
     let mut response = ApiResponse::default();
     let status = ConstellationStatus {
@@ -52,7 +52,7 @@ pub fn version(state: &State<FsSystem>) -> Json<Value> {
 /// Export the current in-memory filesystem index
 #[get("/constellation/export/<format>")]
 pub fn export(state: &State<FsSystem>, format: &str) -> Json<Value> {
-    let fs = state.as_ref().lock();
+    let fs = state.as_ref().read();
     let data = fs
         .export(ConstellationDataType::from(format))
         .unwrap_or_default();
@@ -75,7 +75,7 @@ pub fn export(state: &State<FsSystem>, format: &str) -> Json<Value> {
 /// Add a new directory to the FS at the current working directory.
 #[put("/constellation/directory/create/<name>")]
 pub fn create_directory(state: &State<FsSystem>, name: &str) -> Json<Value> {
-    let mut fs = state.as_ref().lock();
+    let mut fs = state.as_ref().write();
     let directory = Directory::new(name);
 
     //TODO: Remove unwrap
@@ -90,7 +90,7 @@ pub fn create_directory(state: &State<FsSystem>, name: &str) -> Json<Value> {
 
 #[get("/constellation/directory/goto/<path..>")]
 pub fn go_to(state: &State<FsSystem>, path: PathBuf) -> Json<Value> {
-    let mut fs = state.as_ref().lock();
+    let mut fs = state.as_ref().write();
     let joined_path = Path::new("/").join(path).to_string_lossy().to_string();
 
     let response = if let Err(e) = fs.select(&joined_path) {

--- a/warp-bin/src/http/rocket/mod.rs
+++ b/warp-bin/src/http/rocket/mod.rs
@@ -1,7 +1,7 @@
 mod constellation;
 use crate::manager::ModuleManager;
 use warp::pocket_dimension::PocketDimension;
-use warp::sync::{Arc, Mutex};
+use warp::sync::{Arc, RwLock};
 
 #[allow(unused_imports)]
 use rocket::{
@@ -14,10 +14,10 @@ use rocket::{
     Build, Request, Rocket, State,
 };
 
-pub struct CacheSystem(Arc<Mutex<Box<dyn PocketDimension>>>);
+pub struct CacheSystem(Arc<RwLock<Box<dyn PocketDimension>>>);
 
-impl AsRef<Arc<Mutex<Box<dyn PocketDimension>>>> for CacheSystem {
-    fn as_ref(&self) -> &Arc<Mutex<Box<dyn PocketDimension>>> {
+impl AsRef<Arc<RwLock<Box<dyn PocketDimension>>>> for CacheSystem {
+    fn as_ref(&self) -> &Arc<RwLock<Box<dyn PocketDimension>>> {
         &self.0
     }
 }
@@ -33,7 +33,7 @@ pub async fn http_main(manage: &mut ModuleManager) -> anyhow::Result<()> {
     let cache = manage.get_cache()?;
     //TODO: Remove
     if fs
-        .lock()
+        .write()
         .put_buffer("readme.txt", &b"This file was uploaded from Warp".to_vec())
         .await
         .is_err()

--- a/warp-bin/src/manager.rs
+++ b/warp-bin/src/manager.rs
@@ -4,7 +4,7 @@ use warp::{
     multipass::MultiPass,
     pocket_dimension::PocketDimension,
     raygun::RayGun,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
 };
 
 pub trait Information {
@@ -14,85 +14,85 @@ pub trait Information {
 
 #[derive(Clone)]
 pub struct FileSystem {
-    pub handle: Arc<Mutex<Box<dyn Constellation>>>,
+    pub handle: Arc<RwLock<Box<dyn Constellation>>>,
     pub active: bool,
 }
 
 impl Information for FileSystem {
     fn name(&self) -> String {
-        self.handle.lock().name()
+        self.handle.read().name()
     }
     fn id(&self) -> String {
-        self.handle.lock().id()
+        self.handle.read().id()
     }
 }
 
-impl AsRef<Arc<Mutex<Box<dyn Constellation>>>> for FileSystem {
-    fn as_ref(&self) -> &Arc<Mutex<Box<dyn Constellation>>> {
+impl AsRef<Arc<RwLock<Box<dyn Constellation>>>> for FileSystem {
+    fn as_ref(&self) -> &Arc<RwLock<Box<dyn Constellation>>> {
         &self.handle
     }
 }
 
 #[derive(Clone)]
 pub struct Cache {
-    pub handle: Arc<Mutex<Box<dyn PocketDimension>>>,
+    pub handle: Arc<RwLock<Box<dyn PocketDimension>>>,
     pub active: bool,
 }
 
-impl AsRef<Arc<Mutex<Box<dyn PocketDimension>>>> for Cache {
-    fn as_ref(&self) -> &Arc<Mutex<Box<dyn PocketDimension>>> {
+impl AsRef<Arc<RwLock<Box<dyn PocketDimension>>>> for Cache {
+    fn as_ref(&self) -> &Arc<RwLock<Box<dyn PocketDimension>>> {
         &self.handle
     }
 }
 
 impl Information for Cache {
     fn name(&self) -> String {
-        self.handle.lock().name()
+        self.handle.read().name()
     }
     fn id(&self) -> String {
-        self.handle.lock().id()
+        self.handle.read().id()
     }
 }
 
 #[derive(Clone)]
 pub struct Account {
-    pub handle: Arc<Mutex<Box<dyn MultiPass>>>,
+    pub handle: Arc<RwLock<Box<dyn MultiPass>>>,
     pub active: bool,
 }
 
-impl AsRef<Arc<Mutex<Box<dyn MultiPass>>>> for Account {
-    fn as_ref(&self) -> &Arc<Mutex<Box<dyn MultiPass>>> {
+impl AsRef<Arc<RwLock<Box<dyn MultiPass>>>> for Account {
+    fn as_ref(&self) -> &Arc<RwLock<Box<dyn MultiPass>>> {
         &self.handle
     }
 }
 
 impl Information for Messaging {
     fn name(&self) -> String {
-        self.handle.lock().name()
+        self.handle.read().name()
     }
     fn id(&self) -> String {
-        self.handle.lock().id()
+        self.handle.read().id()
     }
 }
 
 #[derive(Clone)]
 pub struct Messaging {
-    pub handle: Arc<Mutex<Box<dyn RayGun>>>,
+    pub handle: Arc<RwLock<Box<dyn RayGun>>>,
     pub active: bool,
 }
 
-impl AsRef<Arc<Mutex<Box<dyn RayGun>>>> for Messaging {
-    fn as_ref(&self) -> &Arc<Mutex<Box<dyn RayGun>>> {
+impl AsRef<Arc<RwLock<Box<dyn RayGun>>>> for Messaging {
+    fn as_ref(&self) -> &Arc<RwLock<Box<dyn RayGun>>> {
         &self.handle
     }
 }
 
 impl Information for Account {
     fn name(&self) -> String {
-        self.handle.lock().name()
+        self.handle.read().name()
     }
     fn id(&self) -> String {
-        self.handle.lock().id()
+        self.handle.read().id()
     }
 }
 
@@ -105,11 +105,11 @@ pub struct ModuleManager {
 }
 
 impl ModuleManager {
-    pub fn set_filesystem(&mut self, handle: Arc<Mutex<Box<dyn Constellation>>>) {
+    pub fn set_filesystem(&mut self, handle: Arc<RwLock<Box<dyn Constellation>>>) {
         if self
             .filesystem
             .iter()
-            .filter(|fs| fs.id() == handle.lock().id())
+            .filter(|fs| fs.id() == handle.read().id())
             .count()
             != 0
         {
@@ -180,11 +180,11 @@ impl ModuleManager {
         Ok(())
     }
 
-    pub fn set_cache(&mut self, handle: Arc<Mutex<Box<dyn PocketDimension>>>) {
+    pub fn set_cache(&mut self, handle: Arc<RwLock<Box<dyn PocketDimension>>>) {
         if self
             .cache
             .iter()
-            .filter(|cs| cs.id() == handle.lock().id())
+            .filter(|cs| cs.id() == handle.read().id())
             .count()
             != 0
         {
@@ -226,11 +226,11 @@ impl ModuleManager {
         Ok(())
     }
 
-    pub fn set_account(&mut self, handle: Arc<Mutex<Box<dyn MultiPass>>>) {
+    pub fn set_account(&mut self, handle: Arc<RwLock<Box<dyn MultiPass>>>) {
         if self
             .account
             .iter()
-            .filter(|cs| cs.id() == handle.lock().id())
+            .filter(|cs| cs.id() == handle.read().id())
             .count()
             != 0
         {
@@ -242,7 +242,7 @@ impl ModuleManager {
         })
     }
 
-    pub fn get_filesystem(&self) -> anyhow::Result<Arc<Mutex<Box<dyn Constellation>>>> {
+    pub fn get_filesystem(&self) -> anyhow::Result<Arc<RwLock<Box<dyn Constellation>>>> {
         let index = self
             .filesystem
             .iter()
@@ -254,7 +254,7 @@ impl ModuleManager {
         Ok(fs.as_ref().clone())
     }
 
-    pub fn get_cache(&self) -> anyhow::Result<Arc<Mutex<Box<dyn PocketDimension>>>> {
+    pub fn get_cache(&self) -> anyhow::Result<Arc<RwLock<Box<dyn PocketDimension>>>> {
         let index = self
             .cache
             .iter()
@@ -266,7 +266,7 @@ impl ModuleManager {
         Ok(cs.as_ref().clone())
     }
 
-    pub fn get_account(&self) -> anyhow::Result<Arc<Mutex<Box<dyn MultiPass>>>> {
+    pub fn get_account(&self) -> anyhow::Result<Arc<RwLock<Box<dyn MultiPass>>>> {
         let index = self
             .account
             .iter()

--- a/warp-bin/src/terminal/ui.rs
+++ b/warp-bin/src/terminal/ui.rs
@@ -148,7 +148,7 @@ impl<'a> WarpApp<'a> {
         let hooks: Vec<ListItem> = self
             .hooks_trigger
             .clone()
-            .lock()
+            .read()
             .iter()
             .map(|i| ListItem::new(vec![Spans::from(Span::from(i.to_string()))]))
             .collect();
@@ -239,7 +239,7 @@ impl<'a> WarpApp<'a> {
             .split(area);
 
         let cache = match self.cache.as_ref() {
-            Some(cache) => cache.lock(),
+            Some(cache) => cache.read(),
             None => return,
         };
 


### PR DESCRIPTION
This should, in theory, improve performance where there can be multiple readers for functions that dont need an exclusive lock but should take note that the writer may be starved on linux (which may impact other linux-based systems like android), though that has yet to be seen under the crate that handles the current sync primitives

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Replaces Mutex with RwLock where necessary 
**Which issue(s) this PR fixes** 🔨
WARP-144
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
