### PR TITLE
add: Implemented a discovery service

### DIFF
--- a/extensions/warp-mp-ipfs/src/config.rs
+++ b/extensions/warp-mp-ipfs/src/config.rs
@@ -176,6 +176,7 @@ pub struct IpfsSetting {
     pub swarm: Swarm,
     pub bootstrap: bool,
     pub portmapping: bool,
+    pub agent_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -226,6 +226,7 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
             identify_configuration: Some(IdentifyConfiguration {
                 cache: 100,
                 push_update: true,
+                agent_version: "satellite/warp/0.1".into(),
                 ..Default::default()
             }),
             kad_configuration: Some({

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -223,11 +223,17 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
             relay: config.ipfs_setting.relay_client.enable,
             relay_server: config.ipfs_setting.relay_server.enable,
             keep_alive: true,
-            identify_configuration: Some(IdentifyConfiguration {
-                cache: 100,
-                push_update: true,
-                protocol_version: "/satellite/warp/0.1".into(),
-                ..Default::default()
+            identify_configuration: Some({
+                let mut idconfig = IdentifyConfiguration {
+                    cache: 100,
+                    push_update: true,
+                    protocol_version: "/satellite/warp/0.1".into(),
+                    ..Default::default()
+                };
+                if let Some(agent) = config.ipfs_setting.agent_version.as_ref() {
+                    idconfig.agent_version = agent.clone();
+                }
+                idconfig
             }),
             kad_configuration: Some({
                 let mut conf = ipfs::libp2p::kad::KademliaConfig::default();

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -226,7 +226,7 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
             identify_configuration: Some(IdentifyConfiguration {
                 cache: 100,
                 push_update: true,
-                protocol_version: "satellite/warp/0.1".into(),
+                protocol_version: "/satellite/warp/0.1".into(),
                 ..Default::default()
             }),
             kad_configuration: Some({

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -226,7 +226,7 @@ impl<T: IpfsTypes> IpfsIdentity<T> {
             identify_configuration: Some(IdentifyConfiguration {
                 cache: 100,
                 push_update: true,
-                agent_version: "satellite/warp/0.1".into(),
+                protocol_version: "satellite/warp/0.1".into(),
                 ..Default::default()
             }),
             kad_configuration: Some({

--- a/extensions/warp-mp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-mp-ipfs/src/store/discovery.rs
@@ -38,7 +38,7 @@ impl Discovery {
 
     /// Start discovery task
     /// Note: This starting will only work across a provided namespace via Discovery::Provider
-    pub async fn start<T: IpfsTypes>(&self, ipfs: Ipfs<T>) -> Result<(), Error> {
+    pub async fn start<T: IpfsTypes>(&self, ipfs: &Ipfs<T>) -> Result<(), Error> {
         if let DiscoveryConfig::Provider(namespace) = &self.config {
             let namespace = namespace.clone().unwrap_or_else(|| "warp-mp-ipfs".into());
             let cid = ipfs
@@ -47,6 +47,7 @@ impl Discovery {
 
             let task = tokio::spawn({
                 let discovery = self.clone();
+                let ipfs = ipfs.clone();
                 async move {
                     let mut cached = HashSet::new();
 

--- a/extensions/warp-mp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-mp-ipfs/src/store/discovery.rs
@@ -131,7 +131,7 @@ impl Discovery {
     }
 
     pub async fn get(&self, did: &DID) -> Option<DiscoveryEntry> {
-        if !self.contains(did.clone()).await {
+        if !self.contains(did).await {
             return None;
         }
 

--- a/extensions/warp-mp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-mp-ipfs/src/store/discovery.rs
@@ -68,7 +68,7 @@ impl Discovery {
                                     && cached.insert(peer_id)
                                 {
                                     let entry = DiscoveryEntry::new(
-                                        ipfs.clone(),
+                                        &ipfs,
                                         peer_id,
                                         None,
                                         discovery.config.clone(),
@@ -103,7 +103,7 @@ impl Discovery {
 
     pub async fn insert<P: Into<PeerType>, T: IpfsTypes>(
         &self,
-        ipfs: Ipfs<T>,
+        ipfs: &Ipfs<T>,
         peer_type: P,
     ) -> Result<(), Error> {
         let (peer_id, did_key) = match &peer_type.into() {
@@ -199,7 +199,7 @@ impl Eq for DiscoveryEntry {}
 
 impl DiscoveryEntry {
     pub async fn new<T: IpfsTypes>(
-        ipfs: Ipfs<T>,
+        ipfs: &Ipfs<T>,
         peer_id: PeerId,
         did: Option<DID>,
         config: DiscoveryConfig,
@@ -215,6 +215,7 @@ impl DiscoveryEntry {
 
         let task = tokio::spawn({
             let entry = entry.clone();
+            let ipfs = ipfs.clone();
             async move {
                 let mut timer = tokio::time::interval(Duration::from_secs(30));
                 loop {
@@ -288,7 +289,7 @@ impl DiscoveryEntry {
                                 }
                             }
                             config::Discovery::None => {
-                                //TODO: Dial out through common relays 
+                                //TODO: Dial out through common relays
                                 // Note: This will work if both peers shares the relays used.
                             }
                         }

--- a/extensions/warp-mp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-mp-ipfs/src/store/discovery.rs
@@ -1,0 +1,243 @@
+use std::{collections::HashSet, hash::Hash, sync::Arc, time::Duration};
+
+use futures::{stream::FuturesUnordered, Stream, StreamExt};
+use rust_ipfs::{Ipfs, IpfsTypes, PeerId};
+use tokio::{sync::RwLock, task::JoinHandle};
+use tracing::log;
+use warp::{crypto::DID, error::Error};
+
+use crate::config::Discovery as DiscoveryConfig;
+
+use super::{did_to_libp2p_pub, libp2p_pub_to_did, PeerConnectionType, PeerType};
+
+#[derive(Clone)]
+pub struct Discovery {
+    config: DiscoveryConfig,
+    entries: Arc<RwLock<HashSet<DiscoveryEntry>>>,
+    task: Arc<RwLock<Option<JoinHandle<()>>>>,
+}
+
+impl Discovery {
+    pub fn new(config: DiscoveryConfig) -> Self {
+        Self {
+            config,
+            entries: Arc::default(),
+            task: Arc::default(),
+        }
+    }
+
+    /// Start discovery task
+    /// Note: This starting will only work across a provided namespace via Discovery::Provider
+    pub async fn start<T: IpfsTypes>(&self, ipfs: Ipfs<T>) -> Result<(), Error> {
+        if let DiscoveryConfig::Provider(namespace) = &self.config {
+            let namespace = namespace.clone().unwrap_or_else(|| "warp-mp-ipfs".into());
+            let cid = ipfs
+                .put_dag(libipld::ipld!(format!("discovery:{namespace}")))
+                .await?;
+
+            let task = tokio::spawn({
+                let discovery = self.clone();
+                async move {
+                    let mut cached = HashSet::new();
+
+                    if let Err(e) = ipfs.provide(cid).await {
+                        //Maybe panic?
+                        log::error!("Error providing key: {e}");
+                        return;
+                    }
+
+                    loop {
+                        if let Ok(mut stream) = ipfs.get_providers(cid).await {
+                            while let Some(peer_id) = stream.next().await {
+                                if cached.insert(peer_id) {
+                                    let entry =
+                                        DiscoveryEntry::new(ipfs.clone(), peer_id, None).await;
+                                    discovery.entries.write().await.insert(entry);
+                                }
+                            }
+                        }
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                }
+            });
+
+            *self.task.write().await = Some(task);
+        }
+        Ok(())
+    }
+
+    pub fn discovery_config(&self) -> DiscoveryConfig {
+        self.config.clone()
+    }
+
+    pub async fn get_with_peer_id(&self, peer_id: PeerId) -> Option<DiscoveryEntry> {
+        self.entries
+            .read()
+            .await
+            .iter()
+            .find(|entry| entry.peer_id == peer_id)
+            .cloned()
+    }
+
+    pub async fn insert<P: Into<PeerType>, T: IpfsTypes>(&self, ipfs: Ipfs<T>, peer_type: P)-> Result<(), Error> {
+        let (peer_id, did_key) = match &peer_type.into() {
+            PeerType::PeerId(peer_id) => (*peer_id, None),
+            PeerType::DID(did_key) => {
+                let peer_id = did_to_libp2p_pub(did_key).map(|pk| pk.to_peer_id())?;
+                (peer_id, Some(did_key.clone()))
+            }
+        };
+
+        if self.contains(peer_id).await {
+            return Ok(())
+        }
+
+        let entry = DiscoveryEntry::new(ipfs, peer_id, did_key).await;
+        self.entries.write().await.insert(entry);
+        Ok(())
+    }
+
+    pub async fn get(&self, did: &DID) -> Option<DiscoveryEntry> {
+        if !self.contains(did.clone()).await {
+            return None;
+        }
+
+        let Ok(peer_id) = did_to_libp2p_pub(did).map(|pk| pk.to_peer_id()) else {
+            return None
+        };
+
+        self.entries
+            .read()
+            .await
+            .iter()
+            .find(|entry| entry.peer_id == peer_id)
+            .cloned()
+    }
+
+    pub async fn contains<P: Into<PeerType>>(&self, peer_type: P) -> bool {
+        match &peer_type.into() {
+            PeerType::DID(did) => {
+                self.did_iter()
+                    .await
+                    .any(|did_key| async move { did_key.eq(did) })
+                    .await
+            }
+            PeerType::PeerId(peer_id) => self
+                .list()
+                .await
+                .iter()
+                .any(|entry| entry.peer_id().eq(peer_id)),
+        }
+    }
+
+    pub async fn list(&self) -> HashSet<DiscoveryEntry> {
+        self.entries.read().await.clone()
+    }
+
+    pub async fn did_iter(&self) -> impl Stream<Item = DID> {
+        FuturesUnordered::from_iter(
+            self.list()
+                .await
+                .iter()
+                .cloned()
+                .map(|entry| async move { entry.did_key().await }),
+        )
+        .filter_map(|result| async { result.ok() })
+    }
+}
+
+#[derive(Clone)]
+pub struct DiscoveryEntry {
+    did: Arc<RwLock<Option<DID>>>,
+    peer_id: PeerId,
+    connection_type: Arc<RwLock<PeerConnectionType>>,
+    task: Arc<RwLock<Option<JoinHandle<()>>>>,
+}
+
+impl PartialEq for DiscoveryEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.peer_id.eq(&other.peer_id)
+    }
+}
+
+impl Hash for DiscoveryEntry {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.peer_id.hash(state);
+    }
+}
+
+impl Eq for DiscoveryEntry {}
+
+impl DiscoveryEntry {
+    pub async fn new<T: IpfsTypes>(ipfs: Ipfs<T>, peer_id: PeerId, did: Option<DID>) -> Self {
+        let entry = Self {
+            did: Arc::new(RwLock::new(did.clone())),
+            peer_id,
+            connection_type: Arc::new(RwLock::new(PeerConnectionType::NotConnected)),
+            task: Arc::default(),
+        };
+
+        let task = tokio::spawn({
+            let entry = entry.clone();
+            let mut did = did;
+            async move {
+                loop {
+                    if did.is_none() {
+                        let info = loop {
+                            //TODO: Possibly dial out over available relays in attempt to establish a connection if we are not able to find them over DHT
+                            if let Ok(info) = ipfs.identity(Some(entry.peer_id)).await {
+                                break info;
+                            }
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        };
+                        if info.peer_id != entry.peer_id
+                            || info.peer_id != info.public_key.to_peer_id()
+                        {
+                            // Possibly panic in this task?
+                            break;
+                        }
+                        let Ok(did_key) = libp2p_pub_to_did(&info.public_key) else {
+                            // If it fails to convert then the public key may not be a ed25519 or may be corrupted in some way
+                            break;
+                        };
+                        *entry.did.write().await = Some(did_key.clone());
+                        did = Some(did_key);
+                    }
+
+                    let Ok(connection_type) = ipfs.connected().await.map(|list| {
+                        if list.iter().any(|peer| *peer == entry.peer_id) {
+                            PeerConnectionType::Connected
+                        } else {
+                            PeerConnectionType::NotConnected
+                        }
+                    }) else {
+                        // If it fails, then its likely that ipfs had a fatal error
+                        // Maybe panic?
+                        break;
+                    };
+
+                    *entry.connection_type.write().await = connection_type;
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+            }
+        });
+        *entry.task.write().await = Some(task);
+        entry
+    }
+
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+
+    pub async fn valid(&self) -> bool {
+        self.did.read().await.is_some()
+    }
+
+    pub async fn did_key(&self) -> Result<DID, Error> {
+        self.did.read().await.clone().ok_or(Error::PublicKeyInvalid)
+    }
+
+    pub async fn connection_type(&self) -> PeerConnectionType {
+        *self.connection_type.read().await
+    }
+}

--- a/extensions/warp-mp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-mp-ipfs/src/store/discovery.rs
@@ -123,11 +123,9 @@ impl Discovery {
 
         let entry = DiscoveryEntry::new(ipfs, peer_id, did_key, self.config.clone()).await;
         entry.enable_discovery();
-        if !self.entries.write().await.insert(entry.clone()) {
+        let prev = self.entries.write().await.replace(entry);
+        if let Some(entry) = prev {
             entry.cancel().await;
-            return Err(Error::OtherWithContext(
-                "Discovery task already exist".into(),
-            ));
         }
         Ok(())
     }

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -417,11 +417,7 @@ impl<T: IpfsTypes> IdentityStore<T> {
         }
 
         if !self.discovery.contains(identity.did_key()).await {
-            if let Err(e) = self
-                .discovery
-                .insert(self.ipfs.clone(), identity.did_key())
-                .await
-            {
+            if let Err(e) = self.discovery.insert(&self.ipfs, identity.did_key()).await {
                 log::warn!("Error inserting into discovery service: {e}");
             }
         }
@@ -661,10 +657,8 @@ impl<T: IpfsTypes> IdentityStore<T> {
                     return self.own_identity().await.map(|i| vec![i]);
                 }
 
-                if !self.discovery.contains(pubkey.clone()).await {
-                    self.discovery
-                        .insert(self.ipfs.clone(), pubkey.clone())
-                        .await?;
+                if !self.discovery.contains(pubkey).await {
+                    self.discovery.insert(&self.ipfs, pubkey).await?;
                 }
 
                 self.cache()

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -256,7 +256,7 @@ impl<T: IpfsTypes> IdentityStore<T> {
             }
         });
 
-        if let Err(e) = store.discovery.start(store.ipfs.clone()).await {
+        if let Err(e) = store.discovery.start(&store.ipfs).await {
             warn!("Error starting discovery service: {e}. Will not be able to discover peers over namespace");
         }
 

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -3,6 +3,7 @@ pub mod friends;
 pub mod identity;
 pub mod phonebook;
 pub mod queue;
+pub mod discovery;
 
 use std::time::Duration;
 

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -1,9 +1,9 @@
+pub mod discovery;
 pub mod document;
 pub mod friends;
 pub mod identity;
 pub mod phonebook;
 pub mod queue;
-pub mod discovery;
 
 use std::time::Duration;
 
@@ -143,9 +143,10 @@ impl From<PeerId> for PeerType {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PeerConnectionType {
     Connected,
+    #[default]
     NotConnected,
 }
 

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -131,6 +131,12 @@ pub enum PeerType {
     DID(DID),
 }
 
+impl From<&DID> for PeerType {
+    fn from(did: &DID) -> Self {
+        PeerType::DID(did.clone())
+    }
+}
+
 impl From<DID> for PeerType {
     fn from(did: DID) -> Self {
         PeerType::DID(did)
@@ -140,6 +146,12 @@ impl From<DID> for PeerType {
 impl From<PeerId> for PeerType {
     fn from(peer_id: PeerId) -> Self {
         PeerType::PeerId(peer_id)
+    }
+}
+
+impl From<&PeerId> for PeerType {
+    fn from(peer_id: &PeerId) -> Self {
+        PeerType::PeerId(*peer_id)
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Adds a discovery service to be used directly for discovering peers and obtaining their public key

**Which issue(s) this PR fixes** 🔨
Resolves #160 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Previous implementation was reduce to a single function with no tracking of peers who been discovered, either via a provided namespace or directly over DHT. This implementation will hold a task to get the providers of the namespace and attempt to fetch their public key in a separate task that can be later used to sign, encrypt, and validate any payloads sent over pubsub or check the possible connection status of a discovered peer.