### PR TITLE
refactor: Store messages in the blockstore

### DIFF
--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -1184,7 +1184,7 @@ fn validate_request(real_request: &FriendRequest) -> Result<(), Error> {
 }
 
 pub fn get_inbox_topic(did: &DID) -> String {
-    format!("/peer/{}/inbox", did.to_string())
+    format!("/peer/{}/inbox", did)
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]

--- a/extensions/warp-rg-ipfs/Cargo.toml
+++ b/extensions/warp-rg-ipfs/Cargo.toml
@@ -21,6 +21,8 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
+async-broadcast = "0.4"
+
 futures = { version = "0.3" }
 async-trait = { version = "0.1" }
 async-stream = "0.3"

--- a/extensions/warp-rg-ipfs/Cargo.toml
+++ b/extensions/warp-rg-ipfs/Cargo.toml
@@ -21,8 +21,6 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 
-async-broadcast = "0.4"
-
 futures = { version = "0.3" }
 async-trait = { version = "0.1" }
 async-stream = "0.3"

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -214,7 +214,7 @@ async fn main() -> anyhow::Result<()> {
     writeln!(stdout, "{message}")?;
 
     // loads all conversations into their own task to process events
-    for conversation in chat.list_conversations().await.unwrap_or_default() {
+    for conversation in chat.list_conversations().await? {
         {
             let topic = topic.clone();
             let id = conversation.id();

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -718,17 +718,17 @@ async fn main() -> anyhow::Result<()> {
                         _ => {
                             if !line.is_empty() {
                                 // Since using crossterm would not pick up every expected event here, we will just pretend we are typing
-                                // if let Err(_e) = chat.send_event(*topic.read(), MessageEvent::Typing).await {
-                                //     //We wont error here although an error such as a conversation not found can easily lead
-                                //     //to an error
-                                // }
+                                if let Err(_e) = chat.send_event(*topic.read(), MessageEvent::Typing).await {
+                                    //We wont error here although an error such as a conversation not found can easily lead
+                                    //to an error
+                                }
                                 if let Err(e) = chat.send(*topic.read(), None, vec![line.to_string()]).await {
                                     writeln!(stdout, "Error sending message: {}", e)?;
                                     continue
                                 }
-                                // if let Err(_e) = chat.cancel_event(*topic.read(), MessageEvent::Typing).await {
-                                //     //ditto
-                                // }
+                                if let Err(_e) = chat.cancel_event(*topic.read(), MessageEvent::Typing).await {
+                                    //ditto
+                                }
                             }
                        }
                     }

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -715,6 +715,26 @@ async fn main() -> anyhow::Result<()> {
                                 None => { writeln!(stdout, "/unpin <id | all>")? }
                             }
                         }
+                        Some("/remove-message") => {
+                            let topic = topic.read().clone();
+                            match cmd_line.next() {
+                                Some(id) => {
+                                    let id = match Uuid::from_str(id) {
+                                        Ok(uuid) => uuid,
+                                        Err(e) => {
+                                            writeln!(stdout, "Error parsing ID: {}", e)?;
+                                            continue
+                                        }
+                                    };
+                                    if let Err(_e) = chat.delete(topic, Some(id)).await {
+
+                                    } else {
+                                        writeln!(stdout, "Message {} removed", id)?;
+                                    }
+                                },
+                                None => { writeln!(stdout, "/remove-message <id>")? }
+                            }
+                        }
                         Some("/count") => {
                             let amount = chat.get_message_count(*topic.read()).await?;
                             writeln!(stdout, "Conversation contains {} messages", amount)?;

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -214,7 +214,7 @@ async fn main() -> anyhow::Result<()> {
     writeln!(stdout, "{message}")?;
 
     // loads all conversations into their own task to process events
-    for conversation in chat.list_conversations().await? {
+    for conversation in chat.list_conversations().await.unwrap_or_default() {
         {
             let topic = topic.clone();
             let id = conversation.id();

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -715,6 +715,10 @@ async fn main() -> anyhow::Result<()> {
                                 None => { writeln!(stdout, "/unpin <id | all>")? }
                             }
                         }
+                        Some("/count") => {
+                            let amount = chat.get_message_count(*topic.read()).await?;
+                            writeln!(stdout, "Conversation contains {} messages", amount)?;
+                        }
                         _ => {
                             if !line.is_empty() {
                                 // Since using crossterm would not pick up every expected event here, we will just pretend we are typing

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -169,8 +169,10 @@ async fn main() -> anyhow::Result<()> {
     )
     .await?;
 
+    println!("Initializing Constellation");
     let fs = create_fs(new_account.clone(), opt.path.clone()).await?;
 
+    println!("Initializing RayGun");
     let mut chat = create_rg(
         opt.path.clone(),
         new_account.clone(),

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -718,17 +718,17 @@ async fn main() -> anyhow::Result<()> {
                         _ => {
                             if !line.is_empty() {
                                 // Since using crossterm would not pick up every expected event here, we will just pretend we are typing
-                                if let Err(_e) = chat.send_event(*topic.read(), MessageEvent::Typing).await {
-                                    //We wont error here although an error such as a conversation not found can easily lead
-                                    //to an error
-                                }
+                                // if let Err(_e) = chat.send_event(*topic.read(), MessageEvent::Typing).await {
+                                //     //We wont error here although an error such as a conversation not found can easily lead
+                                //     //to an error
+                                // }
                                 if let Err(e) = chat.send(*topic.read(), None, vec![line.to_string()]).await {
                                     writeln!(stdout, "Error sending message: {}", e)?;
                                     continue
                                 }
-                                if let Err(_e) = chat.cancel_event(*topic.read(), MessageEvent::Typing).await {
-                                    //ditto
-                                }
+                                // if let Err(_e) = chat.cancel_event(*topic.read(), MessageEvent::Typing).await {
+                                //     //ditto
+                                // }
                             }
                        }
                     }

--- a/extensions/warp-rg-ipfs/src/config.rs
+++ b/extensions/warp-rg-ipfs/src/config.rs
@@ -86,7 +86,6 @@ pub struct StoreSetting {
     pub sync: Vec<Multiaddr>,
     pub sync_interval: u64,
     pub check_spam: bool,
-    pub allow_unsigned_message: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,7 +138,6 @@ impl Default for RgIpfsConfig {
                 check_spam: true,
                 with_friends: false,
                 store_decrypted: false,
-                allow_unsigned_message: false,
                 ..Default::default()
             },
             debug: false,

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -247,8 +247,8 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
 
     async fn get_conversation(&self, conversation_id: Uuid) -> Result<Conversation> {
         self.messaging_store()?
-            .get_conversation(conversation_id)
-            .map(|convo| convo.conversation())
+            .get_conversation(conversation_id).await
+            .map(|convo| convo.into())
     }
 
     async fn list_conversations(&self) -> Result<Vec<Conversation>> {
@@ -402,7 +402,7 @@ impl<T: IpfsTypes> RayGunStream for IpfsMessaging<T> {
         conversation_id: Uuid,
     ) -> Result<MessageEventStream> {
         let store = self.messaging_store()?;
-        let stream = store.get_conversation_stream(conversation_id)?;
+        let stream = store.get_conversation_stream(conversation_id).await?;
         Ok(MessageEventStream(Box::pin(stream)))
     }
 }

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -229,8 +229,6 @@ impl<T: IpfsTypes> Extension for IpfsMessaging<T> {
     }
 }
 
-// pub fn message_task(conversation: Arc<Mutex<Vec<Message>>>) {}
-
 impl<T: IpfsTypes> SingleHandle for IpfsMessaging<T> {
     fn handle(&self) -> std::result::Result<Box<dyn core::any::Any>, warp::error::Error> {
         Ok(Box::new(self.ipfs.read().clone()))

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
-use store::direct::DirectMessageStore;
+use store::message::MessageStore;
 use async_broadcast::{Receiver, Sender};
 use uuid::Uuid;
 use warp::constellation::{Constellation, ConstellationProgressStream};
@@ -44,7 +44,7 @@ pub struct IpfsMessaging<T: IpfsTypes> {
     account: Box<dyn MultiPass>,
     cache: Option<Arc<RwLock<Box<dyn PocketDimension>>>>,
     ipfs: Arc<RwLock<Option<Ipfs<T>>>>,
-    direct_store: Arc<RwLock<Option<DirectMessageStore<T>>>>,
+    direct_store: Arc<RwLock<Option<MessageStore<T>>>>,
     config: Option<RgIpfsConfig>,
     constellation: Option<Box<dyn Constellation>>,
     initialize: Arc<AtomicBool>,
@@ -167,7 +167,7 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
         };
 
         *self.direct_store.write() = Some(
-            DirectMessageStore::new(
+            MessageStore::new(
                 ipfs.clone(),
                 config.path,
                 self.account.clone(),
@@ -212,7 +212,7 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
         Ok(inner)
     }
 
-    pub fn messaging_store(&self) -> std::result::Result<DirectMessageStore<T>, Error> {
+    pub fn messaging_store(&self) -> std::result::Result<MessageStore<T>, Error> {
         self.direct_store
             .read()
             .clone()

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -169,7 +169,7 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
         *self.direct_store.write() = Some(
             DirectMessageStore::new(
                 ipfs.clone(),
-                config.path.map(|p| p.join("messages")),
+                config.path,
                 self.account.clone(),
                 self.constellation.clone(),
                 discovery,

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -175,7 +175,6 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
                 (
                     config.store_setting.check_spam,
                     config.store_setting.store_decrypted,
-                    config.store_setting.allow_unsigned_message,
                     config.store_setting.with_friends,
                 ),
             )

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -4,6 +4,7 @@ mod store;
 
 use crate::spam_filter::SpamFilter;
 use config::RgIpfsConfig;
+use futures::StreamExt;
 use ipfs::IpfsTypes;
 use ipfs::{Ipfs, TestTypes, Types};
 use std::path::PathBuf;
@@ -403,7 +404,7 @@ impl<T: IpfsTypes> RayGunStream for IpfsMessaging<T> {
     ) -> Result<MessageEventStream> {
         let store = self.messaging_store()?;
         let stream = store.get_conversation_stream(conversation_id).await?;
-        Ok(MessageEventStream(Box::pin(stream)))
+        Ok(MessageEventStream(stream.boxed()))
     }
 }
 

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -251,7 +251,7 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
 
     async fn get_message(&self, conversation_id: Uuid, message_id: Uuid) -> Result<Message> {
         self.messaging_store()?
-            .get_message(conversation_id, message_id)
+            .get_message(conversation_id, message_id).await
     }
 
     async fn get_messages(

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -246,7 +246,7 @@ impl<T: IpfsTypes> RayGun for IpfsMessaging<T> {
     }
 
     async fn list_conversations(&self) -> Result<Vec<Conversation>> {
-        Ok(self.messaging_store()?.list_conversations())
+        self.messaging_store()?.list_conversations().await
     }
 
     async fn get_message(&self, conversation_id: Uuid, message_id: Uuid) -> Result<Message> {

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -166,7 +166,7 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
         *self.direct_store.write() = Some(
             MessageStore::new(
                 ipfs.clone(),
-                config.path,
+                config.path.map(|path| path.join("messages")),
                 self.account.clone(),
                 self.constellation.clone(),
                 discovery,

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -30,6 +30,20 @@ pub struct ConversationDocument {
     pub signature: Option<String>,
 }
 
+impl From<Conversation> for ConversationDocument {
+    fn from(conversation: Conversation) -> Self {
+        ConversationDocument {
+            id: conversation.id(),
+            name: conversation.name(),
+            creator: None,
+            conversation_type: conversation.conversation_type(),
+            recipients: conversation.recipients(),
+            messages: Default::default(),
+            signature: None,
+        }
+    }
+}
+
 impl Hash for ConversationDocument {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state)

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -134,7 +134,7 @@ impl ConversationDocument {
         ipfs: Ipfs<T>,
         did: Arc<DID>,
         option: MessageOptions,
-    ) -> Result<Vec<Message>, Error> {
+    ) -> Result<BTreeSet<Message>, Error> {
         if self.messages.is_empty() {
             return Err(Error::EmptyMessage);
         }
@@ -167,7 +167,7 @@ impl ConversationDocument {
                 .map(|document| async { document.resolve(ipfs.clone(), did.clone()).await }),
         )
         .filter_map(|res| async { res.ok() })
-        .collect::<Vec<Message>>()
+        .collect::<BTreeSet<Message>>()
         .await;
 
         Ok(list)

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -313,11 +313,18 @@ impl MessageDocument {
         }
 
         let data = object.encrypt(IpldCodec::DagJson, &did, Kind::Reference, message)?;
+
+        let message = data.to_cid(ipfs.clone()).await?;
+
+        if !ipfs.is_pinned(&message).await? {
+            ipfs.insert_pin(&message, false).await?;
+        }
+
         let document = MessageDocument {
             id,
             conversation_id,
             date,
-            message: data.to_cid(ipfs).await?,
+            message,
         };
 
         Ok(document)

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -47,6 +47,20 @@ impl From<Conversation> for ConversationDocument {
     }
 }
 
+impl From<&Conversation> for ConversationDocument {
+    fn from(conversation: &Conversation) -> Self {
+        ConversationDocument {
+            id: conversation.id(),
+            name: conversation.name(),
+            creator: None,
+            conversation_type: conversation.conversation_type(),
+            recipients: conversation.recipients(),
+            messages: Default::default(),
+            signature: None,
+        }
+    }
+}
+
 impl Hash for ConversationDocument {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state)

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -82,6 +82,18 @@ impl ConversationDocument {
         format!("{}/{}", self.conversation_type, self.id())
     }
 
+    pub fn event_topic(&self) -> String {
+        format!("{}/events", self.topic())
+    }
+
+    pub fn files_topic(&self) -> String {
+        format!("{}/files", self.topic())
+    }
+
+    pub fn files_transfer(&self, id: Uuid) -> String {
+        format!("{}/{id}", self.files_topic())
+    }
+
     pub fn recipients(&self) -> Vec<DID> {
         self.recipients.clone()
     }

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -35,6 +35,12 @@ pub struct ConversationDocument {
     tx: Option<BroadcastSender<MessageEventKind>>,
 }
 
+impl PartialEq for ConversationDocument {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
 impl ConversationDocument {
     pub fn new(
         did: &DID,
@@ -53,7 +59,9 @@ impl ConversationDocument {
         }
 
         if recipients.len() < 2 {
-            return Err(Error::OtherWithContext("Conversation requires a min of 2 recipients".into()));
+            return Err(Error::OtherWithContext(
+                "Conversation requires a min of 2 recipients".into(),
+            ));
         }
 
         let task = Arc::new(Default::default());

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -1,0 +1,141 @@
+use chrono::{DateTime, Utc};
+use futures::{stream::FuturesOrdered, StreamExt};
+use ipfs::{Ipfs, IpfsTypes};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use uuid::Uuid;
+use warp::{
+    crypto::DID,
+    error::Error,
+    raygun::{Conversation, ConversationType, Message, MessageOptions},
+    sata::Sata,
+};
+
+use super::document::DocumentType;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationDocument {
+    pub id: Uuid,
+    pub name: Option<String>,
+    pub conversation_type: ConversationType,
+    pub recipients: Vec<DID>,
+    pub messages: BTreeSet<MessageDocument>,
+}
+
+impl ConversationDocument {
+    pub async fn get_messages<T: IpfsTypes>(
+        &self,
+        ipfs: Ipfs<T>,
+        did: Arc<DID>,
+        option: MessageOptions,
+    ) -> Result<Vec<Message>, Error> {
+        if self.messages.is_empty() {
+            return Err(Error::EmptyMessage);
+        }
+
+        let messages = match option.date_range() {
+            Some(range) => Vec::from_iter(
+                self.messages
+                    .iter()
+                    .filter(|message| message.date >= range.start && message.date <= range.end),
+            ),
+            None => Vec::from_iter(self.messages.iter()),
+        };
+
+        let sorted = option
+            .range()
+            .map(|mut range| {
+                let start = range.start;
+                let end = range.end;
+                range.start = messages.len() - end;
+                range.end = messages.len() - start;
+                range
+            })
+            .and_then(|range| messages.get(range))
+            .map(|messages| messages.to_vec())
+            .unwrap_or(messages);
+
+        let list = FuturesOrdered::from_iter(
+            sorted
+                .iter()
+                .map(|document| async { document.resolve(ipfs.clone(), did.clone()).await }),
+        )
+        .filter_map(|res| async { res.ok() })
+        .collect::<Vec<Message>>()
+        .await;
+
+        Ok(list)
+    }
+
+    pub async fn get_message<T: IpfsTypes>(
+        &self,
+        ipfs: Ipfs<T>,
+        did: Arc<DID>,
+        message_id: Uuid,
+    ) -> Result<Message, Error> {
+        self.messages
+            .iter()
+            .find(|document| document.id == message_id)
+            .ok_or(Error::InvalidMessage)?
+            .resolve(ipfs, did)
+            .await
+    }
+}
+
+impl From<ConversationDocument> for Conversation {
+    fn from(document: ConversationDocument) -> Self {
+        let mut conversation = Conversation::default();
+        conversation.set_id(document.id);
+        conversation.set_name(document.name);
+        conversation.set_conversation_type(document.conversation_type);
+        conversation.set_recipients(document.recipients);
+        conversation
+    }
+}
+
+impl From<&ConversationDocument> for Conversation {
+    fn from(document: &ConversationDocument) -> Self {
+        let mut conversation = Conversation::default();
+        conversation.set_id(document.id);
+        conversation.set_name(document.name.clone());
+        conversation.set_conversation_type(document.conversation_type);
+        conversation.set_recipients(document.recipients.clone());
+        conversation
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MessageDocument {
+    pub id: Uuid,
+    pub conversation_id: Uuid,
+    pub date: DateTime<Utc>,
+    pub message: DocumentType<Sata>,
+}
+
+impl PartialOrd for MessageDocument {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.date.partial_cmp(&other.date)
+    }
+}
+
+impl Ord for MessageDocument {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.date.cmp(&other.date)
+    }
+}
+
+impl MessageDocument {
+    pub async fn resolve<T: IpfsTypes>(
+        &self,
+        ipfs: Ipfs<T>,
+        did: Arc<DID>,
+    ) -> Result<Message, Error> {
+        let data = self.message.resolve(ipfs, None).await?;
+        let message: Message = data.decrypt(&did).map_err(anyhow::Error::from)?;
+        if message.id() != self.id && message.conversation_id() != self.conversation_id {
+            return Err(Error::InvalidMessage);
+        }
+        Ok(message)
+    }
+}

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -77,9 +77,6 @@ impl ConversationDocument {
         id: Option<Uuid>,
         conversation_type: ConversationType,
     ) -> Result<Self, Error> {
-        // let (tx, _) = broadcast::channel(1024);
-        // let tx = Some(tx);
-
         let id = id.unwrap_or_else(Uuid::new_v4);
         let name = None;
 
@@ -95,7 +92,6 @@ impl ConversationDocument {
             ));
         }
 
-        // let task = Arc::new(Default::default());
         let messages = BTreeSet::new();
         Ok(Self {
             id,
@@ -104,8 +100,6 @@ impl ConversationDocument {
             creator: None,
             conversation_type,
             messages,
-            // task,
-            // tx,
             signature: None,
         })
     }

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -185,7 +185,7 @@ impl ConversationDocument {
         self.messages
             .iter()
             .find(|document| document.id == message_id)
-            .ok_or(Error::InvalidMessage)?
+            .ok_or(Error::MessageNotFound)?
             .resolve(ipfs, did)
             .await
     }

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -51,7 +51,7 @@ impl ConversationDocument {
         let (tx, _) = broadcast::channel(1024);
         let tx = Some(tx);
 
-        let id = id.unwrap_or(Uuid::new_v4());
+        let id = id.unwrap_or_else(Uuid::new_v4);
         let name = None;
 
         if !recipients.contains(did) {

--- a/extensions/warp-rg-ipfs/src/store/conversation.rs
+++ b/extensions/warp-rg-ipfs/src/store/conversation.rs
@@ -275,10 +275,6 @@ impl MessageDocument {
             return Err(Error::InvalidMessage);
         }
 
-        if old_message == message {
-            return Err(Error::MessageFound);
-        }
-
         let mut object = Sata::default();
         for recipient in recipients.iter() {
             object.add_recipient(recipient)?;

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -5,9 +5,11 @@ use std::time::Duration;
 
 use futures::{Stream, StreamExt};
 use ipfs::libp2p::swarm::dial_opts::DialOpts;
-use ipfs::{Ipfs, IpfsTypes, PeerId, SubscriptionStream};
+use ipfs::{Ipfs, IpfsPath, IpfsTypes, PeerId, SubscriptionStream};
 
+use libipld::serde::{from_ipld, to_ipld};
 use libipld::{Cid, IpldCodec};
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWriteExt;
 use tokio::sync::broadcast::{self, Sender as BroadcastSender};
@@ -28,6 +30,7 @@ use warp::sync::{Arc, RwLock};
 
 use crate::{Persistent, SpamFilter};
 
+use super::document::ConversationRootDocument;
 use super::{
     did_to_libp2p_pub, topic_discovery, verify_serde_sig, ConversationEvents, MessagingEvents,
     DIRECT_BROADCAST,
@@ -443,6 +446,8 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
             }
         }
 
+        if let Err(_e) = store.load_cid().await {}
+
         if discovery {
             let ipfs = store.ipfs.clone();
             tokio::spawn(async {
@@ -486,16 +491,6 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         });
         tokio::task::yield_now().await;
         Ok(store)
-    }
-
-    #[allow(dead_code)]
-    async fn local(&self) -> anyhow::Result<(ipfs::libp2p::identity::PublicKey, PeerId)> {
-        let (local_ipfs_public_key, local_peer_id) = self
-            .ipfs
-            .identity()
-            .await
-            .map(|(p, _)| (p.clone(), p.to_peer_id()))?;
-        Ok((local_ipfs_public_key, local_peer_id))
     }
 
     async fn process_conversation(
@@ -697,6 +692,48 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
             }
         }
         Ok(())
+    }
+
+    pub async fn get_root_document(&self) -> Result<ConversationRootDocument, Error> {
+        let root_cid = self.get_cid().await?;
+        let path = IpfsPath::from(root_cid);
+        self.get_dag(path, None).await
+    }
+
+    pub async fn set_root_document(
+        &mut self,
+        document: ConversationRootDocument,
+    ) -> Result<(), Error> {
+        let old_cid = self.get_cid().await?;
+
+        let root_cid = self.put_dag(document).await?;
+        if self.ipfs.is_pinned(&old_cid).await? {
+            self.ipfs.remove_pin(&old_cid, true).await?;
+        }
+
+        self.ipfs.insert_pin(&root_cid, true).await?;
+        self.save_cid(root_cid).await?;
+        Ok(())
+    }
+
+    pub async fn get_dag<D: DeserializeOwned>(
+        &self,
+        path: IpfsPath,
+        timeout: Option<Duration>,
+    ) -> Result<D, Error> {
+        let timeout = timeout.unwrap_or(std::time::Duration::from_secs(30));
+        let identity = match tokio::time::timeout(timeout, self.ipfs.get_dag(path)).await {
+            Ok(Ok(ipld)) => from_ipld::<D>(ipld).map_err(anyhow::Error::from)?,
+            Ok(Err(e)) => return Err(Error::Any(e)),
+            Err(e) => return Err(Error::from(anyhow::anyhow!("Timeout at {e}"))),
+        };
+        Ok(identity)
+    }
+
+    pub async fn put_dag<S: Serialize>(&self, data: S) -> Result<Cid, Error> {
+        let ipld = to_ipld(data).map_err(anyhow::Error::from)?;
+        let cid = self.ipfs.put_dag(ipld).await?;
+        Ok(cid)
     }
 
     pub async fn create_conversation(&mut self, did_key: &DID) -> Result<Conversation, Error> {
@@ -911,12 +948,10 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         Ok(conversation)
     }
 
-    pub fn list_conversations(&self) -> Vec<Conversation> {
-        self.direct_conversation
-            .read()
-            .iter()
-            .map(|convo| convo.conversation())
-            .collect()
+    pub async fn list_conversations(&self) -> Result<Vec<Conversation>, Error> {
+        let root = self.get_root_document().await?;
+        let list = root.list_conversations(self.ipfs.clone()).await?;
+        Ok(list.iter().map(|document| document.into()).collect())
     }
 
     pub fn messages_count(&self, conversation: Uuid) -> Result<usize, Error> {

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -2052,6 +2052,8 @@ pub async fn direct_message_event<'a, T: IpfsTypes>(
                 .update(store.ipfs.clone(), store.did.clone(), message)
                 .await?;
 
+            document.messages.replace(message_document);
+
             if let Err(e) = tx.send(MessageEventKind::MessageEdited {
                 conversation_id: convo_id,
                 message_id,
@@ -2130,6 +2132,7 @@ pub async fn direct_message_event<'a, T: IpfsTypes>(
                 .update(store.ipfs.clone(), store.did.clone(), message)
                 .await?;
 
+            document.messages.replace(message_document);
             if let Err(e) = tx.send(event) {
                 error!("Error broadcasting event: {e}");
             }
@@ -2179,7 +2182,7 @@ pub async fn direct_message_event<'a, T: IpfsTypes>(
                     message_document
                         .update(store.ipfs.clone(), store.did.clone(), message)
                         .await?;
-
+                    document.messages.replace(message_document);
                     if let Err(e) = tx.send(MessageEventKind::MessageReactionAdded {
                         conversation_id: convo_id,
                         message_id,
@@ -2214,7 +2217,7 @@ pub async fn direct_message_event<'a, T: IpfsTypes>(
                         message_document
                             .update(store.ipfs.clone(), store.did.clone(), message)
                             .await?;
-
+                        document.messages.replace(message_document);
                         if let Err(e) = tx.send(MessageEventKind::MessageReactionRemoved {
                             conversation_id: convo_id,
                             message_id,

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -372,11 +372,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         let queue = Arc::new(Default::default());
         let root_cid = Arc::new(Default::default());
         let did = Arc::new(account.decrypt_private_key(None)?);
-        let spam_filter = Arc::new(if check_spam {
-            Some(SpamFilter::default()?)
-        } else {
-            None
-        });
+        let spam_filter = Arc::new(check_spam.then_some(SpamFilter::default()?));
 
         let store_decrypted = Arc::new(AtomicBool::new(store_decrypted));
         let allowed_unsigned_message = Arc::new(AtomicBool::new(allowed_unsigned_message));

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -832,13 +832,11 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
 
     pub async fn get_message(
         &self,
-        conversation: Uuid,
+        conversation_id: Uuid,
         message_id: Uuid,
     ) -> Result<Message, Error> {
-        let document = self.get_root_document().await?;
-        let conversation = document
-            .get_conversation(self.ipfs.clone(), conversation)
-            .await?;
+        let _permit = self.permit(conversation_id).await?;
+        let conversation = self.get_conversation(conversation_id).await?;
         conversation
             .get_message(self.ipfs.clone(), self.did.clone(), message_id)
             .await
@@ -886,10 +884,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         conversation: Uuid,
         opt: MessageOptions,
     ) -> Result<Vec<Message>, Error> {
-        let document = self.get_root_document().await?;
-        let conversation = document
-            .get_conversation(self.ipfs.clone(), conversation)
-            .await?;
+        let conversation = self.get_conversation(conversation).await?;
         conversation
             .get_messages(self.ipfs.clone(), self.did.clone(), opt)
             .await

--- a/extensions/warp-rg-ipfs/src/store/direct.rs
+++ b/extensions/warp-rg-ipfs/src/store/direct.rs
@@ -660,6 +660,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
         Ok(())
     }
 
+    #[allow(clippy::clone_on_copy)]
     pub async fn get_cid(&self) -> Result<Cid, Error> {
         (self.root_cid.read().await.clone()).ok_or(Error::Other)
     }

--- a/extensions/warp-rg-ipfs/src/store/document.rs
+++ b/extensions/warp-rg-ipfs/src/store/document.rs
@@ -1,18 +1,13 @@
-use chrono::{DateTime, Utc};
 use futures::{stream::FuturesOrdered, StreamExt};
 use ipfs::{Ipfs, IpfsPath, IpfsTypes};
 use libipld::{serde::from_ipld, Cid};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::collections::BTreeSet;
 use std::hash::Hash;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use uuid::Uuid;
-use warp::{
-    crypto::DID,
-    error::Error,
-    raygun::{Conversation, ConversationType, Message, MessageOptions},
-    sata::Sata,
-};
+use warp::{crypto::DID, error::Error};
+
+use super::conversation::ConversationDocument;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, Eq)]
@@ -172,132 +167,5 @@ impl ConversationRootDocument {
         .await;
 
         Ok(list)
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ConversationDocument {
-    pub id: Uuid,
-    pub name: Option<String>,
-    pub conversation_type: ConversationType,
-    pub recipients: Vec<DID>,
-    pub messages: BTreeSet<MessageDocument>,
-}
-
-impl ConversationDocument {
-    pub async fn get_messages<T: IpfsTypes>(
-        &self,
-        ipfs: Ipfs<T>,
-        did: Arc<DID>,
-        option: MessageOptions,
-    ) -> Result<Vec<Message>, Error> {
-        if self.messages.is_empty() {
-            return Err(Error::EmptyMessage);
-        }
-
-        let messages = match option.date_range() {
-            Some(range) => Vec::from_iter(
-                self.messages
-                    .iter()
-                    .filter(|message| message.date >= range.start && message.date <= range.end),
-            ),
-            None => Vec::from_iter(self.messages.iter()),
-        };
-
-        let sorted = option
-            .range()
-            .map(|mut range| {
-                let start = range.start;
-                let end = range.end;
-                range.start = messages.len() - end;
-                range.end = messages.len() - start;
-                range
-            })
-            .and_then(|range| messages.get(range))
-            .map(|messages| messages.to_vec())
-            .unwrap_or(messages);
-
-        let list = FuturesOrdered::from_iter(
-            sorted
-                .iter()
-                .map(|document| async { document.resolve(ipfs.clone(), did.clone()).await }),
-        )
-        .filter_map(|res| async { res.ok() })
-        .collect::<Vec<Message>>()
-        .await;
-
-        Ok(list)
-    }
-
-    pub async fn get_message<T: IpfsTypes>(
-        &self,
-        ipfs: Ipfs<T>,
-        did: Arc<DID>,
-        message_id: Uuid,
-    ) -> Result<Message, Error> {
-        self.messages
-            .iter()
-            .find(|document| document.id == message_id)
-            .ok_or(Error::InvalidMessage)?
-            .resolve(ipfs, did)
-            .await
-    }
-}
-
-impl From<ConversationDocument> for Conversation {
-    fn from(document: ConversationDocument) -> Self {
-        let mut conversation = Conversation::default();
-        conversation.set_id(document.id);
-        conversation.set_name(document.name);
-        conversation.set_conversation_type(document.conversation_type);
-        conversation.set_recipients(document.recipients);
-        conversation
-    }
-}
-
-impl From<&ConversationDocument> for Conversation {
-    fn from(document: &ConversationDocument) -> Self {
-        let mut conversation = Conversation::default();
-        conversation.set_id(document.id);
-        conversation.set_name(document.name.clone());
-        conversation.set_conversation_type(document.conversation_type);
-        conversation.set_recipients(document.recipients.clone());
-        conversation
-    }
-}
-
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct MessageDocument {
-    pub id: Uuid,
-    pub conversation_id: Uuid,
-    pub date: DateTime<Utc>,
-    pub message: DocumentType<Sata>,
-}
-
-impl PartialOrd for MessageDocument {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.date.partial_cmp(&other.date)
-    }
-}
-
-impl Ord for MessageDocument {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.date.cmp(&other.date)
-    }
-}
-
-impl MessageDocument {
-    pub async fn resolve<T: IpfsTypes>(
-        &self,
-        ipfs: Ipfs<T>,
-        did: Arc<DID>,
-    ) -> Result<Message, Error> {
-        let data = self.message.resolve(ipfs, None).await?;
-        let message: Message = data.decrypt(&did).map_err(anyhow::Error::from)?;
-        if message.id() != self.id && message.conversation_id() != self.conversation_id {
-            return Err(Error::InvalidMessage);
-        }
-        Ok(message)
     }
 }

--- a/extensions/warp-rg-ipfs/src/store/document.rs
+++ b/extensions/warp-rg-ipfs/src/store/document.rs
@@ -171,7 +171,6 @@ impl<T> From<Cid> for DocumentType<T> {
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ConversationRootDocument {
     pub did: DID,
-    #[serde(skip_serializing_if = "HashSet::is_empty")]
     pub conversations: HashSet<DocumentType<ConversationDocument>>,
 }
 

--- a/extensions/warp-rg-ipfs/src/store/document.rs
+++ b/extensions/warp-rg-ipfs/src/store/document.rs
@@ -205,7 +205,7 @@ impl ConversationRootDocument {
         ipfs: Ipfs<T>,
     ) -> Result<Vec<ConversationDocument>, Error> {
         debug!("Loading conversations");
-        let list = FuturesOrdered::from_iter(
+        let list = FuturesUnordered::from_iter(
             self.conversations
                 .iter()
                 .map(|document| async { document.resolve(ipfs.clone(), None).await }),

--- a/extensions/warp-rg-ipfs/src/store/document.rs
+++ b/extensions/warp-rg-ipfs/src/store/document.rs
@@ -36,7 +36,7 @@ where
     T: Serialize + Clone + Send + Sync,
 {
     async fn to_document(&self, ipfs: Ipfs<I>) -> Result<DocumentType<T>, Error> {
-        self.clone().to_cid(ipfs).await.map(|cid| cid.into())
+        ToCid::to_cid(self, ipfs).await.map(|cid| cid.into())
     }
 }
 

--- a/extensions/warp-rg-ipfs/src/store/document.rs
+++ b/extensions/warp-rg-ipfs/src/store/document.rs
@@ -1,7 +1,4 @@
-use futures::{
-    stream::{FuturesOrdered, FuturesUnordered},
-    StreamExt,
-};
+use futures::{stream::FuturesUnordered, StreamExt};
 use ipfs::{Ipfs, IpfsPath, IpfsTypes};
 use libipld::{
     serde::{from_ipld, to_ipld},
@@ -12,7 +9,11 @@ use std::hash::Hash;
 use std::time::Duration;
 use std::{collections::HashSet, marker::PhantomData};
 use uuid::Uuid;
-use warp::{crypto::DID, error::Error, logging::tracing::log::{debug, info, error}};
+use warp::{
+    crypto::DID,
+    error::Error,
+    logging::tracing::log::{debug, error, info},
+};
 
 use super::conversation::ConversationDocument;
 
@@ -57,7 +58,7 @@ impl<D: DeserializeOwned, I: IpfsTypes> GetDag<D, I> for Cid {
 #[async_trait::async_trait]
 impl<D: DeserializeOwned, I: IpfsTypes> GetDag<D, I> for IpfsPath {
     async fn get_dag(&self, ipfs: Ipfs<I>, timeout: Option<Duration>) -> Result<D, Error> {
-        let timeout = timeout.unwrap_or(std::time::Duration::from_secs(30));
+        let timeout = timeout.unwrap_or(std::time::Duration::from_secs(10));
         match tokio::time::timeout(timeout, ipfs.get_dag(self.clone())).await {
             Ok(Ok(ipld)) => from_ipld(ipld)
                 .map_err(anyhow::Error::from)

--- a/extensions/warp-rg-ipfs/src/store/document.rs
+++ b/extensions/warp-rg-ipfs/src/store/document.rs
@@ -1,4 +1,3 @@
-use futures::{stream::FuturesUnordered, StreamExt};
 use ipfs::{Ipfs, IpfsPath, IpfsTypes};
 use libipld::{
     serde::{from_ipld, to_ipld},
@@ -6,16 +5,9 @@ use libipld::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::hash::Hash;
+use std::marker::PhantomData;
 use std::time::Duration;
-use std::{collections::HashSet, marker::PhantomData};
-use uuid::Uuid;
-use warp::{
-    crypto::DID,
-    error::Error,
-    logging::tracing::log::{debug, error, info},
-};
-
-use super::conversation::ConversationDocument;
+use warp::error::Error;
 
 #[async_trait::async_trait]
 pub(crate) trait ToDocument<T: IpfsTypes>: Sized {
@@ -123,6 +115,7 @@ impl<T> DocumentType<T> {
         self.document.get_dag(ipfs, timeout).await
     }
 
+    #[allow(dead_code)]
     pub async fn resolve_or_default<P: IpfsTypes>(
         &self,
         ipfs: Ipfs<P>,
@@ -146,128 +139,129 @@ impl<T> From<Cid> for DocumentType<T> {
     }
 }
 
-#[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct ConversationRootDocument {
-    pub did: DID,
-    pub conversations: HashSet<DocumentType<ConversationDocument>>,
-}
+// Note: This is commented out temporarily due to a race condition that was found while testing. This may get reenabled and used in the near future
+// #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+// pub struct ConversationRootDocument {
+//     pub did: DID,
+//     pub conversations: HashSet<DocumentType<ConversationDocument>>,
+// }
 
-impl ConversationRootDocument {
-    pub fn new(did: DID) -> Self {
-        Self {
-            did,
-            conversations: Default::default(),
-        }
-    }
-}
+// impl ConversationRootDocument {
+//     pub fn new(did: DID) -> Self {
+//         Self {
+//             did,
+//             conversations: Default::default(),
+//         }
+//     }
+// }
 
-impl ConversationRootDocument {
-    pub async fn get_conversation<T: IpfsTypes>(
-        &self,
-        ipfs: Ipfs<T>,
-        conversation_id: Uuid,
-    ) -> Result<ConversationDocument, Error> {
-        let document_type = self
-            .get_conversation_document(ipfs.clone(), conversation_id)
-            .await?;
-        document_type.resolve(ipfs, None).await
-    }
+// impl ConversationRootDocument {
+//     pub async fn get_conversation<T: IpfsTypes>(
+//         &self,
+//         ipfs: Ipfs<T>,
+//         conversation_id: Uuid,
+//     ) -> Result<ConversationDocument, Error> {
+//         let document_type = self
+//             .get_conversation_document(ipfs.clone(), conversation_id)
+//             .await?;
+//         document_type.resolve(ipfs, None).await
+//     }
 
-    pub async fn get_conversation_document<T: IpfsTypes>(
-        &self,
-        ipfs: Ipfs<T>,
-        conversation_id: Uuid,
-    ) -> Result<DocumentType<ConversationDocument>, Error> {
-        FuturesUnordered::from_iter(self.conversations.iter().map(|document| {
-            let ipfs = ipfs.clone();
-            async move {
-                let document_type = document.clone();
-                document
-                    .resolve(ipfs, None)
-                    .await
-                    .map(|document| (document_type, document))
-            }
-        }))
-        .filter_map(|result| async { result.ok() })
-        .filter(|(_, document)| {
-            let id = document.id;
-            async move { id == conversation_id }
-        })
-        .map(|(document_type, _)| document_type)
-        .collect::<Vec<_>>()
-        .await
-        .first()
-        .cloned()
-        .ok_or(Error::InvalidConversation)
-    }
+//     pub async fn get_conversation_document<T: IpfsTypes>(
+//         &self,
+//         ipfs: Ipfs<T>,
+//         conversation_id: Uuid,
+//     ) -> Result<DocumentType<ConversationDocument>, Error> {
+//         FuturesUnordered::from_iter(self.conversations.iter().map(|document| {
+//             let ipfs = ipfs.clone();
+//             async move {
+//                 let document_type = document.clone();
+//                 document
+//                     .resolve(ipfs, None)
+//                     .await
+//                     .map(|document| (document_type, document))
+//             }
+//         }))
+//         .filter_map(|result| async { result.ok() })
+//         .filter(|(_, document)| {
+//             let id = document.id;
+//             async move { id == conversation_id }
+//         })
+//         .map(|(document_type, _)| document_type)
+//         .collect::<Vec<_>>()
+//         .await
+//         .first()
+//         .cloned()
+//         .ok_or(Error::InvalidConversation)
+//     }
 
-    pub async fn list_conversations<T: IpfsTypes>(
-        &self,
-        ipfs: Ipfs<T>,
-    ) -> Result<Vec<ConversationDocument>, Error> {
-        debug!("Loading conversations");
-        let list = FuturesUnordered::from_iter(
-            self.conversations
-                .iter()
-                .map(|document| async { document.resolve(ipfs.clone(), None).await }),
-        )
-        .filter_map(|res| async { res.ok() })
-        .collect::<Vec<_>>()
-        .await;
-        info!("Conversations loaded");
-        Ok(list)
-    }
+//     pub async fn list_conversations<T: IpfsTypes>(
+//         &self,
+//         ipfs: Ipfs<T>,
+//     ) -> Result<Vec<ConversationDocument>, Error> {
+//         debug!("Loading conversations");
+//         let list = FuturesUnordered::from_iter(
+//             self.conversations
+//                 .iter()
+//                 .map(|document| async { document.resolve(ipfs.clone(), None).await }),
+//         )
+//         .filter_map(|res| async { res.ok() })
+//         .collect::<Vec<_>>()
+//         .await;
+//         info!("Conversations loaded");
+//         Ok(list)
+//     }
 
-    pub async fn remove_conversation<T: IpfsTypes>(
-        &mut self,
-        ipfs: Ipfs<T>,
-        conversation_id: Uuid,
-    ) -> Result<ConversationDocument, Error> {
-        info!("Removing conversation");
-        let document_type = self
-            .get_conversation_document(ipfs.clone(), conversation_id)
-            .await?;
+//     pub async fn remove_conversation<T: IpfsTypes>(
+//         &mut self,
+//         ipfs: Ipfs<T>,
+//         conversation_id: Uuid,
+//     ) -> Result<ConversationDocument, Error> {
+//         info!("Removing conversation");
+//         let document_type = self
+//             .get_conversation_document(ipfs.clone(), conversation_id)
+//             .await?;
 
-        if !self.conversations.remove(&document_type) {
-            error!("Conversation doesnt exist");
-            return Err(Error::InvalidConversation);
-        }
+//         if !self.conversations.remove(&document_type) {
+//             error!("Conversation doesnt exist");
+//             return Err(Error::InvalidConversation);
+//         }
 
-        let conversation = document_type.resolve(ipfs.clone(), None).await?;
-        if ipfs.is_pinned(&document_type.document).await? {
-            info!("Unpinning document");
-            ipfs.remove_pin(&document_type.document, false).await?;
-            info!("Document unpinned");
-        }
-        ipfs.remove_block(document_type.document).await?;
-        info!("Block removed");
+//         let conversation = document_type.resolve(ipfs.clone(), None).await?;
+//         if ipfs.is_pinned(&document_type.document).await? {
+//             info!("Unpinning document");
+//             ipfs.remove_pin(&document_type.document, false).await?;
+//             info!("Document unpinned");
+//         }
+//         ipfs.remove_block(document_type.document).await?;
+//         info!("Block removed");
 
-        Ok(conversation)
-    }
+//         Ok(conversation)
+//     }
 
-    pub async fn update_conversation<T: IpfsTypes>(
-        &mut self,
-        ipfs: Ipfs<T>,
-        conversation_id: Uuid,
-        document: ConversationDocument,
-    ) -> Result<(), Error> {
-        let document_type = self
-            .get_conversation_document(ipfs.clone(), conversation_id)
-            .await?;
+//     pub async fn update_conversation<T: IpfsTypes>(
+//         &mut self,
+//         ipfs: Ipfs<T>,
+//         conversation_id: Uuid,
+//         document: ConversationDocument,
+//     ) -> Result<(), Error> {
+//         let document_type = self
+//             .get_conversation_document(ipfs.clone(), conversation_id)
+//             .await?;
 
-        if !self.conversations.remove(&document_type) {
-            return Err(Error::InvalidConversation);
-        }
+//         if !self.conversations.remove(&document_type) {
+//             return Err(Error::InvalidConversation);
+//         }
 
-        let document = document.to_document(ipfs.clone()).await?;
+//         let document = document.to_document(ipfs.clone()).await?;
 
-        self.conversations.insert(document);
+//         self.conversations.insert(document);
 
-        if ipfs.is_pinned(&document_type.document).await? {
-            ipfs.remove_pin(&document_type.document, false).await?;
-        }
-        ipfs.remove_block(document_type.document).await?;
+//         if ipfs.is_pinned(&document_type.document).await? {
+//             ipfs.remove_pin(&document_type.document, false).await?;
+//         }
+//         ipfs.remove_block(document_type.document).await?;
 
-        Ok(())
-    }
-}
+//         Ok(())
+//     }
+// }

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -1625,11 +1625,10 @@ impl<T: IpfsTypes> MessageStore<T> {
         Ok(())
     }
 
-    #[allow(clippy::too_many_arguments)]
-    async fn message_event<'a>(
+    async fn message_event(
         &mut self,
         mut document: ConversationDocument,
-        events: &'a MessagingEvents,
+        events: &MessagingEvents,
         direction: MessageDirection,
         opt: EventOpt,
     ) -> Result<bool, Error> {

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -626,12 +626,6 @@ impl<T: IpfsTypes> MessageStore<T> {
         conversation_id: Uuid,
         broadcast: bool,
     ) -> Result<(), Error> {
-        // let mut root = self.get_root_document().await?;
-
-        // let document_type = root
-        //     .remove_conversation(self.ipfs.clone(), conversation_id)
-        //     .await?;
-        // self.set_root_document(root).await?;
 
         let conversation_cid = self
             .conversation_cid

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -72,8 +72,6 @@ pub struct MessageStore<T: IpfsTypes> {
 
     store_decrypted: Arc<AtomicBool>,
 
-    allowed_unsigned_message: Arc<AtomicBool>,
-
     with_friends: Arc<AtomicBool>,
 }
 
@@ -92,7 +90,6 @@ impl<T: IpfsTypes> Clone for MessageStore<T> {
             event: self.event.clone(),
             spam_filter: self.spam_filter.clone(),
             with_friends: self.with_friends.clone(),
-            allowed_unsigned_message: self.allowed_unsigned_message.clone(),
             store_decrypted: self.store_decrypted.clone(),
         }
     }
@@ -108,12 +105,7 @@ impl<T: IpfsTypes> MessageStore<T> {
         discovery: bool,
         interval_ms: u64,
         event: BroadcastSender<RayGunEventKind>,
-        (check_spam, store_decrypted, allowed_unsigned_message, with_friends): (
-            bool,
-            bool,
-            bool,
-            bool,
-        ),
+        (check_spam, store_decrypted, with_friends): (bool, bool, bool),
     ) -> anyhow::Result<Self> {
         let path = match std::any::TypeId::of::<T>() == std::any::TypeId::of::<Persistent>() {
             true => path,
@@ -132,7 +124,6 @@ impl<T: IpfsTypes> MessageStore<T> {
         let spam_filter = Arc::new(check_spam.then_some(SpamFilter::default()?));
         let stream_task = Arc::new(Default::default());
         let store_decrypted = Arc::new(AtomicBool::new(store_decrypted));
-        let allowed_unsigned_message = Arc::new(AtomicBool::new(allowed_unsigned_message));
         let with_friends = Arc::new(AtomicBool::new(with_friends));
         let stream_sender = Arc::new(Default::default());
 
@@ -149,7 +140,6 @@ impl<T: IpfsTypes> MessageStore<T> {
             event,
             spam_filter,
             store_decrypted,
-            allowed_unsigned_message,
             with_friends,
         };
 

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -929,7 +929,12 @@ impl<T: IpfsTypes> MessageStore<T> {
 
         if let Some(old_cid) = old_cid {
             if self.ipfs.is_pinned(&old_cid).await? {
-                if let Err(_e) = self.ipfs.remove_pin(&old_cid, false).await {}
+                if let Err(e) = self.ipfs.remove_pin(&old_cid, false).await {
+                    error!("Unable to remove pin on {old_cid}: {e}");
+                }
+            }
+            if let Err(e) = self.ipfs.remove_block(old_cid).await {
+                error!("Unable to remove {old_cid}: {e}");
             }
         }
 

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -1957,6 +1957,16 @@ impl<T: IpfsTypes> MessageStore<T> {
                                 reaction.set_emoji(&emoji);
                                 reaction.set_users(vec![sender.clone()]);
                                 reactions.push(reaction);
+                                
+                                message_document
+                                    .update(self.ipfs.clone(), self.did.clone(), message)
+                                    .await?;
+                                document.messages.replace(message_document);
+
+                                let mut root = self.get_root_document().await?;
+                                root.update_conversation(self.ipfs.clone(), convo_id, document)
+                                    .await?;
+                                self.set_root_document(root).await?;
                                 if let Err(e) = tx.send(MessageEventKind::MessageReactionAdded {
                                     conversation_id: convo_id,
                                     message_id,

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -49,6 +49,9 @@ pub struct MessageStore<T: IpfsTypes> {
     // conversation root cid
     root_cid: Arc<tokio::sync::RwLock<Option<Cid>>>,
 
+    // conversation cid
+    conversation_cid: Arc<tokio::sync::RwLock<HashMap<Uuid, Cid>>>,
+
     // account instance
     account: Box<dyn MultiPass>,
 
@@ -82,6 +85,7 @@ impl<T: IpfsTypes> Clone for MessageStore<T> {
             path: self.path.clone(),
             stream_sender: self.stream_sender.clone(),
             root_cid: self.root_cid.clone(),
+            conversation_cid: self.conversation_cid.clone(),
             account: self.account.clone(),
             filesystem: self.filesystem.clone(),
             stream_task: self.stream_task.clone(),
@@ -121,6 +125,7 @@ impl<T: IpfsTypes> MessageStore<T> {
 
         let queue = Arc::new(Default::default());
         let root_cid = Arc::new(Default::default());
+        let conversation_cid = Arc::new(Default::default());
         let did = Arc::new(account.decrypt_private_key(None)?);
         let spam_filter = Arc::new(check_spam.then_some(SpamFilter::default()?));
         let stream_task = Arc::new(Default::default());
@@ -134,6 +139,7 @@ impl<T: IpfsTypes> MessageStore<T> {
             stream_sender,
             stream_task,
             root_cid,
+            conversation_cid,
             account,
             filesystem,
             queue,

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -42,7 +42,7 @@ use super::{
     DIRECT_BROADCAST,
 };
 
-pub struct DirectMessageStore<T: IpfsTypes> {
+pub struct MessageStore<T: IpfsTypes> {
     // ipfs instance
     ipfs: Ipfs<T>,
 
@@ -82,7 +82,7 @@ pub struct DirectMessageStore<T: IpfsTypes> {
     with_friends: Arc<AtomicBool>,
 }
 
-impl<T: IpfsTypes> Clone for DirectMessageStore<T> {
+impl<T: IpfsTypes> Clone for MessageStore<T> {
     fn clone(&self) -> Self {
         Self {
             ipfs: self.ipfs.clone(),
@@ -105,7 +105,7 @@ impl<T: IpfsTypes> Clone for DirectMessageStore<T> {
 }
 
 #[allow(clippy::too_many_arguments)]
-impl<T: IpfsTypes> DirectMessageStore<T> {
+impl<T: IpfsTypes> MessageStore<T> {
     pub async fn new(
         ipfs: Ipfs<T>,
         path: Option<PathBuf>,
@@ -456,7 +456,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
     }
 }
 
-impl<T: IpfsTypes> DirectMessageStore<T> {
+impl<T: IpfsTypes> MessageStore<T> {
     pub async fn save_cid(&mut self, cid: Cid) -> Result<(), Error> {
         *self.root_cid.write().await = Some(cid);
         if let Some(path) = self.path.as_ref() {
@@ -682,7 +682,7 @@ impl<T: IpfsTypes> DirectMessageStore<T> {
             .remove_conversation(self.ipfs.clone(), conversation_id)
             .await?;
         self.set_root_document(root).await?;
-        // conversation.end_task();
+
         if broadcast {
             let recipients = document_type.recipients();
 

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -805,6 +805,7 @@ impl<T: IpfsTypes> MessageStore<T> {
         conversation
             .get_messages(self.ipfs.clone(), self.did.clone(), opt)
             .await
+            .map(Vec::from_iter)
     }
 
     pub async fn exist(&self, conversation: Uuid) -> bool {

--- a/extensions/warp-rg-ipfs/src/store/message.rs
+++ b/extensions/warp-rg-ipfs/src/store/message.rs
@@ -43,6 +43,8 @@ use super::{
     DIRECT_BROADCAST,
 };
 
+const PERMIT_AMOUNT: usize = 1;
+
 pub struct MessageStore<T: IpfsTypes> {
     // ipfs instance
     ipfs: Ipfs<T>,
@@ -242,7 +244,7 @@ impl<T: IpfsTypes> MessageStore<T> {
         self.conversation_lock
             .write()
             .await
-            .insert(conversation_id, Arc::new(Semaphore::new(1)));
+            .insert(conversation_id, Arc::new(Semaphore::new(PERMIT_AMOUNT)));
         info!("Task started for {conversation_id}");
         let did = self.did.clone();
 
@@ -337,7 +339,7 @@ impl<T: IpfsTypes> MessageStore<T> {
                 self.conversation_lock
                     .write()
                     .await
-                    .insert(convo.id(), Arc::new(Semaphore::new(1)));
+                    .insert(convo.id(), Arc::new(Semaphore::new(PERMIT_AMOUNT)));
 
                 let stream = match self.ipfs.pubsub_subscribe(convo.topic()).await {
                     Ok(stream) => stream,
@@ -556,7 +558,7 @@ impl<T: IpfsTypes> MessageStore<T> {
         self.conversation_lock
             .write()
             .await
-            .insert(convo_id, Arc::new(Semaphore::new(1)));
+            .insert(convo_id, Arc::new(Semaphore::new(PERMIT_AMOUNT)));
         let stream = self.ipfs.pubsub_subscribe(topic).await?;
 
         let (tx, _) = broadcast::channel(1024);
@@ -790,7 +792,7 @@ impl<T: IpfsTypes> MessageStore<T> {
                     self.conversation_lock
                         .write()
                         .await
-                        .insert(id, Arc::new(Semaphore::new(1)));
+                        .insert(id, Arc::new(Semaphore::new(PERMIT_AMOUNT)));
                 }
             }
         }

--- a/extensions/warp-rg-ipfs/src/store/mod.rs
+++ b/extensions/warp-rg-ipfs/src/store/mod.rs
@@ -87,12 +87,12 @@ fn verify_serde_sig<D: Serialize>(pk: DID, data: &D, signature: &[u8]) -> anyhow
 #[allow(clippy::large_enum_variant)]
 pub enum PeerType {
     PeerId(PeerId),
-    DID(DID),
+    Did(DID),
 }
 
 impl From<DID> for PeerType {
     fn from(did: DID) -> Self {
-        PeerType::DID(did)
+        PeerType::Did(did)
     }
 }
 
@@ -113,7 +113,7 @@ pub async fn connected_to_peer<T: IpfsTypes, I: Into<PeerType>>(
     pkey: I,
 ) -> anyhow::Result<PeerConnectionType> {
     let peer_id = match pkey.into() {
-        PeerType::DID(did) => did_to_libp2p_pub(&did)?.to_peer_id(),
+        PeerType::Did(did) => did_to_libp2p_pub(&did)?.to_peer_id(),
         PeerType::PeerId(peer) => peer,
     };
 

--- a/extensions/warp-rg-ipfs/src/store/mod.rs
+++ b/extensions/warp-rg-ipfs/src/store/mod.rs
@@ -1,4 +1,4 @@
-pub mod direct;
+pub mod message;
 pub mod document;
 pub mod conversation;
 

--- a/extensions/warp-rg-ipfs/src/store/mod.rs
+++ b/extensions/warp-rg-ipfs/src/store/mod.rs
@@ -1,5 +1,6 @@
 pub mod direct;
 pub mod document;
+pub mod conversation;
 
 use std::time::Duration;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Changes the way messages are stored. Previously, each conversation was stored in its own file. In this PR, it pushes the conversations into the blockstore that can be later resolved by the sender and/or the receipients of the messages of the conversation. 
 
**Which issue(s) this PR fixes** 🔨
Resolves #52 
<!--AP-X-->

**Special notes for reviewers** 🗒️
This will require additional testing due to the way conversations are handled to make sure there is little to no chance of a race condition. 

**Additional comments** 🎤
This might get changed to where the cid to each conversation is handled outside of the root ipld depending on the results, however performance under basic test seem to have improved alot. 