### PR TITLE
chore/identity: Store pictures in blocks

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -563,6 +563,38 @@ async fn main() -> anyhow::Result<()> {
 
                             writeln!(stdout, "Username updated")?;
                         },
+                        Some("update-picture") => {
+                            let picture = match cmd_line.next() {
+                                Some(picture) => picture,
+                                None => {
+                                    writeln!(stdout, "picture is required")?;
+                                    continue;
+                                }
+                            };
+
+                            if let Err(e) = account.update_identity(IdentityUpdate::set_graphics_picture(picture.to_string())) {
+                                writeln!(stdout, "Error updating picture: {}", e)?;
+                                continue;
+                            }
+
+                            writeln!(stdout, "picture updated")?;
+                        },
+                        Some("update-banner") => {
+                            let banner = match cmd_line.next() {
+                                Some(banner) => banner,
+                                None => {
+                                    writeln!(stdout, "banner is required")?;
+                                    continue;
+                                }
+                            };
+
+                            if let Err(e) = account.update_identity(IdentityUpdate::set_graphics_banner(banner.to_string())) {
+                                writeln!(stdout, "Error updating banner: {}", e)?;
+                                continue;
+                            }
+
+                            writeln!(stdout, "banner updated")?;
+                        },
                         Some("lookup") => {
                             let idents = match cmd_line.next() {
                                 Some("username") => {
@@ -618,7 +650,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
                             let mut table = Table::new();
-                            table.set_header(vec!["Username", "Public Key", "Status Message", "Status"]);
+                            table.set_header(vec!["Username", "Public Key", "Status Message", "Banner", "Picture", "Status"]);
                             for identity in idents {
                                 let status = match identity.did_key() == own_identity.did_key() {
                                     true => IdentityStatus::Online,
@@ -628,6 +660,8 @@ async fn main() -> anyhow::Result<()> {
                                     identity.username(),
                                     identity.did_key().to_string(),
                                     identity.status_message().unwrap_or_default(),
+                                    (!identity.graphics().profile_banner().is_empty()).to_string(),
+                                    (!identity.graphics().profile_picture().is_empty()).to_string(),
                                     format!("{:?}", status),
                                 ]);
                             }

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -227,11 +227,10 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
             relay: config.ipfs_setting.relay_client.enable,
             relay_server: config.ipfs_setting.relay_server.enable,
             keep_alive: true,
-            identify_configuration: Some({
-                let mut config = IdentifyConfiguration::default();
-                config.cache = 100;
-                config.push_update = true;
-                config
+            identify_configuration: Some(IdentifyConfiguration {
+                cache: 100,
+                push_update: true,
+                ..Default::default()
             }),
             kad_configuration: Some({
                 let mut conf = ipfs::libp2p::kad::KademliaConfig::default();

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -628,8 +628,8 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
                         .store_photo(
                             futures::stream::once(async move {
                                 serde_json::to_vec(&data).unwrap_or_default()
-                            })
-                            .boxed(),
+                            }).boxed(),
+                            Some(2 * 1024 * 1024)
                         )
                         .await?;
 
@@ -662,8 +662,8 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
                         .store_photo(
                             futures::stream::once(async move {
                                 serde_json::to_vec(&data).unwrap_or_default()
-                            })
-                            .boxed(),
+                            }).boxed(),
+                            Some(2 * 1024 * 1024)
                         )
                         .await?;
 

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -636,14 +636,12 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
 
                     let mut root_document = store.get_root_document().await?;
 
-                    if let Some(picture) = root_document.picture {
-                        if let DocumentType::UnixFS(picture_cid, _) = picture {
-                            if picture_cid == cid {
-                                return Err(Error::CannotUpdateIdentityPicture);
-                            }
-                            if let Err(e) = store.delete_photo(picture_cid).await {
-                                error!("Error deleting picture: {e}");
-                            }
+                    if let Some(DocumentType::UnixFS(picture_cid, _)) = root_document.picture {
+                        if picture_cid == cid {
+                            return Err(Error::CannotUpdateIdentityPicture);
+                        }
+                        if let Err(e) = store.delete_photo(picture_cid).await {
+                            error!("Error deleting picture: {e}");
                         }
                     }
 
@@ -671,14 +669,12 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
                         .await?;
 
                     let mut root_document = store.get_root_document().await?;
-                    if let Some(banner) = root_document.banner {
-                        if let DocumentType::UnixFS(banner_cid, _) = banner {
-                            if banner_cid == cid {
-                                return Err(Error::CannotUpdateIdentityBanner);
-                            }
-                            if let Err(e) = store.delete_photo(banner_cid).await {
-                                error!("Error deleting banner: {e}");
-                            }
+                    if let Some(DocumentType::UnixFS(banner_cid, _)) = root_document.banner {
+                        if banner_cid == cid {
+                            return Err(Error::CannotUpdateIdentityBanner);
+                        }
+                        if let Err(e) = store.delete_photo(banner_cid).await {
+                            error!("Error deleting banner: {e}");
                         }
                     }
 

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -757,6 +757,7 @@ impl<T: IpfsTypes> IdentityStore<T> {
     pub async fn store_photo(
         &mut self,
         mut stream: BoxStream<'static, Vec<u8>>,
+        limit: Option<usize>
     ) -> Result<Cid, Error> {
         let ipfs = self.ipfs.clone();
 
@@ -777,13 +778,15 @@ impl<T: IpfsTypes> IdentityStore<T> {
                 }
                 total += consumed;
             }
-            if total >= 5 * 1024 * 1024 {
-                return Err(Error::InvalidLength {
-                    context: "photo".into(),
-                    current: total,
-                    minimum: None,
-                    maximum: Some(5 * 1024 * 1024),
-                });
+            if let Some(limit) = limit {
+                if total >= limit {
+                    return Err(Error::InvalidLength {
+                        context: "photo".into(),
+                        current: total,
+                        minimum: None,
+                        maximum: Some(limit),
+                    });
+                }
             }
         }
 

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use ipfs::{IpfsTypes, Multiaddr, PeerId, Protocol};
-use libipld::Cid;
 use serde::{Deserialize, Serialize};
 use tracing::log::error;
 use warp::{
@@ -79,11 +78,11 @@ pub struct IdentityPayload {
 
     /// Type that represents profile picture
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub picture: Option<Cid>,
+    pub picture: Option<DocumentType<String>>,
 
     /// Type that represents profile banner
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub banner: Option<Cid>,
+    pub banner: Option<DocumentType<String>>,
 
     /// Type that represents identity or cid
     pub payload: DocumentType<Identity>,

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use ipfs::{IpfsTypes, Multiaddr, PeerId, Protocol};
+use libipld::Cid;
 use serde::{Deserialize, Serialize};
 use tracing::log::error;
 use warp::{
@@ -75,6 +76,15 @@ pub enum Payload {
 pub struct IdentityPayload {
     /// Not required but would be used to cross check the identity did, sender (if sent directly)
     pub did: DID,
+
+    /// Type that represents profile picture
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub picture: Option<Cid>,
+
+    /// Type that represents profile banner
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub banner: Option<Cid>,
+
     /// Type that represents identity or cid
     pub payload: DocumentType<Identity>,
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Moves pictures and banners out of identity by default and store them using unixfs.

**Which issue(s) this PR fixes** 🔨
Resolves #86 
<!--AP-X-->

**Special notes for reviewers** 🗒️
Although it was tried to minimize any breaking changes, this would require uploading new photos. 

**Additional comments** 🎤
