### PR TITLE
add: flag disable broadcasting `RayGunEventKind::ConversatinCreated` on sender side

### DIFF
--- a/extensions/warp-rg-ipfs/src/config.rs
+++ b/extensions/warp-rg-ipfs/src/config.rs
@@ -76,18 +76,34 @@ pub struct IpfsSetting {
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct StoreSetting {
+    /// Allow only interactions with `MultiPass` friends
+    /// Note: This is ignored when it comes to chating between group chat recipients 
     pub with_friends: bool,
-    pub store_decrypted: bool,
     pub broadcast_interval: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Placeholder
     pub discovery_name: Option<String>,
+    /// Placeholder
     pub discovery: bool,
+    /// TBD
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sync: Vec<Multiaddr>,
+    /// TBD
     pub sync_interval: u64,
+
+    /// Enables spam check
     pub check_spam: bool,
+
+    /// Load conversation in a separate task
+    /// Note: While this is loaded in a separate task, not all conversations will be made available up front.
+    ///       If any conversations are corrupted for whatever reason they will not be made available
     pub conversation_load_task: bool,
+
+    /// Attaches recipients to the local message block
     pub attach_recipients_on_storing: bool,
+
+    /// Disables emitting an event on stream for creating a conversation
+    pub disable_sender_event_emit: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,7 +155,6 @@ impl Default for RgIpfsConfig {
                 discovery: true,
                 check_spam: true,
                 with_friends: false,
-                store_decrypted: false,
                 ..Default::default()
             },
             debug: false,

--- a/extensions/warp-rg-ipfs/src/lib.rs
+++ b/extensions/warp-rg-ipfs/src/lib.rs
@@ -175,7 +175,7 @@ impl<T: IpfsTypes> IpfsMessaging<T> {
                 self.tx.clone(),
                 (
                     config.store_setting.check_spam,
-                    config.store_setting.store_decrypted,
+                    config.store_setting.disable_sender_event_emit,
                     config.store_setting.with_friends,
                     config.store_setting.conversation_load_task,
                     config.store_setting.attach_recipients_on_storing,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Added flag to disable broadcasting event on the sender side when creating a conversation

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
This flag is false by default. 