### PR TITLE
refactor: Change IdentityUpdate to enum

### DIFF
--- a/extensions/warp-mp-ipfs/Cargo.toml
+++ b/extensions/warp-mp-ipfs/Cargo.toml
@@ -13,6 +13,7 @@ rust-ipfs = "=0.3.0-alpha.2"
 libipld = { version = "0.15", features = ["serde-codec"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["full"] }
 futures = { version = "0.3" }
 async-trait = { version = "0.1" }
 async-stream = "0.3"

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use store::friends::FriendsStore;
 use store::identity::{IdentityStore, LookupBy};
 use tokio::sync::broadcast;
+use tokio_util::io::ReaderStream;
 use tracing::log::{error, info, trace, warn};
 use warp::crypto::did_key::Generate;
 use warp::data::DataType;
@@ -275,8 +276,8 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
 
         info!("Starting ipfs");
         let ipfs = UninitializedIpfs::<T>::new(opts)
-        // We check the events from the swarm for autonat
-        // So we can determine our nat status when it does change
+            // We check the events from the swarm for autonat
+            // So we can determine our nat status when it does change
             .swarm_events({
                 move |_, event| {
                     //Note: This will be used
@@ -643,14 +644,9 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
     async fn update_identity(&mut self, option: IdentityUpdate) -> Result<(), Error> {
         let mut store = self.identity_store(true).await?;
         let mut identity = self.get_own_identity().await?;
-        let old_identity = identity.clone();
-        match (
-            option.username(),
-            option.graphics_picture(),
-            option.graphics_banner(),
-            option.status_message(),
-        ) {
-            (Some(username), None, None, None) => {
+
+        match option {
+            IdentityUpdate::Username(username) => {
                 let len = username.chars().count();
                 if !(4..=64).contains(&len) {
                     return Err(Error::InvalidLength {
@@ -663,7 +659,7 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
 
                 identity.set_username(&username);
             }
-            (None, Some(data), None, None) => {
+            IdentityUpdate::Picture(data) => {
                 let len = data.len();
                 if len > 2 * 1024 * 1024 {
                     return Err(Error::InvalidLength {
@@ -697,7 +693,50 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
                 root_document.picture = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
                 store.set_root_document(root_document).await?;
             }
-            (None, None, Some(data), None) => {
+            IdentityUpdate::PicturePath(path) => {
+                if !path.is_file() {
+                    return Err(Error::IoError(std::io::Error::from(
+                        std::io::ErrorKind::NotFound,
+                    )));
+                }
+
+                let file = tokio::fs::File::open(path).await?;
+
+                let metadata = file.metadata().await?;
+
+                let len = metadata.len() as _;
+
+                if metadata.len() > 2 * 1024 * 1024 {
+                    return Err(Error::InvalidLength {
+                        context: "profile picture".into(),
+                        current: len,
+                        minimum: None,
+                        maximum: Some(2 * 1024 * 1024),
+                    });
+                }
+
+                let stream = ReaderStream::new(file)
+                    .filter_map(|result| async { result.ok() })
+                    .map(|data| data.into());
+
+                let cid = store
+                    .store_photo(stream.boxed(), Some(2 * 1024 * 1024))
+                    .await?;
+
+                let mut root_document = store.get_root_document().await?;
+                if let Some(DocumentType::UnixFS(picture_cid, _)) = root_document.picture {
+                    if picture_cid == cid {
+                        return Err(Error::CannotUpdateIdentityPicture);
+                    }
+                    if let Err(e) = store.delete_photo(picture_cid).await {
+                        error!("Error deleting banner: {e}");
+                    }
+                }
+
+                root_document.picture = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
+                store.set_root_document(root_document).await?;
+            }
+            IdentityUpdate::Banner(data) => {
                 let len = data.len();
                 if len > 2 * 1024 * 1024 {
                     return Err(Error::InvalidLength {
@@ -731,10 +770,53 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
                 root_document.banner = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
                 store.set_root_document(root_document).await?;
             }
-            (None, None, None, Some(status)) => {
+            IdentityUpdate::BannerPath(path) => {
+                if !path.is_file() {
+                    return Err(Error::IoError(std::io::Error::from(
+                        std::io::ErrorKind::NotFound,
+                    )));
+                }
+
+                let file = tokio::fs::File::open(path).await?;
+
+                let metadata = file.metadata().await?;
+
+                let len = metadata.len() as _;
+
+                if metadata.len() > 2 * 1024 * 1024 {
+                    return Err(Error::InvalidLength {
+                        context: "profile banner".into(),
+                        current: len,
+                        minimum: None,
+                        maximum: Some(2 * 1024 * 1024),
+                    });
+                }
+
+                let stream = ReaderStream::new(file)
+                    .filter_map(|result| async { result.ok() })
+                    .map(|data| data.into());
+
+                let cid = store
+                    .store_photo(stream.boxed(), Some(2 * 1024 * 1024))
+                    .await?;
+
+                let mut root_document = store.get_root_document().await?;
+                if let Some(DocumentType::UnixFS(banner_cid, _)) = root_document.banner {
+                    if banner_cid == cid {
+                        return Err(Error::CannotUpdateIdentityBanner);
+                    }
+                    if let Err(e) = store.delete_photo(banner_cid).await {
+                        error!("Error deleting banner: {e}");
+                    }
+                }
+
+                root_document.banner = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
+                store.set_root_document(root_document).await?;
+            }
+            IdentityUpdate::StatusMessage(status) => {
                 if let Some(status) = status.clone() {
                     let len = status.chars().count();
-                    if len >= 512 {
+                    if len > 512 {
                         return Err(Error::InvalidLength {
                             context: "status".into(),
                             current: len,
@@ -745,36 +827,9 @@ impl<T: IpfsTypes> MultiPass for IpfsIdentity<T> {
                 }
                 identity.set_status_message(status);
             }
-            _ => return Err(Error::CannotUpdateIdentity),
-        }
-        store.identity_update(identity.clone()).await?;
+        };
 
-        if let Ok(mut cache) = self.get_cache_mut() {
-            let mut query = QueryBuilder::default();
-            //TODO: Query by public key to tie/assiociate the username to identity in the event of dup
-            query.r#where("username", &old_identity.username())?;
-            if let Ok(list) = cache.get_data(DataType::from(Module::Accounts), Some(&query)) {
-                //get last
-                if !list.is_empty() {
-                    // let mut obj = list.last().unwrap().clone();
-                    let mut object = Sata::default();
-                    object.set_version(list.len() as _);
-                    let obj = object.encode(
-                        warp::sata::libipld::IpldCodec::DagJson,
-                        warp::sata::Kind::Reference,
-                        identity.clone(),
-                    )?;
-                    cache.add_data(DataType::from(Module::Accounts), &obj)?;
-                }
-            } else {
-                let object = Sata::default().encode(
-                    warp::sata::libipld::IpldCodec::DagJson,
-                    warp::sata::Kind::Reference,
-                    identity.clone(),
-                )?;
-                cache.add_data(DataType::from(Module::Accounts), &object)?;
-            }
-        }
+        store.identity_update(identity.clone()).await?;
 
         info!("Update identity store");
         store.update_identity().await?;

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -384,7 +384,6 @@ impl<S: AsRef<str>> From<S> for Identifier {
 }
 
 #[derive(Debug, Clone, FFIFree)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub enum IdentityUpdate {
     Username(String),
     Picture(String),
@@ -394,30 +393,24 @@ pub enum IdentityUpdate {
     StatusMessage(Option<String>),
 }
 
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl IdentityUpdate {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_username(username: String) -> IdentityUpdate {
         IdentityUpdate::Username(username)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_graphics_picture(graphics: String) -> IdentityUpdate {
         IdentityUpdate::Picture(graphics)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_graphics_banner(graphics: String) -> IdentityUpdate {
         IdentityUpdate::Banner(graphics)
     }
 
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_status_message(status_message: Option<String>) -> IdentityUpdate {
         IdentityUpdate::StatusMessage(status_message)
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl IdentityUpdate {
     pub fn set_graphics_picture_path(path: std::path::PathBuf) -> IdentityUpdate {
         IdentityUpdate::PicturePath(path)
@@ -428,72 +421,47 @@ impl IdentityUpdate {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl IdentityUpdate {
     pub fn username(&self) -> Option<String> {
         match self.clone() {
             IdentityUpdate::Username(username) => Some(username),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn graphics_picture(&self) -> Option<String> {
         match self.clone() {
             IdentityUpdate::Picture(data) => Some(data),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn graphics_banner(&self) -> Option<String> {
         match self.clone() {
             IdentityUpdate::Banner(data) => Some(data),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn graphics_picture_path(&self) -> Option<std::path::PathBuf> {
         match self.clone() {
             IdentityUpdate::PicturePath(path) => Some(path),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn graphics_banner_path(&self) -> Option<std::path::PathBuf> {
         match self.clone() {
             IdentityUpdate::BannerPath(path) => Some(path),
-            _ => None
+            _ => None,
         }
     }
 
     pub fn status_message(&self) -> Option<Option<String>> {
         match self.clone() {
             IdentityUpdate::StatusMessage(status) => Some(status),
-            _ => None
+            _ => None,
         }
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl IdentityUpdate {
-    #[wasm_bindgen(getter)]
-    pub fn username(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.username).unwrap()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn graphics_picture(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.graphics_picture).unwrap()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn graphics_banner(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.graphics_banner).unwrap()
-    }
-
-    #[wasm_bindgen(getter)]
-    pub fn status_message(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.status_message).unwrap()
     }
 }
 

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -383,73 +383,93 @@ impl<S: AsRef<str>> From<S> for Identifier {
     }
 }
 
-#[derive(Debug, Clone, Default, FFIFree)]
+#[derive(Debug, Clone, FFIFree)]
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub struct IdentityUpdate {
-    /// Setting Username
-    username: Option<String>,
-
-    /// Path of picture
-    graphics_picture: Option<String>,
-
-    /// Path of banner
-    graphics_banner: Option<String>,
-
-    /// Setting Status Message
-    status_message: Option<Option<String>>,
+pub enum IdentityUpdate {
+    Username(String),
+    Picture(String),
+    PicturePath(std::path::PathBuf),
+    Banner(String),
+    BannerPath(std::path::PathBuf),
+    StatusMessage(Option<String>),
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 impl IdentityUpdate {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_username(username: String) -> IdentityUpdate {
-        IdentityUpdate {
-            username: Some(username),
-            ..Default::default()
-        }
+        IdentityUpdate::Username(username)
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_graphics_picture(graphics: String) -> IdentityUpdate {
-        IdentityUpdate {
-            graphics_picture: Some(graphics),
-            ..Default::default()
-        }
+        IdentityUpdate::Picture(graphics)
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_graphics_banner(graphics: String) -> IdentityUpdate {
-        IdentityUpdate {
-            graphics_banner: Some(graphics),
-            ..Default::default()
-        }
+        IdentityUpdate::Banner(graphics)
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
     pub fn set_status_message(status_message: Option<String>) -> IdentityUpdate {
-        IdentityUpdate {
-            status_message: Some(status_message),
-            ..Default::default()
-        }
+        IdentityUpdate::StatusMessage(status_message)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl IdentityUpdate {
+    pub fn set_graphics_picture_path(path: std::path::PathBuf) -> IdentityUpdate {
+        IdentityUpdate::PicturePath(path)
+    }
+
+    pub fn set_graphics_banner_path(path: std::path::PathBuf) -> IdentityUpdate {
+        IdentityUpdate::BannerPath(path)
     }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl IdentityUpdate {
     pub fn username(&self) -> Option<String> {
-        self.username.clone()
+        match self.clone() {
+            IdentityUpdate::Username(username) => Some(username),
+            _ => None
+        }
     }
 
     pub fn graphics_picture(&self) -> Option<String> {
-        self.graphics_picture.clone()
+        match self.clone() {
+            IdentityUpdate::Picture(data) => Some(data),
+            _ => None
+        }
     }
 
     pub fn graphics_banner(&self) -> Option<String> {
-        self.graphics_banner.clone()
+        match self.clone() {
+            IdentityUpdate::Banner(data) => Some(data),
+            _ => None
+        }
+    }
+
+    pub fn graphics_picture_path(&self) -> Option<std::path::PathBuf> {
+        match self.clone() {
+            IdentityUpdate::PicturePath(path) => Some(path),
+            _ => None
+        }
+    }
+
+    pub fn graphics_banner_path(&self) -> Option<std::path::PathBuf> {
+        match self.clone() {
+            IdentityUpdate::BannerPath(path) => Some(path),
+            _ => None
+        }
     }
 
     pub fn status_message(&self) -> Option<Option<String>> {
-        self.status_message.clone()
+        match self.clone() {
+            IdentityUpdate::StatusMessage(status) => Some(status),
+            _ => None
+        }
     }
 }
 
@@ -481,8 +501,7 @@ impl IdentityUpdate {
 pub mod ffi {
     use crate::crypto::DID;
     use crate::multipass::identity::{
-        Badge, FFIVec_Badge, FFIVec_Role, Graphics, Identifier,
-        Identity, IdentityUpdate, Role,
+        Badge, FFIVec_Badge, FFIVec_Role, Graphics, Identifier, Identity, IdentityUpdate, Role,
     };
     use std::ffi::{CStr, CString};
     use std::os::raw::{c_char, c_void};

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -394,28 +394,34 @@ pub enum IdentityUpdate {
 }
 
 impl IdentityUpdate {
+    /// Set new username
     pub fn set_username(username: String) -> IdentityUpdate {
         IdentityUpdate::Username(username)
     }
 
+    /// Set profile picture
     pub fn set_graphics_picture(graphics: String) -> IdentityUpdate {
         IdentityUpdate::Picture(graphics)
     }
 
+    /// Set profile banner
     pub fn set_graphics_banner(graphics: String) -> IdentityUpdate {
         IdentityUpdate::Banner(graphics)
     }
 
+    /// Set status message
     pub fn set_status_message(status_message: Option<String>) -> IdentityUpdate {
         IdentityUpdate::StatusMessage(status_message)
     }
 }
 
 impl IdentityUpdate {
+    /// Set profile picture from a file
     pub fn set_graphics_picture_path(path: std::path::PathBuf) -> IdentityUpdate {
         IdentityUpdate::PicturePath(path)
     }
 
+    /// Set profile banner from a file
     pub fn set_graphics_banner_path(path: std::path::PathBuf) -> IdentityUpdate {
         IdentityUpdate::BannerPath(path)
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Convert IdentityUpdate back to an enum
- Add the ability to add a picture or banner from a file (See comments)
- Removes wasm bindgen attr on `IdentityUpdate`

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Adding an image from a file does not validate the image itself at this time. Its suggested that its validated before pushing the image forward. Furthermore, this does not encode the image in base64, which will be done in separate PR

Related to #124 for removal of wasm exports. 