### PR TITLE
fix/friends: Use std::fs while saving data when dropping store

### DIFF
--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -356,6 +356,9 @@ impl<T: IpfsTypes> Drop for FriendsStore<T> {
             counter
         };
 
+        //Note: This is used as an attempt to save to disk after this drops if previous attempts fail
+        //      however this may not be needed in the future.
+        //TODO: Possibly remove in the future
         if counter == 0 {
             self.end_event.store(true, Ordering::SeqCst);
             if let Some(path) = self.path.as_ref() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Fixes friends being erase when dropping internal store.

**Which issue(s) this PR fixes** 🔨
Resolves #41 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
