### PR TITLE
refactor: Transmit data directly rather than using encoding

### DIFF
--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -380,6 +380,8 @@ impl IdentityStore {
 
         let bytes = Cipher::self_encrypt(&payload_bytes)?;
 
+        log::trace!("Transmitting size: {}", bytes.len());
+        
         self.ipfs
             .pubsub_publish(IDENTITY_BROADCAST.into(), bytes)
             .await?;

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -32,8 +32,9 @@ use tracing::{
     warn,
 };
 
+use warp::multipass::identity::Platform;
 use warp::{
-    crypto::{did_key::Generate, DIDKey, Ed25519KeyPair, Fingerprint, DID},
+    crypto::{cipher::Cipher, did_key::Generate, DIDKey, Ed25519KeyPair, Fingerprint, DID},
     error::Error,
     multipass::{
         identity::{Identity, IdentityStatus, SHORT_ID_SIZE},
@@ -42,7 +43,6 @@ use warp::{
     sync::Arc,
     tesseract::Tesseract,
 };
-use warp::{multipass::identity::Platform, sata::Sata};
 
 use super::{
     connected_to_peer,
@@ -340,8 +340,6 @@ impl IdentityStore {
             return Ok(());
         }
 
-        let data = Sata::default();
-
         let root = self.get_root_document().await?;
 
         let identity = self
@@ -371,16 +369,16 @@ impl IdentityStore {
             banner,
             platform,
             status,
+            signature: None,
         };
 
-        let res = data.encode(
-            libipld::IpldCodec::DagJson,
-            warp::sata::Kind::Static,
-            payload,
-        )?;
+        let kp_did = self.get_keypair_did()?;
 
-        //TODO: Maybe use bincode instead
-        let bytes = serde_json::to_vec(&res)?;
+        let payload = payload.sign(&kp_did)?;
+
+        let payload_bytes = serde_json::to_vec(&payload)?;
+
+        let bytes = Cipher::self_encrypt(&payload_bytes)?;
 
         self.ipfs
             .pubsub_publish(IDENTITY_BROADCAST.into(), bytes)
@@ -390,11 +388,11 @@ impl IdentityStore {
     }
 
     async fn process_message(&mut self, message: GossipsubMessage) -> anyhow::Result<()> {
-        let data = serde_json::from_slice::<Sata>(&message.data)?;
+        let bytes = Cipher::self_decrypt(&message.data)?;
 
-        let raw_object = data.decode::<IdentityPayload>()?;
+        let raw_object = serde_json::from_slice::<IdentityPayload>(&bytes)?;
 
-        let payload = raw_object.payload;
+        let payload = raw_object.payload.clone();
 
         //TODO: Validate public key against peer that sent it
         let _pk = did_to_libp2p_pub(&raw_object.did)?;
@@ -407,6 +405,9 @@ impl IdentityStore {
             raw_object.did == identity.did_key(),
             "Payload doesnt match identity"
         );
+
+        // Validate after making sure the identity did matches the payload
+        raw_object.verify()?;
 
         if let Some(own_id) = self.identity.read().await.clone() {
             anyhow::ensure!(own_id != identity, "Cannot accept own identity");
@@ -541,8 +542,7 @@ impl IdentityStore {
                 Platform::Desktop
             } else if cfg!(any(target_os = "android", target_os = "ios")) {
                 Platform::Mobile
-            }
-            else { 
+            } else {
                 Platform::Unknown
             }
         } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Switches out to using the payload document directly and transmitting to peers

**Which issue(s) this PR fixes** 🔨
Relates to #125 (though indirectly since this is more on transmitting than storing) 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
This is a breaking change in terms of broadcasting, but would reduce the overall size of the payload in comparison to before 