### PR TITLE
refactor: Clear images from identity

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -600,7 +600,7 @@ async fn main() -> anyhow::Result<()> {
                             }
 
                             let status = status.join(" ").to_string();
-                            if let Err(e) = account.update_identity(IdentityUpdate::set_status_message(Some(status))).await {
+                            if let Err(e) = account.update_identity(IdentityUpdate::StatusMessage(Some(status))).await {
                                 writeln!(stdout, "Error updating status: {e}")?;
                                 continue
                             }
@@ -615,7 +615,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
 
-                            if let Err(e) = account.update_identity(IdentityUpdate::set_username(username.to_string())).await {
+                            if let Err(e) = account.update_identity(IdentityUpdate::Username(username.to_string())).await {
                                 writeln!(stdout, "Error updating username: {e}")?;
                                 continue;
                             }
@@ -631,7 +631,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
 
-                            if let Err(e) = account.update_identity(IdentityUpdate::set_graphics_picture(picture.to_string())).await {
+                            if let Err(e) = account.update_identity(IdentityUpdate::Picture(picture.to_string())).await {
                                 writeln!(stdout, "Error updating picture: {e}")?;
                                 continue;
                             }
@@ -647,7 +647,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
 
-                            if let Err(e) = account.update_identity(IdentityUpdate::set_graphics_banner(banner.to_string())).await {
+                            if let Err(e) = account.update_identity(IdentityUpdate::Banner(banner.to_string())).await {
                                 writeln!(stdout, "Error updating banner: {e}")?;
                                 continue;
                             }

--- a/extensions/warp-mp-ipfs/examples/ipfs-identity.rs
+++ b/extensions/warp-mp-ipfs/examples/ipfs-identity.rs
@@ -4,7 +4,7 @@ use warp::tesseract::Tesseract;
 use warp_mp_ipfs::ipfs_identity_temporary;
 
 async fn update_name(account: &mut impl MultiPass, name: &str) -> anyhow::Result<()> {
-    account.update_identity(IdentityUpdate::set_username(name.to_string())).await?;
+    account.update_identity(IdentityUpdate::Username(name.to_string())).await?;
     let ident = account.get_own_identity().await?;
     println!();
     println!("Updated Identity: {}", serde_json::to_string(&ident)?);
@@ -12,7 +12,7 @@ async fn update_name(account: &mut impl MultiPass, name: &str) -> anyhow::Result
 }
 
 async fn update_status(account: &mut impl MultiPass, status: &str) -> anyhow::Result<()> {
-    account.update_identity(IdentityUpdate::set_status_message(Some(status.to_string()))).await?;
+    account.update_identity(IdentityUpdate::StatusMessage(Some(status.to_string()))).await?;
     let ident = account.get_own_identity().await?;
     println!();
     println!("Updated Identity: {}", serde_json::to_string(&ident)?);

--- a/extensions/warp-mp-ipfs/src/config.rs
+++ b/extensions/warp-mp-ipfs/src/config.rs
@@ -16,7 +16,7 @@ pub enum Bootstrap {
     None,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Discovery {
     /// Uses DHT PROVIDER to find and connect to peers using the same context
@@ -24,13 +24,8 @@ pub enum Discovery {
     /// Dials out to peers directly. Using this will only work with the DID til that connection is made
     Direct,
     /// Disables Discovery over DHT or Directly (which relays on direct connection via multiaddr)
+    #[default]
     None,
-}
-
-impl Default for Discovery {
-    fn default() -> Self {
-        Discovery::None
-    }
 }
 
 impl Bootstrap {

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -744,6 +744,14 @@ impl MultiPass for IpfsIdentity {
                 root_document.picture = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
                 store.set_root_document(root_document).await?;
             }
+            IdentityUpdate::ClearPicture => {
+                let mut root_document = store.get_root_document().await?;
+                let document = root_document.picture.take();
+                if let Some(DocumentType::UnixFS(cid, _)) = document {
+                    store.delete_photo(cid).await?;
+                }
+                store.set_root_document(root_document).await?;
+            }
             IdentityUpdate::Banner(data) => {
                 let len = data.len();
                 if len == 0 || len > 2 * 1024 * 1024 {
@@ -842,6 +850,14 @@ impl MultiPass for IpfsIdentity {
                 root_document.banner = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
                 store.set_root_document(root_document).await?;
             }
+            IdentityUpdate::ClearBanner => {
+                let mut root_document = store.get_root_document().await?;
+                let document = root_document.banner.take();
+                if let Some(DocumentType::UnixFS(cid, _)) = document {
+                    store.delete_photo(cid).await?;
+                }
+                store.set_root_document(root_document).await?;
+            }
             IdentityUpdate::StatusMessage(status) => {
                 if let Some(status) = status.clone() {
                     let len = status.chars().count();
@@ -856,6 +872,9 @@ impl MultiPass for IpfsIdentity {
                 }
                 identity.set_status_message(status);
                 store.identity_update(identity.clone()).await?;
+            }
+            IdentityUpdate::ClearStatusMessage => {
+                
             }
         };
 

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -748,7 +748,7 @@ impl MultiPass for IpfsIdentity {
                 let mut root_document = store.get_root_document().await?;
                 let document = root_document.picture.take();
                 if let Some(DocumentType::UnixFS(cid, _)) = document {
-                    store.delete_photo(cid).await?;
+                    old_cid = Some(cid);
                 }
                 store.set_root_document(root_document).await?;
             }
@@ -854,7 +854,7 @@ impl MultiPass for IpfsIdentity {
                 let mut root_document = store.get_root_document().await?;
                 let document = root_document.banner.take();
                 if let Some(DocumentType::UnixFS(cid, _)) = document {
-                    store.delete_photo(cid).await?;
+                    old_cid = Some(cid);
                 }
                 store.set_root_document(root_document).await?;
             }
@@ -874,7 +874,8 @@ impl MultiPass for IpfsIdentity {
                 store.identity_update(identity.clone()).await?;
             }
             IdentityUpdate::ClearStatusMessage => {
-                
+                identity.set_status_message(None);
+                store.identity_update(identity.clone()).await?;
             }
         };
 

--- a/extensions/warp-mp-ipfs/tests/accounts.rs
+++ b/extensions/warp-mp-ipfs/tests/accounts.rs
@@ -146,7 +146,7 @@ mod test {
         let old_identity = account.get_own_identity().await?;
 
         account
-            .update_identity(IdentityUpdate::set_username("JohnDoe2.0".into()))
+            .update_identity(IdentityUpdate::Username("JohnDoe2.0".into()))
             .await?;
 
         let updated_identity = account.get_own_identity().await?;
@@ -172,7 +172,7 @@ mod test {
         let old_identity = account.get_own_identity().await?;
 
         account
-            .update_identity(IdentityUpdate::set_status_message(Some("Blast off".into())))
+            .update_identity(IdentityUpdate::StatusMessage(Some("Blast off".into())))
             .await?;
 
         let updated_identity = account.get_own_identity().await?;

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -365,87 +365,12 @@ pub enum IdentityUpdate {
     Username(String),
     Picture(String),
     PicturePath(std::path::PathBuf),
+    ClearPicture,
     Banner(String),
     BannerPath(std::path::PathBuf),
+    ClearBanner,
     StatusMessage(Option<String>),
-}
-
-impl IdentityUpdate {
-    /// Set new username
-    pub fn set_username(username: String) -> IdentityUpdate {
-        IdentityUpdate::Username(username)
-    }
-
-    /// Set profile picture
-    pub fn set_graphics_picture(graphics: String) -> IdentityUpdate {
-        IdentityUpdate::Picture(graphics)
-    }
-
-    /// Set profile banner
-    pub fn set_graphics_banner(graphics: String) -> IdentityUpdate {
-        IdentityUpdate::Banner(graphics)
-    }
-
-    /// Set status message
-    pub fn set_status_message(status_message: Option<String>) -> IdentityUpdate {
-        IdentityUpdate::StatusMessage(status_message)
-    }
-}
-
-impl IdentityUpdate {
-    /// Set profile picture from a file
-    pub fn set_graphics_picture_path(path: std::path::PathBuf) -> IdentityUpdate {
-        IdentityUpdate::PicturePath(path)
-    }
-
-    /// Set profile banner from a file
-    pub fn set_graphics_banner_path(path: std::path::PathBuf) -> IdentityUpdate {
-        IdentityUpdate::BannerPath(path)
-    }
-}
-
-impl IdentityUpdate {
-    pub fn username(&self) -> Option<String> {
-        match self.clone() {
-            IdentityUpdate::Username(username) => Some(username),
-            _ => None,
-        }
-    }
-
-    pub fn graphics_picture(&self) -> Option<String> {
-        match self.clone() {
-            IdentityUpdate::Picture(data) => Some(data),
-            _ => None,
-        }
-    }
-
-    pub fn graphics_banner(&self) -> Option<String> {
-        match self.clone() {
-            IdentityUpdate::Banner(data) => Some(data),
-            _ => None,
-        }
-    }
-
-    pub fn graphics_picture_path(&self) -> Option<std::path::PathBuf> {
-        match self.clone() {
-            IdentityUpdate::PicturePath(path) => Some(path),
-            _ => None,
-        }
-    }
-
-    pub fn graphics_banner_path(&self) -> Option<std::path::PathBuf> {
-        match self.clone() {
-            IdentityUpdate::BannerPath(path) => Some(path),
-            _ => None,
-        }
-    }
-
-    pub fn status_message(&self) -> Option<Option<String>> {
-        match self.clone() {
-            IdentityUpdate::StatusMessage(status) => Some(status),
-            _ => None,
-        }
-    }
+    ClearStatusMessage
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -723,7 +648,7 @@ pub mod ffi {
 
         let name = CStr::from_ptr(name).to_string_lossy().to_string();
 
-        Box::into_raw(Box::new(IdentityUpdate::set_username(name))) as *mut IdentityUpdate
+        Box::into_raw(Box::new(IdentityUpdate::Username(name))) as *mut IdentityUpdate
     }
 
     #[allow(clippy::missing_safety_doc)]
@@ -737,7 +662,7 @@ pub mod ffi {
 
         let name = CStr::from_ptr(name).to_string_lossy().to_string();
 
-        Box::into_raw(Box::new(IdentityUpdate::set_graphics_picture(name))) as *mut IdentityUpdate
+        Box::into_raw(Box::new(IdentityUpdate::Picture(name))) as *mut IdentityUpdate
     }
 
     #[allow(clippy::missing_safety_doc)]
@@ -751,7 +676,7 @@ pub mod ffi {
 
         let name = CStr::from_ptr(name).to_string_lossy().to_string();
 
-        Box::into_raw(Box::new(IdentityUpdate::set_graphics_banner(name))) as *mut IdentityUpdate
+        Box::into_raw(Box::new(IdentityUpdate::Banner(name))) as *mut IdentityUpdate
     }
 
     #[allow(clippy::missing_safety_doc)]
@@ -761,9 +686,9 @@ pub mod ffi {
     ) -> *mut IdentityUpdate {
         let update = if !name.is_null() {
             let name = CStr::from_ptr(name).to_string_lossy().to_string();
-            IdentityUpdate::set_status_message(Some(name))
+            IdentityUpdate::StatusMessage(Some(name))
         } else {
-            IdentityUpdate::set_status_message(None)
+            IdentityUpdate::StatusMessage(None)
         };
 
         Box::into_raw(Box::new(update)) as *mut IdentityUpdate
@@ -780,12 +705,12 @@ pub mod ffi {
 
         let update = &*update;
 
-        match update.username() {
-            Some(data) => match CString::new(data) {
+        match update {
+            IdentityUpdate::Username(data) => match CString::new(data.clone()) {
                 Ok(data) => data.into_raw(),
                 Err(_) => std::ptr::null_mut(),
             },
-            None => std::ptr::null_mut(),
+            _ => std::ptr::null_mut(),
         }
     }
 
@@ -800,12 +725,12 @@ pub mod ffi {
 
         let update = &*update;
 
-        match update.graphics_picture() {
-            Some(data) => match CString::new(data) {
+        match update {
+            IdentityUpdate::Picture(data) => match CString::new(data.clone()) {
                 Ok(data) => data.into_raw(),
                 Err(_) => std::ptr::null_mut(),
             },
-            None => std::ptr::null_mut(),
+            _ => std::ptr::null_mut(),
         }
     }
 
@@ -820,12 +745,12 @@ pub mod ffi {
 
         let update = &*update;
 
-        match update.graphics_banner() {
-            Some(data) => match CString::new(data) {
+        match update {
+            IdentityUpdate::Banner(data) => match CString::new(data.clone()) {
                 Ok(data) => data.into_raw(),
                 Err(_) => std::ptr::null_mut(),
             },
-            None => std::ptr::null_mut(),
+            _ => std::ptr::null_mut(),
         }
     }
 
@@ -840,8 +765,8 @@ pub mod ffi {
 
         let update = &*update;
 
-        if let Some(Some(inner)) = update.status_message() {
-            if let Ok(data) = CString::new(inner) {
+        if let IdentityUpdate::StatusMessage(Some(inner)) = update {
+            if let Ok(data) = CString::new(inner.clone()) {
                 return data.into_raw();
             }
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add to enum to allow clearing picture, banner, and status from identity
- Remove functions and use enum directly

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
