### PR TITLE
refactor: Remove mut from Tesseract

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -49,7 +49,7 @@ async fn account(
     no_discovery: bool,
     mdns: bool,
 ) -> anyhow::Result<Box<dyn MultiPass>> {
-    let mut tesseract = Tesseract::default();
+    let tesseract = Tesseract::default();
     tesseract
         .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
 
@@ -77,10 +77,10 @@ async fn account_persistent<P: AsRef<Path>>(
     mdns: bool,
 ) -> anyhow::Result<Box<dyn MultiPass>> {
     let path = path.as_ref();
-    let mut tesseract = match Tesseract::from_file(path.join("tdatastore")) {
+    let tesseract = match Tesseract::from_file(path.join("tdatastore")) {
         Ok(tess) => tess,
         Err(_) => {
-            let mut tess = Tesseract::default();
+            let tess = Tesseract::default();
             tess.set_file(path.join("tdatastore"));
             tess.set_autosave();
             tess

--- a/extensions/warp-mp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-mp-ipfs/examples/ipfs-friends.rs
@@ -9,7 +9,7 @@ use warp_mp_ipfs::config::MpIpfsConfig;
 use warp_mp_ipfs::ipfs_identity_temporary;
 
 async fn account(username: Option<&str>) -> anyhow::Result<Box<dyn MultiPass>> {
-    let mut tesseract = Tesseract::default();
+    let tesseract = Tesseract::default();
     tesseract
         .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
 

--- a/extensions/warp-mp-ipfs/examples/ipfs-identity.rs
+++ b/extensions/warp-mp-ipfs/examples/ipfs-identity.rs
@@ -22,7 +22,7 @@ fn update_status(account: &mut impl MultiPass, status: &str) -> anyhow::Result<(
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     
-    let mut tesseract = Tesseract::default();
+    let tesseract = Tesseract::default();
     tesseract.unlock(b"super duper pass")?;
 
     let mut identity = ipfs_identity_temporary(Default::default(), tesseract, None).await?;

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -131,7 +131,7 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
     }
 
     async fn initialize_store(&mut self, init: bool) -> anyhow::Result<()> {
-        let mut tesseract = self.tesseract.clone();
+        let tesseract = self.tesseract.clone();
 
         if init && self.identity_store.read().is_some() && self.friend_store.read().is_some()
             || self.initialized.load(Ordering::SeqCst)

--- a/extensions/warp-mp-ipfs/tests/accounts.rs
+++ b/extensions/warp-mp-ipfs/tests/accounts.rs
@@ -8,7 +8,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn create_identity() -> anyhow::Result<()> {
-        let mut tesseract = Tesseract::default();
+        let tesseract = Tesseract::default();
         tesseract.unlock(b"internal pass").unwrap();
 
         let mut account = ipfs_identity_temporary(None, tesseract, None).await?;
@@ -27,7 +27,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_own_identity() -> anyhow::Result<()> {
-        let mut tesseract = Tesseract::default();
+        let tesseract = Tesseract::default();
         tesseract.unlock(b"internal pass").unwrap();
 
         let mut account = ipfs_identity_temporary(None, tesseract, None).await?;
@@ -49,7 +49,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_identity() -> anyhow::Result<()> {
-        let mut tesseract_a = Tesseract::default();
+        let tesseract_a = Tesseract::default();
         tesseract_a.unlock(b"internal pass").unwrap();
         let mut account_a = ipfs_identity_temporary(None, tesseract_a, None).await?;
         account_a.create_identity(
@@ -57,7 +57,7 @@ mod test {
             Some("morning caution dose lab six actress pond humble pause enact virtual train"),
         )?;
 
-        let mut tesseract_b = Tesseract::default();
+        let tesseract_b = Tesseract::default();
         tesseract_b.unlock(b"internal pass").unwrap();
         let mut account_b = ipfs_identity_temporary(None, tesseract_b, None).await?;
         let did_b = account_b.create_identity(Some("JaneDoe"), None)?;
@@ -81,7 +81,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[ignore = "Will re-evaluate"]
     async fn get_identity_by_username() -> anyhow::Result<()> {
-        let mut tesseract_a = Tesseract::default();
+        let tesseract_a = Tesseract::default();
         tesseract_a.unlock(b"internal pass").unwrap();
         let mut account_a = ipfs_identity_temporary(None, tesseract_a, None).await?;
         account_a.create_identity(
@@ -89,7 +89,7 @@ mod test {
             Some("morning caution dose lab six actress pond humble pause enact virtual train"),
         )?;
 
-        let mut tesseract_b = Tesseract::default();
+        let tesseract_b = Tesseract::default();
         tesseract_b.unlock(b"internal pass").unwrap();
         let mut account_b = ipfs_identity_temporary(None, tesseract_b, None).await?;
         account_b.create_identity(Some("JaneDoe"), None)?;
@@ -112,7 +112,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_identity_username() -> anyhow::Result<()> {
-        let mut tesseract = Tesseract::default();
+        let tesseract = Tesseract::default();
         tesseract.unlock(b"internal pass").unwrap();
 
         let mut account = ipfs_identity_temporary(None, tesseract, None).await?;
@@ -134,7 +134,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn update_identity_status() -> anyhow::Result<()> {
-        let mut tesseract = Tesseract::default();
+        let tesseract = Tesseract::default();
         tesseract.unlock(b"internal pass").unwrap();
 
         let mut account = ipfs_identity_temporary(None, tesseract, None).await?;

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -54,7 +54,7 @@ async fn create_account<P: AsRef<Path>>(
     passphrase: Zeroizing<String>,
     experimental: bool,
 ) -> anyhow::Result<Arc<RwLock<Box<dyn MultiPass>>>> {
-    let mut tesseract = match path.as_ref() {
+    let tesseract = match path.as_ref() {
         Some(path) => {
             let path = path.as_ref();
             let mut tesseract =


### PR DESCRIPTION

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Due to using RwLock/Mutex internally, we dont need to define what is mutable and isnt mutable on the function due to interior mutability.

**Which issue(s) this PR fixes** 🔨
Resolves #59 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
