### PR TITLE
feat: Add BlockedBy and UnblockedBy to MultiPassEventKind

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -309,7 +309,27 @@ async fn main() -> anyhow::Result<()> {
                                 .unwrap_or_else(|| did.to_string());
 
                             writeln!(stdout, "> {} was unblocked", username)?;
-                        }
+                        },
+                        warp::multipass::MultiPassEventKind::UnblockedBy { did } => {
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone())).await
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
+                            writeln!(stdout, "> {} unblocked you", username)?;
+                        },
+                        warp::multipass::MultiPassEventKind::BlockedBy { did } => {
+                            let username = account
+                                .get_identity(Identifier::did_key(did.clone())).await
+                                .ok()
+                                .and_then(|list| list.first().cloned())
+                                .map(|ident| ident.username())
+                                .unwrap_or_else(|| did.to_string());
+
+                            writeln!(stdout, "> {} blocked you", username)?;
+                        },
                     }
                 }
             }

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -473,8 +473,17 @@ impl<T: IpfsTypes> FriendsStore<T> {
                     }
 
                     let mut list = self.block_by_list().await?;
-                    list.insert(data.sender);
+                    let completed = list.insert(data.sender.clone());
                     self.set_block_by_list(list).await?;
+
+                    if completed {
+                        if let Err(e) = self
+                            .tx
+                            .send(MultiPassEventKind::BlockedBy { did: data.sender })
+                        {
+                            error!("Error broadcasting event: {e}");
+                        }
+                    }
 
                     if let Some(tx) = std::mem::take(&mut signal) {
                         let _ = tx.send(Err(Error::BlockedByUser));
@@ -482,8 +491,16 @@ impl<T: IpfsTypes> FriendsStore<T> {
                 }
                 Event::Unblock => {
                     let mut list = self.block_by_list().await?;
-                    list.remove(&data.sender);
+                    let completed = list.remove(&data.sender);
                     self.set_block_by_list(list).await?;
+                    if completed {
+                        if let Err(e) = self
+                            .tx
+                            .send(MultiPassEventKind::UnblockedBy { did: data.sender })
+                        {
+                            error!("Error broadcasting event: {e}");
+                        }
+                    }
                 }
                 Event::Response => {
                     if let Some(tx) = std::mem::take(&mut signal) {

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -33,7 +33,9 @@ pub enum MultiPassEventKind {
     IdentityOnline { did: DID },
     IdentityOffline { did: DID },
     Blocked { did: DID },
-    Unblocked { did: DID }
+    BlockedBy { did: DID },
+    Unblocked { did: DID },
+    UnblockedBy { did: DID },
 }
 
 #[derive(FFIFree)]
@@ -68,7 +70,8 @@ pub trait MultiPass:
 
     /// Obtain your own [`Identity`]
     async fn get_own_identity(&self) -> Result<Identity, Error> {
-        self.get_identity(Identifier::own()).await
+        self.get_identity(Identifier::own())
+            .await
             .and_then(|list| list.get(0).cloned().ok_or(Error::IdentityDoesntExist))
     }
 
@@ -147,7 +150,7 @@ pub trait Friends: Sync + Send {
     }
 
     /// Check to see if public key is blocked
-   async fn is_blocked(&self, _: &DID) -> Result<bool, Error> {
+    async fn is_blocked(&self, _: &DID) -> Result<bool, Error> {
         Err(Error::Unimplemented)
     }
 
@@ -169,7 +172,6 @@ pub trait FriendsEvent: Sync + Send {
         Err(Error::Unimplemented)
     }
 }
-
 
 #[async_trait::async_trait]
 pub trait IdentityInformation: Send + Sync {
@@ -232,10 +234,7 @@ pub mod ffi {
     use crate::error::Error;
     use crate::ffi::{FFIResult, FFIResult_Null, FFIResult_String};
     use crate::multipass::{
-        identity::{
-             FFIResult_FFIVec_Identity, Identifier, Identity,
-            IdentityUpdate,
-        },
+        identity::{FFIResult_FFIVec_Identity, Identifier, Identity, IdentityUpdate},
         MultiPassAdapter,
     };
     use std::ffi::CStr;
@@ -274,8 +273,8 @@ pub mod ffi {
         let mp = &mut *(ctx);
 
         match async_on_block(async {
-            mp
-                .create_identity(username.as_deref(), passphrase.as_deref()).await
+            mp.create_identity(username.as_deref(), passphrase.as_deref())
+                .await
         }) {
             Ok(pkey) => FFIResult::ok(pkey),
             Err(e) => FFIResult::err(e),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Adds MultiPassEventKind::BlockedBy and MultiPassEventKind::UnblockedBy to notify when the user is blocked by somebody

**Which issue(s) this PR fixes** 🔨
Resolves #150 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Although this is easily implemented, should this be emitted since other events are emitted if a user is blocked when a request is sent, received, or if they are friends with said user. 