### PR TITLE
add: Implemented Steams for Cipher

### DIFF
--- a/warp/Cargo.toml
+++ b/warp/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib", "staticlib"]
 # Async and futures crates
 futures = { version = "0.3" }
 async-trait = { version = "0.1" }
+async-stream = "0.3"
 
 # Crypto crates
 x25519-dalek = { version = "1" }

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -323,7 +323,7 @@ impl Cipher {
         });
 
         let stream = async_stream::stream! {
-            let mut buffer = [0u8; 1024];
+            let mut buffer = [0u8; 512];
             let cipher = Aes256Gcm::new(key.as_slice().into());
             let mut stream = EncryptorBE32::from_aead(cipher, nonce.as_slice().into());
 
@@ -331,7 +331,7 @@ impl Cipher {
 
             loop {
                 match reader.read(&mut buffer).await {
-                    Ok(1024) => match stream.encrypt_next(buffer.as_slice()).map_err(|_| Error::EncryptionStreamError) {
+                    Ok(512) => match stream.encrypt_next(buffer.as_slice()).map_err(|_| Error::EncryptionStreamError) {
                         Ok(data) => yield Ok(data),
                         Err(e) => {
                             yield Err(e);
@@ -376,7 +376,7 @@ impl Cipher {
 
             loop {
                 match reader.read(&mut buffer).await {
-                    Ok(1040) => {
+                    Ok(528) => {
                         match stream.decrypt_next(buffer.as_slice()).map_err(|_| Error::DecryptionStreamError) {
                             Ok(data) => yield Ok(data),
                             Err(e) => {

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -162,7 +162,7 @@ impl Cipher {
     pub async fn self_decrypt_async_stream<'a>(
         mut stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
     ) -> Result<impl Stream<Item = Result<Vec<u8>>> + Send + 'a> {
-        let mut key = vec![0u8; 34];
+        let mut key = [0u8; 34];
         {
             let mut reader = stream.by_ref().into_async_read();
             reader.read_exact(&mut key).await?;
@@ -225,7 +225,7 @@ impl Cipher {
     ) -> Result<impl Stream<Item = Result<Vec<u8>>> + Send + 'a> {
         let mut reader = stream.into_async_read();
 
-        let mut nonce = vec![0u8; 7];
+        let mut nonce = [0u8; 7];
 
         reader.read_exact(&mut nonce).await?;
 
@@ -323,7 +323,7 @@ impl Cipher {
         &self,
         mut reader: R,
     ) -> Result<impl Stream<Item = Result<Vec<u8>>> + Send + 'a> {
-        let mut nonce = vec![0u8; 7];
+        let mut nonce = [0u8; 7];
 
         reader.read_exact(&mut nonce).await?;
 
@@ -394,7 +394,7 @@ impl Cipher {
         reader: &mut impl Read,
         writer: &mut impl Write,
     ) -> Result<()> {
-        let mut key = vec![0u8; 34];
+        let mut key = [0u8; 34];
         reader.read_exact(&mut key)?;
         let cipher = Cipher::from(key);
         cipher.decrypt_stream(cipher_type, reader, writer)?;
@@ -458,7 +458,7 @@ impl Cipher {
         writer: &mut impl Write,
     ) -> Result<()> {
         let mut nonce = match cipher_type {
-            CipherType::Aes256Gcm => vec![0u8; 7],
+            CipherType::Aes256Gcm => [0u8; 7],
         };
 
         reader.read_exact(&mut nonce)?;

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -6,7 +6,7 @@ use std::io::{ErrorKind, Read, Write};
 use crate::crypto::hash::sha256_hash;
 use futures::{
     stream::{self, BoxStream},
-    AsyncReadExt, Stream, StreamExt, TryStreamExt,
+    AsyncRead, AsyncReadExt, Stream, StreamExt, TryStreamExt,
 };
 use zeroize::Zeroize;
 
@@ -162,6 +162,7 @@ impl Cipher {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl Cipher {
+    /// Encrypts and embeds private key into writer stream
     pub fn self_encrypt_stream(
         cipher_type: CipherType,
         reader: &mut impl Read,
@@ -173,6 +174,7 @@ impl Cipher {
         Ok(())
     }
 
+    /// Decrypts with embedded private key into writer stream
     pub fn self_decrypt_stream(
         cipher_type: CipherType,
         reader: &mut impl Read,
@@ -185,6 +187,7 @@ impl Cipher {
         Ok(())
     }
 
+    /// Encrypts and embeds private key into async stream
     pub async fn self_encrypt_async_stream<'a>(
         stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
     ) -> Result<BoxStream<'a, Result<Vec<u8>>>> {
@@ -197,6 +200,7 @@ impl Cipher {
         Ok(stream.boxed())
     }
 
+    /// Decrypts with embedded private key into async stream
     pub async fn self_decrypt_async_stream<'a>(
         mut stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
     ) -> Result<BoxStream<'a, Result<Vec<u8>>>> {
@@ -210,6 +214,7 @@ impl Cipher {
         cipher.decrypt_async_stream(stream).await
     }
 
+    /// Encrypts data from std reader into std writer
     pub fn encrypt_stream(
         &self,
         cipher_type: CipherType,
@@ -258,6 +263,7 @@ impl Cipher {
         Ok(())
     }
 
+    /// Decrypts data from std reader into std writer
     pub fn decrypt_stream(
         &self,
         cipher_type: CipherType,
@@ -309,6 +315,7 @@ impl Cipher {
         Ok(())
     }
 
+    /// Encrypts data from async stream into another async stream
     pub async fn encrypt_async_stream<'a>(
         &self,
         stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
@@ -354,6 +361,7 @@ impl Cipher {
         Ok(stream.boxed())
     }
 
+    /// Decrypt data from async stream into another async stream
     pub async fn decrypt_async_stream<'a>(
         &self,
         stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
@@ -410,6 +418,7 @@ impl Cipher {
         Ok(stream.boxed())
     }
 
+    /// Encrypts data from async reader into async stream
     pub async fn encrypt_async_read_to_stream<'a, R: AsyncRead + Unpin + Send + 'a>(
         &self,
         mut reader: R,
@@ -452,6 +461,7 @@ impl Cipher {
         Ok(stream.boxed())
     }
 
+    /// Decrypts data from async read into async stream
     pub async fn decrypt_async_read_to_stream<'a, R: AsyncRead + Unpin + Send + 'a>(
         &self,
         mut reader: R,

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -510,7 +510,7 @@ impl Cipher {
             }
         };
 
-        Ok(stream.boxed())
+        Ok(stream)
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Implements functions that uses futures Stream for input and output
- Implements functions that uses futures AsyncRead for input and Stream for output

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- So far there have not been any performance hits when using the async functions for encrypting and decrypting, but should keep an eye on for any blocking of the thread from any task using these functions since encrypting and decrypting can be cpu intensive, however, there is no additional cost.
- If tokio is used, ReaderStream may not be compatible be compatible (requires a bit more investigating). Work around would be to use the compat wrapper for `File` from tokio to make it support futures `AsyncRead`.