### PR TITLE
fix: Save when setting only if file doesnt exist

### DIFF
--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -226,7 +226,9 @@ impl Tesseract {
     /// ```
     pub fn set_file<P: AsRef<Path>>(&self, file: P) {
         *self.file.write() = Some(file.as_ref().to_path_buf());
-        if let Err(_e) = self.to_file(file) {}
+        if !file.as_ref().is_file() {
+            if let Err(_e) = self.to_file(file) {}
+        }
     }
 
     /// Internal file handle


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Prevent file from being overridden when setting path by checking if file doesnt exist for tesseract first

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤

