### PR TITLE
refactor: Split friend request events

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -193,35 +193,33 @@ async fn main() -> anyhow::Result<()> {
                             };
                             writeln!(stdout, "> A request has been sent to {}. Do \"request close {}\" to if you wish to close the request", username, did)?;
                         }
-                        warp::multipass::MultiPassEventKind::FriendRequestRejected { from, to } => {
-                            if from == own_identity.did_key() {
-                                let username = match account.get_identity(Identifier::did_key(to.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                    Ok(idents) => idents.username(),
-                                    Err(_) => to.to_string()
-                                };
-                                writeln!(stdout, "> You've rejected {} request", username)?;
-                            } else {
-                                let username = match account.get_identity(Identifier::did_key(from.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                    Ok(idents) => idents.username(),
-                                    Err(_) => from.to_string()
-                                };
-                                writeln!(stdout, "> {} rejected your request", username)?;
-                            }
+                        warp::multipass::MultiPassEventKind::IncomingFriendRequestRejected { did } => {
+                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
+                                Ok(idents) => idents.username(),
+                                Err(_) => did.to_string()
+                            };
+                            writeln!(stdout, "> You've rejected {} request", username)?;
                         },
-                        warp::multipass::MultiPassEventKind::FriendRequestClosed { from, to } => {
-                            if from == own_identity.did_key() {
-                                let username = match account.get_identity(Identifier::did_key(to.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                    Ok(idents) => idents.username(),
-                                    Err(_) => to.to_string()
-                                };
-                                writeln!(stdout, "> Request for {} has been retracted", username)?;
-                            } else {
-                                let username = match account.get_identity(Identifier::did_key(from.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                    Ok(idents) => idents.username(),
-                                    Err(_) => from.to_string()
-                                };
-                                writeln!(stdout, "> {} has retracted their request", username)?;
-                            }
+                        warp::multipass::MultiPassEventKind::OutgoingFriendRequestRejected { did } => {
+                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
+                                Ok(idents) => idents.username(),
+                                Err(_) => did.to_string()
+                            };
+                            writeln!(stdout, "> {} rejected your request", username)?;
+                        },
+                        warp::multipass::MultiPassEventKind::IncomingFriendRequestClosed { did } => {
+                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
+                                Ok(idents) => idents.username(),
+                                Err(_) => did.to_string()
+                            };
+                            writeln!(stdout, "> {} has retracted their request", username)?;
+                        },
+                        warp::multipass::MultiPassEventKind::OutgoingFriendRequestClosed { did } => {
+                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
+                                Ok(idents) => idents.username(),
+                                Err(_) => did.to_string()
+                            };
+                            writeln!(stdout, "> Request for {} has been retracted", username)?;
                         },
                         warp::multipass::MultiPassEventKind::FriendAdded { did } => {
                             let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -193,12 +193,20 @@ async fn main() -> anyhow::Result<()> {
                             };
                             writeln!(stdout, "> A request has been sent to {}. Do \"request close {}\" to if you wish to close the request", username, did)?;
                         }
-                        warp::multipass::MultiPassEventKind::FriendRequestRejected { from } => {
-                            let username = match account.get_identity(Identifier::did_key(from.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => from.to_string()
-                            };
-                            writeln!(stdout, "> {} has denied requested your request", username)?;
+                        warp::multipass::MultiPassEventKind::FriendRequestRejected { from, to } => {
+                            if from == own_identity.did_key() {
+                                let username = match account.get_identity(Identifier::did_key(to.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
+                                    Ok(idents) => idents.username(),
+                                    Err(_) => to.to_string()
+                                };
+                                writeln!(stdout, "> You've rejected {} request", username)?;
+                            } else {
+                                let username = match account.get_identity(Identifier::did_key(from.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
+                                    Ok(idents) => idents.username(),
+                                    Err(_) => from.to_string()
+                                };
+                                writeln!(stdout, "> {} rejected your request", username)?;
+                            }
                         },
                         warp::multipass::MultiPassEventKind::FriendRequestClosed { from, to } => {
                             if from == own_identity.did_key() {

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -179,74 +179,104 @@ async fn main() -> anyhow::Result<()> {
             event = event_stream.next() => {
                 if let Some(event) = event {
                     match event {
-                        warp::multipass::MultiPassEventKind::FriendRequestReceived { from } => {
-                            let username = match account.get_identity(Identifier::did_key(from.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(ident) => ident.username(),
-                                Err(_) => from.to_string()
-                            };
-                            writeln!(stdout, "> Pending request from {}. Do \"request accept {}\" to accept.", username, from)?;
+                        warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did } => {
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
+                            writeln!(stdout, "> Pending request from {}. Do \"request accept {}\" to accept.", username, did)?;
                         },
                         warp::multipass::MultiPassEventKind::FriendRequestSent { to: did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(ident) => ident.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> A request has been sent to {}. Do \"request close {}\" to if you wish to close the request", username, did)?;
                         }
                         warp::multipass::MultiPassEventKind::IncomingFriendRequestRejected { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> You've rejected {} request", username)?;
                         },
                         warp::multipass::MultiPassEventKind::OutgoingFriendRequestRejected { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> {} rejected your request", username)?;
                         },
                         warp::multipass::MultiPassEventKind::IncomingFriendRequestClosed { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> {} has retracted their request", username)?;
                         },
                         warp::multipass::MultiPassEventKind::OutgoingFriendRequestClosed { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> Request for {} has been retracted", username)?;
                         },
                         warp::multipass::MultiPassEventKind::FriendAdded { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> You are now friends with {}", username)?;
                         },
                         warp::multipass::MultiPassEventKind::FriendRemoved { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> {} has been removed from friends list", username)?;
                         },
                         warp::multipass::MultiPassEventKind::IdentityOnline { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
                             writeln!(stdout, "> {} has came online", username)?;
                         },
                         warp::multipass::MultiPassEventKind::IdentityOffline { did } => {
-                            let username = match account.get_identity(Identifier::did_key(did.clone())).and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist)) {
-                                Ok(idents) => idents.username(),
-                                Err(_) => did.to_string()
-                            };
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone()))
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+                                
                             writeln!(stdout, "> {} went offline", username)?;
                         },
                     }

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -338,10 +338,12 @@ impl<T: IpfsTypes> FriendsStore<T> {
                     list.remove(&internal_request);
                     self.set_request_list(list).await?;
 
-                    if let Err(e) = self.tx.send(MultiPassEventKind::FriendRequestRejected {
-                        from: data.from(),
-                        to: data.to(),
-                    }) {
+                    if let Err(e) =
+                        self.tx
+                            .send(MultiPassEventKind::OutgoingFriendRequestRejected {
+                                did: data.from(),
+                            })
+                    {
                         error!("Error broadcasting event: {e}");
                     }
                 }
@@ -368,10 +370,10 @@ impl<T: IpfsTypes> FriendsStore<T> {
 
                     self.set_request_list(list).await?;
 
-                    if let Err(e) = self.tx.send(MultiPassEventKind::FriendRequestClosed {
-                        from: data.from(),
-                        to: data.to(),
-                    }) {
+                    if let Err(e) = self
+                        .tx
+                        .send(MultiPassEventKind::IncomingFriendRequestClosed { did: data.from() })
+                    {
                         error!("Error broadcasting event: {e}");
                     }
                 }
@@ -973,18 +975,18 @@ impl<T: IpfsTypes> FriendsStore<T> {
                 }
             }
             FriendRequestStatus::RequestRemoved => {
-                if let Err(e) = self.tx.send(MultiPassEventKind::FriendRequestClosed {
-                    from: request.from(),
-                    to: request.to(),
-                }) {
+                if let Err(e) = self
+                    .tx
+                    .send(MultiPassEventKind::OutgoingFriendRequestClosed { did: request.to() })
+                {
                     error!("Error broadcasting event: {e}");
                 }
             }
             FriendRequestStatus::Denied => {
-                if let Err(e) = self.tx.send(MultiPassEventKind::FriendRequestRejected {
-                    from: request.from(),
-                    to: request.to(),
-                }) {
+                if let Err(e) = self
+                    .tx
+                    .send(MultiPassEventKind::IncomingFriendRequestRejected { did: request.to() })
+                {
                     error!("Error broadcasting event: {e}");
                 }
             }

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -24,7 +24,7 @@ use self::identity::{IdentityStatus, Relationship};
 pub enum MultiPassEventKind {
     FriendRequestReceived { from: DID },
     FriendRequestSent { to: DID },
-    FriendRequestRejected { from: DID },
+    FriendRequestRejected { from: DID, to: DID },
     FriendRequestClosed { from: DID, to: DID },
     FriendAdded { did: DID },
     FriendRemoved { did: DID },

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -24,8 +24,10 @@ use self::identity::{IdentityStatus, Relationship};
 pub enum MultiPassEventKind {
     FriendRequestReceived { from: DID },
     FriendRequestSent { to: DID },
-    FriendRequestRejected { from: DID, to: DID },
-    FriendRequestClosed { from: DID, to: DID },
+    IncomingFriendRequestRejected { did: DID },
+    OutgoingFriendRequestRejected { did: DID },
+    IncomingFriendRequestClosed { did: DID },
+    OutgoingFriendRequestClosed { did: DID },
     FriendAdded { did: DID },
     FriendRemoved { did: DID },
     IdentityOnline { did: DID },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Refactors FriendRequestReJected and FriendRequestClosed to be split into 2 incoming and outgoing events and have it broadcast the event on the sender side as well. 

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
