### PR TITLE
Warp 152 - Remove unnecessary wrapper and change group structure

### DIFF
--- a/extensions/warp-rg-ipfs/examples/ipfs_messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/ipfs_messenger.rs
@@ -10,7 +10,7 @@ use warp::crypto::DID;
 use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
-use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, SenderId};
+use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState};
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_ipfs::config::{Autonat, Dcutr, IpfsSetting, RelayClient, StoreSetting};
@@ -421,16 +421,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
-    if let Some(id) = id.get_id() {
-        //if for some reason uuid is used, we can just return that instead as a string
-        return Ok(id.to_string());
-    }
-
-    if let Some(pubkey) = id.get_did_key() {
+fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, did: DID) -> anyhow::Result<String> {
         let account = account.read();
-        let identity = account.get_identity(Identifier::did_key(pubkey))?;
-        return Ok(format!("{}#{}", identity.username(), identity.short_id()));
-    }
-    anyhow::bail!("Invalid SenderId")
+        let identity = account.get_identity(Identifier::did_key(did))?;
+        Ok(format!("{}#{}", identity.username(), identity.short_id()))
 }

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -13,7 +13,7 @@ use warp::crypto::DID;
 use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
-use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, SenderId};
+use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState};
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_ipfs::config::{Autonat, Dcutr, IpfsSetting, RelayClient, StoreSetting};
@@ -436,16 +436,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
-    if let Some(id) = id.get_id() {
-        //if for some reason uuid is used, we can just return that instead as a string
-        return Ok(id.to_string());
-    }
-
-    if let Some(pubkey) = id.get_did_key() {
-        let account = account.read();
-        let identity = account.get_identity(Identifier::did_key(pubkey))?;
-        return Ok(format!("{}#{}", identity.username(), identity.short_id()));
-    }
-    anyhow::bail!("Invalid SenderId")
+fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, did: DID) -> anyhow::Result<String> {
+    let account = account.read();
+    let identity = account.get_identity(Identifier::did_key(did))?;
+    Ok(format!("{}#{}", identity.username(), identity.short_id()))
 }

--- a/extensions/warp-rg-ipfs/examples/rg_messenger_persistent.rs
+++ b/extensions/warp-rg-ipfs/examples/rg_messenger_persistent.rs
@@ -12,7 +12,7 @@ use warp::crypto::DID;
 use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
-use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, SenderId};
+use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState};
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_ipfs::{ipfs_identity_persistent, Persistent};
@@ -425,16 +425,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
-    if let Some(id) = id.get_id() {
-        //if for some reason uuid is used, we can just return that instead as a string
-        return Ok(id.to_string());
-    }
-
-    if let Some(pubkey) = id.get_did_key() {
-        let account = account.read();
-        let identity = account.get_identity(Identifier::did_key(pubkey))?;
-        return Ok(format!("{}#{}", identity.username(), identity.short_id()));
-    }
-    anyhow::bail!("Invalid SenderId")
+fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, did: DID) -> anyhow::Result<String> {
+    let account = account.read();
+    let identity = account.get_identity(Identifier::did_key(did))?;
+    Ok(format!("{}#{}", identity.username(), identity.short_id()))
 }

--- a/extensions/warp-rg-ipfs/examples/solana_messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/solana_messenger.rs
@@ -10,7 +10,7 @@ use warp::crypto::DID;
 use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
-use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, SenderId};
+use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState};
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
 use warp_mp_solana::config::MpSolanaConfig;
