### PR TITLE
refactor: Change FriendRequestClosed to use 2 fields and misc fixes

### DIFF
--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -864,7 +864,7 @@ pub mod ffi {
 
         let config = match config.is_null() {
             true => MpIpfsConfig::testing(true),
-            false => (&*config).clone(),
+            false => (*config).clone(),
         };
 
         let cache = match pocketdimension.is_null() {
@@ -905,7 +905,7 @@ pub mod ffi {
             true => {
                 return FFIResult::err(Error::from(anyhow::anyhow!("Configuration is invalid")))
             }
-            false => (&*config).clone(),
+            false => (*config).clone(),
         };
 
         let cache = match pocketdimension.is_null() {

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -509,10 +509,11 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
 
                                                     let topic = conversation.topic();
 
-                                                    if let Err(e) = store.ipfs.pubsub_unsubscribe(&topic).await
+                                                    //Note needed as we ran `conversation.end_task();` which would unsubscribe from the topic
+                                                    //after dropping the stream, but this serves as a secondary precaution
+                                                    if store.ipfs.pubsub_unsubscribe(&topic).await.is_ok()
                                                     {
-                                                        error!("Error unsubscribing from topic: {e}");
-                                                        continue;
+                                                        warn!("topic should have been unsubscribed after dropping conversation.");
                                                     }
 
                                                     if let Err(e) = conversation.delete().await {
@@ -728,6 +729,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
             .ok_or(Error::InvalidConversation)?;
 
         let conversation = self.direct_conversation.write().remove(index);
+        conversation.end_task();
         if broadcast {
             let recipients = conversation.recipients();
 
@@ -765,7 +767,6 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
                         .await
                     {
                         warn!("Unable to publish to topic: {e}. Queuing event");
-                        //TODO: Log
                         //Note: If the error is related to peer not available then we should push this to queue but if
                         //      its due to the message limit being reached we should probably break up the message to fix into
                         //      "max_transmit_size" within rust-libp2p gossipsub

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -799,7 +799,11 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
                 }
             };
         }
-
+        if let Err(e) = self.event.send(RayGunEventKind::ConversationDeleted {
+            conversation_id: conversation.id(),
+        }) {
+            error!("Error broadcasting event: {e}");
+        }
         warp::async_block_in_place_uncheck(conversation.delete())?;
         Ok(conversation)
     }

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -25,7 +25,7 @@ pub enum MultiPassEventKind {
     FriendRequestReceived { from: DID },
     FriendRequestSent { to: DID },
     FriendRequestRejected { from: DID },
-    FriendRequestClosed { from: DID },
+    FriendRequestClosed { from: DID, to: DID },
     FriendAdded { did: DID },
     FriendRemoved { did: DID },
     IdentityOnline { did: DID },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Changes FriendRequestClosed event to support 2 fields for from and to and change logic so that conversations are properly deleted when receiving such a event
**Which issue(s) this PR fixes** 🔨
- N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
