### PR TITLE
fix/messages: Change range to start at the end of the list rather tha…

### DIFF
--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -797,12 +797,10 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         let list = match opt
             .range()
             .map(|mut range| {
-                if range.start > messages.len() {
-                    range.start = 0;
-                }
-                if range.end > messages.len() {
-                    range.end = messages.len();
-                }
+                let start = range.start;
+                let end = range.end;
+                range.start = messages.len() - end;
+                range.end = messages.len() - start;
                 range
             })
             .and_then(|range| messages.get(range))


### PR DESCRIPTION
…n the beginning

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fixes `RayGun::get_messages` when using `MessageOptions::set_range` to fetch messages at the end of the list
 
**Which issue(s) this PR fixes** 🔨
Resolves #28 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