@@ -411,16 +411,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, id: SenderId) -> anyhow::Result<String> {
-    if let Some(id) = id.get_id() {
-        //if for some reason uuid is used, we can just return that instead as a string
-        return Ok(id.to_string());
-    }
-
-    if let Some(pubkey) = id.get_did_key() {
-        let account = account.read();
-        let identity = account.get_identity(Identifier::did_key(pubkey))?;
-        return Ok(format!("{}#{}", identity.username(), identity.short_id()));
-    }
-    anyhow::bail!("Invalid SenderId")
+fn get_username(account: Arc<RwLock<Box<dyn MultiPass>>>, did: DID) -> anyhow::Result<String> {
+    let account = account.read();
+    let identity = account.get_identity(Identifier::did_key(did))?;
+    Ok(format!("{}#{}", identity.username(), identity.short_id()))
 }

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -26,10 +26,10 @@ use warp::module::Module;
 use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
 use warp::raygun::group::{
-    Group, GroupChat, GroupChatManagement, GroupId, GroupInvite, GroupMember,
+    Group, GroupChat, GroupChatManagement, GroupInvite, Member,
 };
 use warp::raygun::{
-    Callback, EmbedState, Message, MessageOptions, PinState, RayGun, ReactionState, SenderId,
+    EmbedState, Message, MessageOptions, PinState, RayGun, ReactionState,
 };
 use warp::sync::RwLock;
 use warp::sync::{RwLockReadGuard, RwLockWriteGuard};

--- a/extensions/warp-rg-ipfs/src/spam_filter/classifiers/bayes_classifier/mod.rs
+++ b/extensions/warp-rg-ipfs/src/spam_filter/classifiers/bayes_classifier/mod.rs
@@ -15,7 +15,7 @@ pub struct BayesClassifier {
 }
 #[allow(dead_code)]
 impl BayesClassifier {
-    pub fn new() -> anyhow::Result<Box<Self>> {
+    pub fn new() -> anyhow::Result<Self> {
         let file_name = FILE_NAME.to_string();
 
         let mut file = File::options()
@@ -31,13 +31,13 @@ impl BayesClassifier {
 
         let classifier = bayespam::classifier::Classifier::new_from_pre_trained(&mut file)?;
 
-        Ok(Box::new(Self {
+        Ok(Self {
             classifier,
             file_name,
-        }))
+        })
     }
 
-    pub fn from_config(config: Config) -> anyhow::Result<Box<Self>> {
+    pub fn from_config(config: Config) -> anyhow::Result<Self> {
         let mut file = File::options()
             .read(true)
             .write(true)
@@ -45,10 +45,10 @@ impl BayesClassifier {
 
         let classifier = bayespam::classifier::Classifier::new_from_pre_trained(&mut file)?;
 
-        Ok(Box::new(Self {
+        Ok(Self {
             classifier,
             file_name: config.file_name,
-        }))
+        })
     }
 }
 

--- a/extensions/warp-rg-ipfs/src/spam_filter/mod.rs
+++ b/extensions/warp-rg-ipfs/src/spam_filter/mod.rs
@@ -35,7 +35,8 @@ impl SpamFilter {
     }
 
     pub fn add_spam(&mut self, str: &str) -> Result<()> {
-        Ok(self.classifier.add_spam(str))
+        self.classifier.add_spam(str);
+        Ok(())
     }
 
     pub fn add_not_spam(&mut self, str: &str) -> Result<()> {

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -16,8 +16,7 @@ use warp::crypto::DID;
 use warp::error::Error;
 use warp::multipass::identity::FriendRequest;
 use warp::multipass::MultiPass;
-use warp::raygun::group::GroupId;
-use warp::raygun::{EmbedState, Message, PinState, Reaction, ReactionState, SenderId};
+use warp::raygun::{EmbedState, Message, PinState, Reaction, ReactionState};
 use warp::sata::Sata;
 use warp::sync::{Arc, Mutex, RwLock};
 
@@ -643,7 +642,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
 
         let mut message = Message::default();
         message.set_conversation_id(conversation);
-        message.set_sender(SenderId::from_did_key(own_did.clone()));
+        message.set_sender(own_did.clone());
         message.set_value(messages.clone());
 
         // TODO: Construct the message into a body of bytes that would be used for signing
@@ -735,7 +734,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
 
         let mut message = Message::default();
         message.set_conversation_id(conversation);
-        message.set_sender(SenderId::from_did_key(own_did.clone()));
+        message.set_sender(own_did.clone());
         message.set_value(messages);
         message.set_replied(Some(message_id));
 
@@ -794,8 +793,6 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
 
         let own_did = &*self.did;
 
-        let sender = SenderId::from_did_key(own_did.clone());
-
         let index = self
             .direct_conversation
             .read()
@@ -803,7 +800,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
             .position(|convo| convo.id() == conversation)
             .ok_or(Error::InvalidConversation)?;
 
-        let event = MessagingEvents::Pin(conversation, sender, message_id, state);
+        let event = MessagingEvents::Pin(conversation, own_did.clone(), message_id, state);
         if let Some(conversation) = self.direct_conversation.write().get_mut(index) {
             direct_message_event(conversation.messages_mut(), &event)?;
             if let Some(path) = self.path.as_ref() {
@@ -839,9 +836,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
 
         let own_did = &*self.did;
 
-        let sender = SenderId::from_did_key(own_did.clone());
-
-        let event = MessagingEvents::React(conversation, sender, message_id, state, emoji);
+        let event = MessagingEvents::React(conversation, own_did.clone(), message_id, state, emoji);
 
         let index = self
             .direct_conversation

--- a/extensions/warp-rg-ipfs/src/store/mod.rs
+++ b/extensions/warp-rg-ipfs/src/store/mod.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 use warp::{
     crypto::{did_key::CoreSign, hash::sha256_hash, DIDKey, Ed25519KeyPair, KeyMaterial, DID},
     error::Error,
-    raygun::{Message, PinState, ReactionState, SenderId},
+    raygun::{Message, PinState, ReactionState},
     sync::{Arc, Mutex},
 };
 
@@ -28,8 +28,8 @@ pub enum MessagingEvents {
     New(Message),
     Edit(Uuid, Uuid, Vec<String>),
     Delete(Uuid, Uuid),
-    Pin(Uuid, SenderId, Uuid, PinState),
-    React(Uuid, SenderId, Uuid, ReactionState, String),
+    Pin(Uuid, DID, Uuid, PinState),
+    React(Uuid, DID, Uuid, ReactionState, String),
 }
 
 pub fn generate_uuid(generate: &str) -> Uuid {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
This PR removes SenderId and other wrappers that were around `Uid` to use UUID or DID where its needed. This is due to the lack of use case around using a UUID as a sender. 

This PR also change the group structure in preparation of a group messaging  (WIP) 
**Which issue(s) this PR fixes** 🔨
Warp 152
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
