### PR TITLE
refactor: Use relay first

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -153,6 +153,8 @@ async fn main() -> anyhow::Result<()> {
         own_identity.username(),
         own_identity.short_id()
     );
+    println!("DID: {}", own_identity.did_key());
+    
     let (mut rl, mut stdout) = Readline::new(format!(
         "{}#{} >>> ",
         own_identity.username(),

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -325,7 +325,14 @@ impl IpfsIdentity {
                         for addr in config.ipfs_setting.relay_client.relay_address.clone() {
                             if let Err(e) = ipfs.connect(addr.clone()).await {
                                 error!("Error dialing relay {}: {e}", addr.clone());
+                                continue;
                             }
+
+                            //Give time for identify to be sent/received
+                            //TODO: Remove on next rust-ipfs update
+                            //TODO: Check for relay protocol from address before attempting to use
+                            //      as a precaution
+                            tokio::time::sleep(Duration::from_millis(500)).await;
 
                             match ipfs
                                 .add_listening_address(addr.with(Protocol::P2pCircuit))

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -16,7 +16,7 @@ use store::friends::FriendsStore;
 use store::identity::{IdentityStore, LookupBy};
 use tokio::sync::broadcast;
 use tokio_util::compat::TokioAsyncReadCompatExt;
-use tracing::log::{error, info, trace, warn};
+use tracing::log::{error, info, trace, warn, self};
 use warp::crypto::did_key::Generate;
 use warp::crypto::zeroize::Zeroizing;
 use warp::data::DataType;
@@ -29,7 +29,7 @@ use warp::pocket_dimension::PocketDimension;
 use warp::tesseract::{Tesseract, TesseractEvent};
 use warp::{Extension, SingleHandle};
 
-use ipfs::{Ipfs, IpfsOptions, Keypair, Protocol, StoragePath, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsOptions, Keypair, Multiaddr, Protocol, StoragePath, UninitializedIpfs};
 use warp::crypto::{DIDKey, Ed25519KeyPair, DID};
 use warp::error::Error;
 use warp::multipass::identity::{Identifier, Identity, IdentityUpdate, Relationship};
@@ -297,19 +297,24 @@ impl IpfsIdentity {
                     }
                 }
 
-                let relay_client = {
+                let start_relay_client = || {
                     let ipfs = ipfs.clone();
                     let config = config.clone();
                     async move {
                         info!("Relay client enabled. Loading relays");
+                        let mut relayed = vec![];
+
                         for addr in config.bootstrap.address() {
-                            if let Err(e) = ipfs
+                            match ipfs
                                 .add_listening_address(addr.with(Protocol::P2pCircuit))
                                 .await
                             {
-                                info!("Error listening on relay: {e}");
-                                continue;
-                            }
+                                Ok(addr) => relayed.push(addr),
+                                Err(e) => {
+                                    info!("Error listening on relay: {e}");
+                                    continue;
+                                }
+                            };
                             if config.ipfs_setting.relay_client.single {
                                 break;
                             }
@@ -317,20 +322,41 @@ impl IpfsIdentity {
 
                         //TODO: Replace this with (soon to be implemented) relay functions so we dont have to assume
                         //      anything on this end
-                        for addr in config.ipfs_setting.relay_client.relay_address.iter() {
+                        for addr in config.ipfs_setting.relay_client.relay_address.clone() {
                             if let Err(e) = ipfs.connect(addr.clone()).await {
                                 error!("Error dialing relay {}: {e}", addr.clone());
                             }
 
-                            if let Err(e) = ipfs
-                                .add_listening_address(addr.clone().with(Protocol::P2pCircuit))
+                            match ipfs
+                                .add_listening_address(addr.with(Protocol::P2pCircuit))
                                 .await
                             {
-                                info!("Error listening on relay: {e}");
-                                continue;
-                            }
+                                Ok(addr) => relayed.push(addr),
+                                Err(e) => {
+                                    info!("Error listening on relay: {e}");
+                                    continue;
+                                }
+                            };
                             if config.ipfs_setting.relay_client.single {
                                 break;
+                            }
+                        }
+
+                        relayed
+                    }
+                };
+
+                let stop_relay_client = |relays: Vec<Multiaddr>| {
+                    let ipfs = ipfs.clone();
+                    async move {
+                        info!("Disconnecting from relays");
+                        for addr in relays {
+                            if let Err(e) = ipfs
+                                .remove_listening_address(addr.with(Protocol::P2pCircuit))
+                                .await
+                            {
+                                info!("Error removing relay: {e}");
+                                continue;
                             }
                         }
                     }
@@ -341,15 +367,33 @@ impl IpfsIdentity {
                     config.ipfs_setting.relay_client.enable,
                 ) {
                     (true, true) => {
+                        //Start using relays right away rather than waiting for nat status
+                        let mut addrs = start_relay_client().await;
+                        let mut using_relay = true;
                         while let Some(public) = nat_channel_rx.next().await {
-                            if !public {
-                                relay_client.await;
-                                //Note: Although this breaks the loop now, it may be possible for the nat to change in the future resulting in it being public
-                                break;
+                            match public {
+                                true => {
+                                    if using_relay {
+                                        log::trace!("Disabling relays due to being publicly accessible.");
+                                        let addrs = addrs.drain(..).collect::<Vec<_>>();
+                                        stop_relay_client(addrs).await;
+                                        using_relay = false;
+                                    }
+                                }
+                                false => {
+                                    if !using_relay {
+                                        log::trace!("No longer publicly accessible. Switching to relays");
+                                        addrs = start_relay_client().await;
+                                        using_relay = true;
+                                    }
+                                }
                             }
                         }
                     }
-                    (false, true) => relay_client.await,
+                    (false, true) => {
+                        // We dont need the addresses of the circuit relays
+                        start_relay_client().await;
+                    }
                     (true, false) | (false, false) => {}
                 }
             }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Start with relay first instead of waiting to be notified if node can be publicly access by another peer
- Disable relays when its detected that it can be publicly accessed. 

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
