### PR TITLE
fix: Remove sending event twice when removing a friend

### DIFF
--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -1146,14 +1146,6 @@ impl<T: IpfsTypes> FriendsStore<T> {
                     error!("Error broadcasting event: {e}");
                 }
             }
-            FriendRequestStatus::FriendRemoved => {
-                if let Err(e) = self
-                    .tx
-                    .send(MultiPassEventKind::FriendRemoved { did: request.to() })
-                {
-                    error!("Error broadcasting event: {e}");
-                }
-            }
             FriendRequestStatus::RequestRemoved => {
                 if let Err(e) = self
                     .tx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Removes the additional event bring send when removing a friend
**Which issue(s) this PR fixes** 🔨
Resolves #53
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
