### PR TITLE
refactor: Move phonebook future into separate task

### DIFF
--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -152,9 +152,8 @@ impl<T: IpfsTypes> FriendsStore<T> {
         let did_key = Arc::new(did_keypair(&tesseract)?);
         let override_ipld = Arc::new(AtomicBool::new(override_ipld));
 
-        let (phonebook, fut) = PhoneBook::new(ipfs.clone(), tx.clone());
+        let phonebook = PhoneBook::new(ipfs.clone(), tx.clone());
         let phonebook = use_phonebook.then_some(phonebook);
-        tokio::spawn(fut);
 
         let store = Self {
             ipfs,

--- a/extensions/warp-mp-ipfs/src/store/phonebook.rs
+++ b/extensions/warp-mp-ipfs/src/store/phonebook.rs
@@ -1,9 +1,11 @@
 use rust_ipfs as ipfs;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 
 use ipfs::Multiaddr;
 use tokio::sync::broadcast;
@@ -24,160 +26,42 @@ use super::PeerConnectionType;
 #[allow(clippy::type_complexity)]
 pub struct PhoneBook<T: IpfsTypes> {
     ipfs: Ipfs<T>,
-    friends: Arc<
-        RwLock<
-            Vec<(
-                DID,
-                Arc<RwLock<Option<PeerConnectionType>>>,
-                Arc<AtomicBool>,
-            )>,
-        >,
-    >,
     discovery: Arc<RwLock<Discovery>>,
     relays: Arc<RwLock<Vec<Multiaddr>>>,
     emit_event: Arc<AtomicBool>,
+    entries: Arc<RwLock<HashMap<DID, PhoneBookEntry<T>>>>,
+    event: broadcast::Sender<MultiPassEventKind>,
 }
 
 impl<T: IpfsTypes> Clone for PhoneBook<T> {
     fn clone(&self) -> Self {
         Self {
             ipfs: self.ipfs.clone(),
-            friends: self.friends.clone(),
             discovery: self.discovery.clone(),
             relays: self.relays.clone(),
             emit_event: self.emit_event.clone(),
+            entries: self.entries.clone(),
+            event: self.event.clone(),
         }
     }
 }
 
 impl<T: IpfsTypes> PhoneBook<T> {
     pub fn new(ipfs: Ipfs<T>, event: broadcast::Sender<MultiPassEventKind>) -> Self {
-        let friends = Default::default();
         let discovery = Arc::new(RwLock::new(Discovery::None));
         let relays = Default::default();
         let emit_event = Arc::new(AtomicBool::new(false));
 
-        let book = PhoneBook {
-            friends,
+        let entries = Default::default();
+
+        PhoneBook {
             discovery,
             relays,
             emit_event,
-            ipfs: ipfs.clone(),
-        };
-
-        tokio::spawn({
-            let book = book.clone();
-            async move {
-                loop {
-                    let discovery = book.discovery.read().await.clone();
-                    let relays = book.relays.read().await.clone();
-                    if !book.friends.read().await.is_empty() {
-                        for (did, status, discovering) in book.friends.read().await.iter() {
-                            let discovery = discovery.clone();
-                            match connected_to_peer(ipfs.clone(), did.clone()).await {
-                                Ok(inner_status) => match (
-                                    inner_status,
-                                    discovering.load(Ordering::Relaxed),
-                                    book.emit_event.load(Ordering::Relaxed),
-                                ) {
-                                    (PeerConnectionType::NotConnected, false, emit) => {
-                                        let ipfs = ipfs.clone();
-                                        let relays = relays.clone();
-                                        let did = did.clone();
-                                        if let Some(status) = *status.read().await {
-                                            if status != PeerConnectionType::NotConnected && emit {
-                                                if let Err(e) = event.send(
-                                                    MultiPassEventKind::IdentityOffline {
-                                                        did: did.clone(),
-                                                    },
-                                                ) {
-                                                    error!("Error broadcasting event: {e}");
-                                                }
-                                            }
-                                        }
-
-                                        tokio::spawn(async move {
-                                            if let Err(_e) = super::discover_peer(
-                                                ipfs.clone(),
-                                                &did,
-                                                discovery,
-                                                relays.clone(),
-                                            )
-                                            .await
-                                            {}
-                                        });
-                                        discovering.store(true, Ordering::Relaxed);
-                                        *status.write().await =
-                                            Some(PeerConnectionType::NotConnected);
-                                    }
-                                    (PeerConnectionType::NotConnected, true, _)
-                                        if status.read().await.is_none() =>
-                                    {
-                                        *status.write().await =
-                                            Some(PeerConnectionType::NotConnected);
-                                    }
-                                    (PeerConnectionType::NotConnected, true, _)
-                                        if status.read().await.is_some() =>
-                                    {
-                                        if let Some(PeerConnectionType::NotConnected) =
-                                            *status.read().await
-                                        {
-                                            continue;
-                                        }
-                                        *status.write().await =
-                                            Some(PeerConnectionType::NotConnected);
-                                    }
-                                    (PeerConnectionType::Connected, true, emit) => {
-                                        if emit {
-                                            if let Err(e) =
-                                                event.send(MultiPassEventKind::IdentityOnline {
-                                                    did: did.clone(),
-                                                })
-                                            {
-                                                error!("Error broadcasting event: {e}");
-                                            }
-                                        }
-                                        discovering.store(false, Ordering::Relaxed);
-                                        *status.write().await = Some(inner_status)
-                                    }
-                                    (PeerConnectionType::Connected, false, emit) => {
-                                        if let Some(PeerConnectionType::NotConnected) =
-                                            *status.read().await
-                                        {
-                                            if emit {
-                                                if let Err(e) =
-                                                    event.send(MultiPassEventKind::IdentityOnline {
-                                                        did: did.clone(),
-                                                    })
-                                                {
-                                                    error!("Error broadcasting event: {e}");
-                                                }
-                                                *status.write().await = Some(inner_status)
-                                            }
-                                        } else {
-                                            if emit {
-                                                if let Err(e) =
-                                                    event.send(MultiPassEventKind::IdentityOnline {
-                                                        did: did.clone(),
-                                                    })
-                                                {
-                                                    error!("Error broadcasting event: {e}");
-                                                }
-                                            }
-                                            *status.write().await = Some(inner_status)
-                                        }
-                                    }
-                                    _ => {}
-                                },
-                                Err(_) => continue,
-                            }
-                        }
-                    }
-                    tokio::time::sleep(Duration::from_secs(1)).await;
-                }
-            }
-        });
-        book
+            ipfs,
+            entries,
+            event,
+        }
     }
 
     pub async fn add_friend_list(&self, list: HashSet<DID>) -> anyhow::Result<()> {
@@ -188,18 +72,28 @@ impl<T: IpfsTypes> PhoneBook<T> {
     }
 
     pub async fn add_friend(&self, did: &DID) -> anyhow::Result<()> {
-        self.friends
-            .write()
-            .await
-            .push((did.clone(), Default::default(), Default::default()));
+        let entry = PhoneBookEntry::new(
+            self.ipfs.clone(),
+            did.clone(),
+            self.event.clone(),
+            self.emit_event.clone(),
+            self.discovery.clone(),
+            self.relays.clone(),
+        )
+        .await?;
+
+        let old = self.entries.write().await.insert(did.clone(), entry);
+        if let Some(old) = old {
+            old.cancel_entry().await;
+        }
         Ok(())
     }
 
     pub async fn online_friends(&self) -> Result<Vec<DID>, Error> {
         let mut online = vec![];
-        for (friend, status, _) in self.friends.read().await.iter() {
-            if let Some(PeerConnectionType::Connected) = *status.read().await {
-                online.push(friend.clone())
+        for (did, entry) in &*self.entries.read().await {
+            if matches!(entry.status().await, PeerConnectionType::Connected) {
+                online.push(did.clone())
             }
         }
         Ok(online)
@@ -207,27 +101,20 @@ impl<T: IpfsTypes> PhoneBook<T> {
 
     pub async fn offline_friends(&self) -> Result<Vec<DID>, Error> {
         let mut offline = vec![];
-        for (friend, status, _) in self.friends.read().await.iter() {
-            if let Some(PeerConnectionType::NotConnected) = *status.read().await {
-                offline.push(friend.clone());
+        for (did, entry) in &*self.entries.read().await {
+            if matches!(entry.status().await, PeerConnectionType::NotConnected) {
+                offline.push(did.clone())
             }
         }
         Ok(offline)
     }
 
     pub async fn remove_friend(&self, did: &DID) -> Result<(), Error> {
-        let mut friends = self.friends.write().await;
-        match friends
-            .iter()
-            .map(|(d, _, _)| d)
-            .position(|inner_did| did.eq(inner_did))
-        {
-            Some(index) => {
-                friends.remove(index);
-                Ok(())
-            }
-            None => Err(Error::FriendDoesntExist),
+        if let Some(entry) = self.entries.write().await.remove(did) {
+            entry.cancel_entry().await;
+            return Ok(());
         }
+        Err(Error::FriendDoesntExist)
     }
 
     pub async fn enable_events(&self) -> anyhow::Result<()> {
@@ -248,5 +135,154 @@ impl<T: IpfsTypes> PhoneBook<T> {
     pub async fn add_relay(&self, addr: Multiaddr) -> anyhow::Result<()> {
         self.relays.write().await.push(addr);
         Ok(())
+    }
+}
+
+pub struct PhoneBookEntry<T: IpfsTypes> {
+    ipfs: Ipfs<T>,
+    did: DID,
+    connection_type: Arc<RwLock<PeerConnectionType>>,
+    task: Arc<RwLock<Option<JoinHandle<()>>>>,
+    event: broadcast::Sender<MultiPassEventKind>,
+    discovery: Arc<RwLock<Discovery>>,
+    relays: Arc<RwLock<Vec<Multiaddr>>>,
+    emit_event: Arc<AtomicBool>,
+}
+
+impl<T: IpfsTypes> PartialEq for PhoneBookEntry<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.did.eq(&other.did)
+    }
+}
+
+impl<T: IpfsTypes> Eq for PhoneBookEntry<T> {}
+
+impl<T: IpfsTypes> core::hash::Hash for PhoneBookEntry<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.did.hash(state);
+    }
+}
+
+impl<T: IpfsTypes> Clone for PhoneBookEntry<T> {
+    fn clone(&self) -> Self {
+        Self {
+            ipfs: self.ipfs.clone(),
+            did: self.did.clone(),
+            connection_type: self.connection_type.clone(),
+            task: self.task.clone(),
+            event: self.event.clone(),
+            discovery: self.discovery.clone(),
+            relays: self.relays.clone(),
+            emit_event: self.emit_event.clone(),
+        }
+    }
+}
+
+impl<T: IpfsTypes> PhoneBookEntry<T> {
+    pub async fn new(
+        ipfs: Ipfs<T>,
+        did: DID,
+        event: broadcast::Sender<MultiPassEventKind>,
+        emit_event: Arc<AtomicBool>,
+        discovery: Arc<RwLock<Discovery>>,
+        relays: Arc<RwLock<Vec<Multiaddr>>>,
+    ) -> Result<Self, Error> {
+        let connection_type = connected_to_peer(ipfs.clone(), did.clone())
+            .await
+            .map(RwLock::new)
+            .map(Arc::new)?;
+
+        let task = Default::default();
+
+        let entry = Self {
+            ipfs,
+            did,
+            connection_type,
+            task,
+            event,
+            emit_event,
+            discovery,
+            relays,
+        };
+
+        let task = tokio::spawn({
+            let entry = entry.clone();
+            async move {
+                let mut discovering = false;
+                let previous_status = entry.connection_type.clone();
+                loop {
+                    let Ok(connection_status) =  connected_to_peer(entry.ipfs.clone(), entry.did.clone()).await else {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        continue;
+                    };
+                    match (connection_status, discovering) {
+                        (PeerConnectionType::Connected, true) => {
+                            if matches!(
+                                *previous_status.read().await,
+                                PeerConnectionType::NotConnected
+                            ) && entry.emit_event.load(Ordering::Relaxed)
+                            {
+                                let did = entry.did.clone();
+                                if let Err(e) =
+                                    entry.event.send(MultiPassEventKind::IdentityOnline { did })
+                                {
+                                    error!("Error broadcasting event: {e}");
+                                }
+                                *previous_status.write().await = PeerConnectionType::Connected;
+                            }
+                            discovering = false;
+                        }
+                        (PeerConnectionType::Connected, false) => {
+                            *previous_status.write().await = PeerConnectionType::Connected;
+                        }
+                        (PeerConnectionType::NotConnected, true) => {
+                            let did = entry.did.clone();
+                            let discovery = entry.discovery.read().await.clone();
+                            let relays = entry.relays.read().await.clone();
+                            let ipfs = entry.ipfs.clone();
+                            if matches!(
+                                *previous_status.read().await,
+                                PeerConnectionType::Connected
+                            ) && entry.emit_event.load(Ordering::Relaxed)
+                            {
+                                let did = did.clone();
+                                if let Err(e) = entry
+                                    .event
+                                    .send(MultiPassEventKind::IdentityOffline { did })
+                                {
+                                    error!("Error broadcasting event: {e}");
+                                }
+                                *previous_status.write().await = PeerConnectionType::NotConnected;
+                            }
+                            tokio::spawn(async move {
+                                if let Err(_e) =
+                                    super::discover_peer(ipfs, &did, discovery, relays).await
+                                {
+                                }
+                            });
+                            discovering = true;
+                        }
+                        (PeerConnectionType::NotConnected, false) => {
+                            *previous_status.write().await = PeerConnectionType::NotConnected;
+                        }
+                    }
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        });
+
+        *entry.task.write().await = Some(task);
+
+        Ok(entry)
+    }
+
+    pub async fn status(&self) -> PeerConnectionType {
+        *self.connection_type.read().await
+    }
+
+    pub async fn cancel_entry(&self) {
+        if let Some(task) = std::mem::take(&mut *self.task.write().await) {
+            task.abort()
+        }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Split phonebook future into separate task for each individual to be discovered

**Which issue(s) this PR fixes** 🔨
Resolves #135 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Event broadcast for online and offline status is disabled by default for now. 