### PR TITLE
Reuses passphrase field in MultiPass::create_identity

### DIFF
--- a/extensions/warp-mp-ipfs/src/config.rs
+++ b/extensions/warp-mp-ipfs/src/config.rs
@@ -77,7 +77,6 @@ pub struct IpfsSetting {
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct StoreSetting {
     pub broadcast_interval: u64,
-    pub broadcast_with_connection: bool,
     pub discovery: bool,
 }
 

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -118,7 +118,9 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
         if !identity.tesseract.is_unlock() {
             let mut inner = identity.clone();
             tokio::spawn(async move {
-                while !inner.tesseract.is_unlock() {}
+                while !inner.tesseract.is_unlock() {
+                    tokio::time::sleep(Duration::from_nanos(50)).await
+                }
                 if let Err(_e) = inner.initialize_store(false).await {}
             });
         } else if let Err(_e) = identity.initialize_store(false).await {
@@ -304,7 +306,7 @@ impl<T: IpfsTypes> Extension for IpfsIdentity<T> {
 
 impl<T: IpfsTypes> SingleHandle for IpfsIdentity<T> {
     fn handle(&self) -> Result<Box<dyn Any>, Error> {
-        Ok(Box::new(self.ipfs()?))
+        self.ipfs().map(|ipfs| Box::new(ipfs) as Box<dyn Any>)
     }
 }
 

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -210,7 +210,6 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
                 config.path.clone(),
                 tesseract.clone(),
                 config.store_setting.discovery,
-                config.store_setting.broadcast_with_connection,
                 config.store_setting.broadcast_interval,
             )
             .await?,

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -315,6 +315,12 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
         username: Option<&str>,
         passphrase: Option<&str>,
     ) -> Result<DID, Error> {
+        if let Some(phrase) = passphrase {
+            let mut tesseract = self.tesseract.clone();
+            if !tesseract.exist("keypair") {
+                warp::crypto::keypair::mnemonic_into_tesseract(&mut tesseract, phrase, None)?;
+            }
+        }
         async_block_in_place_uncheck(self.initialize_store(true))?;
         let identity =
             async_block_in_place_uncheck(self.identity_store()?.create_identity(username))?;

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -37,8 +37,6 @@ pub struct IdentityStore<T: IpfsTypes> {
 
     start_event: Arc<AtomicBool>,
 
-    broadcast_with_connection: Arc<AtomicBool>,
-
     end_event: Arc<AtomicBool>,
 
     tesseract: Tesseract,
@@ -53,17 +51,9 @@ impl<T: IpfsTypes> Clone for IdentityStore<T> {
             identity: self.identity.clone(),
             cache: self.cache.clone(),
             start_event: self.start_event.clone(),
-            broadcast_with_connection: self.broadcast_with_connection.clone(),
             end_event: self.end_event.clone(),
             tesseract: self.tesseract.clone(),
         }
-    }
-}
-
-impl<T: IpfsTypes> Drop for IdentityStore<T> {
-    fn drop(&mut self) {
-        self.disable_event();
-        self.end_event();
     }
 }
 
@@ -80,7 +70,6 @@ impl<T: IpfsTypes> IdentityStore<T> {
         path: Option<PathBuf>,
         tesseract: Tesseract,
         discovery: bool,
-        broadcast_with_connection: bool,
         interval: u64,
     ) -> Result<Self, Error> {
         let path = match std::any::TypeId::of::<T>() == std::any::TypeId::of::<Persistent>() {
@@ -97,7 +86,6 @@ impl<T: IpfsTypes> IdentityStore<T> {
         let identity = Arc::new(Default::default());
         let start_event = Arc::new(Default::default());
         let end_event = Arc::new(Default::default());
-        let broadcast_with_connection = Arc::new(AtomicBool::new(broadcast_with_connection));
         let ident_cid = Arc::new(Default::default());
         let store = Self {
             ipfs,
@@ -106,7 +94,6 @@ impl<T: IpfsTypes> IdentityStore<T> {
             cache,
             identity,
             start_event,
-            broadcast_with_connection,
             end_event,
             tesseract,
         };
@@ -488,9 +475,5 @@ impl<T: IpfsTypes> IdentityStore<T> {
 
     pub fn clear_internal_cache(&mut self) {
         self.cache.write().clear();
-    }
-
-    pub fn set_broadcast_with_connection(&mut self, val: bool) {
-        self.broadcast_with_connection.store(val, Ordering::SeqCst)
     }
 }

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -294,7 +294,6 @@ impl<T: IpfsTypes> IdentityStore<T> {
     }
 
     pub fn lookup(&self, lookup: LookupBy) -> Result<Vec<Identity>, Error> {
-        // Check own identity just in case since we dont store this in the cache
         if let Some(ident) = self.identity.read().clone() {
             match lookup {
                 LookupBy::DidKey(pubkey) if ident.did_key() == *pubkey => return Ok(vec![ident]),

--- a/extensions/warp-rg-ipfs/examples/ipfs_messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/ipfs_messenger.rs
@@ -14,7 +14,6 @@ use warp::pocket_dimension::PocketDimension;
 use warp::raygun::{MessageOptions, PinState, RayGun, ReactionState, ConversationType};
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
-use warp_mp_ipfs::config::{Autonat, Dcutr, IpfsSetting, RelayClient, StoreSetting};
 use warp_mp_ipfs::ipfs_identity_temporary;
 use warp_pd_stretto::StrettoClient;
 use warp_rg_ipfs::IpfsMessaging;
@@ -32,27 +31,7 @@ async fn create_account(
     tesseract
         .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
 
-    let config = warp_mp_ipfs::config::MpIpfsConfig {
-        ipfs_setting: IpfsSetting {
-            mdns: warp_mp_ipfs::config::Mdns { enable: true },
-            relay_client: RelayClient {
-                enable: true,
-                ..Default::default()
-            },
-            dcutr: Dcutr { enable: true },
-            autonat: Autonat {
-                enable: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-        store_setting: StoreSetting {
-            discovery: true,
-            broadcast_interval: 100,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
+    let config = warp_mp_ipfs::config::MpIpfsConfig::testing();
 
     let mut account = ipfs_identity_temporary(Some(config), tesseract, Some(cache)).await?;
 

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -45,11 +45,11 @@ pub type Temporary = TestTypes;
 pub type Persistent = Types;
 
 pub struct IpfsMessaging<T: IpfsTypes> {
-    pub account: Arc<RwLock<Box<dyn MultiPass>>>,
-    pub cache: Option<Arc<RwLock<Box<dyn PocketDimension>>>>,
-    pub ipfs: Arc<RwLock<Option<Ipfs<T>>>>,
-    pub direct_store: Arc<RwLock<Option<DirectMessageStore<T>>>>,
-    pub config: Option<RgIpfsConfig>,
+    account: Arc<RwLock<Box<dyn MultiPass>>>,
+    cache: Option<Arc<RwLock<Box<dyn PocketDimension>>>>,
+    ipfs: Arc<RwLock<Option<Ipfs<T>>>>,
+    direct_store: Arc<RwLock<Option<DirectMessageStore<T>>>>,
+    config: Option<RgIpfsConfig>,
     initialize: Arc<AtomicBool>,
     //TODO: GroupManager
     //      * Create, Join, and Leave GroupChats

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -14,7 +14,10 @@ use libp2p::identity;
 use std::any::Any;
 use std::ops::Deref;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use store::direct::DirectMessageStore;
 #[allow(unused_imports)]
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -44,13 +47,28 @@ pub type Persistent = Types;
 pub struct IpfsMessaging<T: IpfsTypes> {
     pub account: Arc<RwLock<Box<dyn MultiPass>>>,
     pub cache: Option<Arc<RwLock<Box<dyn PocketDimension>>>>,
-    pub ipfs: Ipfs<T>,
-    pub direct_store: DirectMessageStore<T>,
+    pub ipfs: Arc<RwLock<Option<Ipfs<T>>>>,
+    pub direct_store: Arc<RwLock<Option<DirectMessageStore<T>>>>,
+    pub config: Option<RgIpfsConfig>,
+    initialize: Arc<AtomicBool>,
     //TODO: GroupManager
     //      * Create, Join, and Leave GroupChats
     //      * Send message
     //      * Assign permissions to peers
     //      * TBD
+}
+
+impl<T: IpfsTypes> Clone for IpfsMessaging<T> {
+    fn clone(&self) -> Self {
+        Self {
+            account: self.account.clone(),
+            cache: self.cache.clone(),
+            ipfs: self.ipfs.clone(),
+            direct_store: self.direct_store.clone(),
+            config: self.config.clone(),
+            initialize: self.initialize.clone(),
+        }
+    }
 }
 
 impl<T: IpfsTypes> IpfsMessaging<T> {
@@ -59,8 +77,34 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
         account: Arc<RwLock<Box<dyn MultiPass>>>,
         cache: Option<Arc<RwLock<Box<dyn PocketDimension>>>>,
     ) -> anyhow::Result<Self> {
-        let config = config.clone().unwrap_or_default();
-        let ipfs_handle = match account.read().handle() {
+        let mut messaging = IpfsMessaging {
+            account,
+            config,
+            cache,
+            ipfs: Default::default(),
+            direct_store: Default::default(),
+            initialize: Default::default(),
+        };
+
+        if messaging.account.read().get_own_identity().is_err() {
+            let mut messaging = messaging.clone();
+            tokio::spawn(async move {
+                while messaging.account.read().get_own_identity().is_err() {
+                    tokio::time::sleep(Duration::from_millis(100)).await
+                }
+                if let Err(_e) = messaging.initialize().await {}
+            });
+        } else {
+            messaging.initialize().await?;
+        }
+
+        Ok(messaging)
+    }
+
+    async fn initialize(&mut self) -> anyhow::Result<()> {
+        let config = self.config.clone().unwrap_or_default();
+
+        let ipfs_handle = match self.account.read().handle() {
             Ok(handle) if handle.is::<Ipfs<T>>() => handle.downcast_ref::<Ipfs<T>>().cloned(),
             _ => None,
         };
@@ -69,7 +113,7 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
             Some(ipfs) => ipfs,
             None => {
                 let keypair = {
-                    let prikey = account.read().decrypt_private_key(None)?;
+                    let prikey = self.account.read().decrypt_private_key(None)?;
                     let mut sec_key = prikey.as_ref().private_key_bytes();
                     let id_secret = identity::ed25519::SecretKey::from_bytes(&mut sec_key)?;
                     Keypair::Ed25519(id_secret.into())
@@ -105,23 +149,23 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
             }
         };
 
-        let direct_store = DirectMessageStore::new(
-            ipfs.clone(),
-            config.path.map(|p| p.join("messages")),
-            account.clone(),
-            config.store_setting.discovery,
-            config.store_setting.broadcast_interval,
-            config.store_setting.check_spam,
-        )
-        .await?;
+        *self.direct_store.write() = Some(
+            DirectMessageStore::new(
+                ipfs.clone(),
+                config.path.map(|p| p.join("messages")),
+                self.account.clone(),
+                config.store_setting.discovery,
+                config.store_setting.broadcast_interval,
+                config.store_setting.check_spam,
+            )
+            .await?,
+        );
 
-        let messaging = IpfsMessaging {
-            account,
-            cache,
-            ipfs,
-            direct_store,
-        };
-        Ok(messaging)
+        *self.ipfs.write() = Some(ipfs);
+
+        self.initialize.store(true, Ordering::SeqCst);
+
+        Ok(())
     }
 
     pub fn get_cache(&self) -> anyhow::Result<RwLockReadGuard<Box<dyn PocketDimension>>> {
@@ -142,6 +186,13 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
 
         let inner = cache.write();
         Ok(inner)
+    }
+
+    pub fn messaging_store(&self) -> std::result::Result<DirectMessageStore<T>, Error> {
+        self.direct_store
+            .read()
+            .clone()
+            .ok_or(Error::RayGunExtensionUnavailable)
     }
 }
 
@@ -169,15 +220,15 @@ impl<T: IpfsTypes> SingleHandle for IpfsMessaging<T> {
 #[async_trait::async_trait]
 impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
     async fn create_conversation(&mut self, did_key: &DID) -> Result<Conversation> {
-        self.direct_store.create_conversation(did_key).await
+        self.messaging_store()?.create_conversation(did_key).await
     }
 
     async fn list_conversations(&self) -> Result<Vec<Conversation>> {
-        Ok(self.direct_store.list_conversations())
+        Ok(self.messaging_store()?.list_conversations())
     }
 
     async fn get_messages(&self, conversation_id: Uuid, _: MessageOptions) -> Result<Vec<Message>> {
-        self.direct_store
+        self.messaging_store()?
             .get_messages(conversation_id, None)
             .await
             .map_err(Error::from)
@@ -189,14 +240,13 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
         message_id: Option<Uuid>,
         value: Vec<String>,
     ) -> Result<()> {
+        let mut store = self.messaging_store()?;
         match message_id {
-            Some(id) => self
-                .direct_store
+            Some(id) => store
                 .edit_message(conversation_id, id, value)
                 .await
                 .map_err(Error::from),
-            None => self
-                .direct_store
+            None => store
                 .send_message(conversation_id, value)
                 .await
                 .map_err(Error::from),
@@ -204,14 +254,13 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
     }
 
     async fn delete(&mut self, conversation_id: Uuid, message_id: Option<Uuid>) -> Result<()> {
+        let mut store = self.messaging_store()?;
         match message_id {
-            Some(id) => self
-                .direct_store
+            Some(id) => store
                 .delete_message(conversation_id, id, true)
                 .await
                 .map_err(Error::from),
-            None => self
-                .direct_store
+            None => store
                 .delete_conversation(conversation_id, true)
                 .await
                 .map(|_| ())
@@ -226,7 +275,7 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
         state: ReactionState,
         emoji: String,
     ) -> Result<()> {
-        self.direct_store
+        self.messaging_store()?
             .react(conversation_id, message_id, state, emoji)
             .await
             .map_err(Error::from)
@@ -238,7 +287,7 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
         message_id: Uuid,
         state: PinState,
     ) -> Result<()> {
-        self.direct_store
+        self.messaging_store()?
             .pin_message(conversation_id, message_id, state)
             .await
             .map_err(Error::from)
@@ -250,7 +299,7 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
         message_id: Uuid,
         value: Vec<String>,
     ) -> Result<()> {
-        self.direct_store
+        self.messaging_store()?
             .reply_message(conversation_id, message_id, value)
             .await
             .map_err(Error::from)
@@ -262,7 +311,7 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
         message_id: Uuid,
         state: EmbedState,
     ) -> Result<()> {
-        self.direct_store
+        self.messaging_store()?
             .embeds(conversation_id, message_id, state)
             .await
             .map_err(Error::from)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
This PR allows using the passphrase field in `MultiPass::create_identity` to accept a mnemonic phrase. If one is not provided, a keypair will be generated at random.

**Which issue(s) this PR fixes** 🔨
WARP-154
<!--AP-X-->

**Special notes for reviewers** 🗒️
This PR also relaxes the need to have tesseract unlocked before initializing warp-mp-ipfs, which would allow it to be unlocked later (which is required for using an existing or creating an identity) on while also allowing warp-rg-ipfs to be initialized without a valid account, but would still require an identity before it actually begin allowing messaging of any kind. 

**Additional comments** 🎤
