### PR TITLE
refactor: Internal changes to transmitting identity

### DIFF
--- a/extensions/warp-mp-ipfs/Cargo.toml
+++ b/extensions/warp-mp-ipfs/Cargo.toml
@@ -13,14 +13,14 @@ rust-ipfs.workspace = true
 libipld.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }
 tokio = { workspace = true, features = ["full"] }
-tokio-util = {workspace = true, features = ["full"] }
+tokio-util = { workspace = true, features = ["full"] }
 futures.workspace = true
 async-trait.workspace = true
 async-stream.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-either.workspace = true
+either = { workspace = true, features = ["serde"] }
 bs58 = "0.4"
 
 tracing = "0.1"

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -44,6 +44,8 @@ struct Opt {
     #[clap(long)]
     provide_platform_info: bool,
     #[clap(long)]
+    autoaccept_friend: bool,
+    #[clap(long)]
     wait: Option<u64>,
 }
 
@@ -175,8 +177,11 @@ async fn main() -> anyhow::Result<()> {
                                 .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
                                 .unwrap_or_else(|| did.to_string());
-
-                            writeln!(stdout, "> Pending request from {username}. Do \"request accept {did}\" to accept.")?;
+                            if !opt.autoaccept_friend { 
+                                writeln!(stdout, "> Pending request from {username}. Do \"request accept {did}\" to accept.")?;
+                            } else {
+                                account.accept_request(&did).await?;
+                            }
                         },
                         warp::multipass::MultiPassEventKind::FriendRequestSent { to: did } => {
                             let username = account
@@ -719,8 +724,8 @@ async fn main() -> anyhow::Result<()> {
                                     identity.username(),
                                     identity.did_key().to_string(),
                                     identity.status_message().unwrap_or_default(),
-                                    (!identity.graphics().profile_banner().is_empty()).to_string(),
-                                    (!identity.graphics().profile_picture().is_empty()).to_string(),
+                                    (!identity.profile_banner().is_empty()).to_string(),
+                                    (!identity.profile_picture().is_empty()).to_string(),
                                     platform.to_string(),
                                     format!("{status:?}"),
                                 ]);

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 use warp::crypto::DID;
 use warp::multipass::identity::{Identifier, IdentityStatus, IdentityUpdate};
-use warp::multipass::{MultiPass, UpdateKind};
+use warp::multipass::MultiPass;
 use warp::pocket_dimension::PocketDimension;
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
@@ -155,7 +155,7 @@ async fn main() -> anyhow::Result<()> {
         own_identity.short_id()
     );
     println!("DID: {}", own_identity.did_key());
-    
+
     let (mut rl, mut stdout) = Readline::new(format!(
         "{}#{} >>> ",
         own_identity.username(),
@@ -307,21 +307,14 @@ async fn main() -> anyhow::Result<()> {
 
                             writeln!(stdout, "> {username} blocked you")?;
                         },
-                        warp::multipass::MultiPassEventKind::IdentityUpdate { did, kind } => {
+                        warp::multipass::MultiPassEventKind::IdentityUpdate { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
                                 .ok()
                                 .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
                                 .unwrap_or_else(|| did.to_string());
-
-                            match kind {
-                                UpdateKind::Username { old, new } => writeln!(stdout, "> {old} username been updated to \"{new}\"")?,
-                                UpdateKind::Status { status } => writeln!(stdout, "> {username} changed to {status} ")?,
-                                UpdateKind::Picture => writeln!(stdout, "> {username} updated their profile picture ")?,
-                                UpdateKind::Banner => writeln!(stdout, "> {username} updated their profile banner ")?,
-                                _ => writeln!(stdout, "> {username} has been updated ")?,
-                            };
+                            writeln!(stdout, "> {username} has been updated ")?;
                         }
                     }
                 }

--- a/extensions/warp-mp-ipfs/src/config.rs
+++ b/extensions/warp-mp-ipfs/src/config.rs
@@ -228,7 +228,7 @@ pub struct StoreSetting {
     pub sync: Vec<Multiaddr>,
     /// Interval to push or check node
     pub sync_interval: Duration,
-    /// Use objects directly rather than a cid
+    /// TBD
     pub override_ipld: bool,
     /// Enables sharing platform (Desktop, Mobile, Web) information to another user
     pub share_platform: bool,
@@ -240,6 +240,8 @@ pub struct StoreSetting {
     pub friend_request_response_duration: Option<Duration>,
     /// Options to allow emitting identity events to all or just friends
     pub update_events: UpdateEvents,
+    /// Disable providing images for identities
+    pub disable_images: bool,
 }
 
 impl Default for StoreSetting {
@@ -255,6 +257,7 @@ impl Default for StoreSetting {
             friend_request_response_duration: None,
             emit_online_event: false,
             update_events: Default::default(),
+            disable_images: false,
         }
     }
 }

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -42,7 +42,6 @@ use warp::multipass::{
 
 use crate::config::Bootstrap;
 use crate::store::discovery::Discovery;
-use crate::store::document::DocumentType;
 
 #[derive(Clone)]
 pub struct IpfsIdentity {
@@ -637,7 +636,7 @@ impl MultiPass for IpfsIdentity {
 
     async fn update_identity(&mut self, option: IdentityUpdate) -> Result<(), Error> {
         let mut store = self.identity_store(true).await?;
-        let mut identity = self.get_own_identity().await?;
+        let mut identity = store.own_identity_document().await?;
 
         let mut old_cid = None;
         match option {
@@ -652,7 +651,7 @@ impl MultiPass for IpfsIdentity {
                     });
                 }
 
-                identity.set_username(&username);
+                identity.username = username;
                 store.identity_update(identity.clone()).await?;
             }
             IdentityUpdate::Picture(data) => {
@@ -675,22 +674,20 @@ impl MultiPass for IpfsIdentity {
                     )
                     .await?;
 
-                let mut root_document = store.get_root_document().await?;
-
-                if let Some(DocumentType::UnixFS(picture_cid, _)) = root_document.picture {
+                if let Some(picture_cid) = identity.profile_picture {
                     if picture_cid == cid {
                         return Ok(());
                     }
 
-                    if let Some(DocumentType::UnixFS(banner_cid, _)) = root_document.banner {
+                    if let Some(banner_cid) = identity.profile_banner {
                         if picture_cid != banner_cid {
                             old_cid = Some(picture_cid);
                         }
                     }
                 }
 
-                root_document.picture = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
-                store.set_root_document(root_document).await?;
+                identity.profile_picture = Some(cid);
+                store.identity_update(identity).await?;
             }
             IdentityUpdate::PicturePath(path) => {
                 if !path.is_file() {
@@ -737,29 +734,27 @@ impl MultiPass for IpfsIdentity {
                     .store_photo(stream.boxed(), Some(2 * 1024 * 1024))
                     .await?;
 
-                let mut root_document = store.get_root_document().await?;
-                if let Some(DocumentType::UnixFS(picture_cid, _)) = root_document.picture {
+                if let Some(picture_cid) = identity.profile_picture {
                     if picture_cid == cid {
                         return Ok(());
                     }
 
-                    if let Some(DocumentType::UnixFS(banner_cid, _)) = root_document.banner {
+                    if let Some(banner_cid) = identity.profile_banner {
                         if picture_cid != banner_cid {
                             old_cid = Some(picture_cid);
                         }
                     }
                 }
 
-                root_document.picture = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
-                store.set_root_document(root_document).await?;
+                identity.profile_picture = Some(cid);
+                store.identity_update(identity).await?;
             }
             IdentityUpdate::ClearPicture => {
-                let mut root_document = store.get_root_document().await?;
-                let document = root_document.picture.take();
-                if let Some(DocumentType::UnixFS(cid, _)) = document {
+                let document = identity.profile_picture.take();
+                if let Some(cid) = document {
                     old_cid = Some(cid);
                 }
-                store.set_root_document(root_document).await?;
+                store.identity_update(identity).await?;
             }
             IdentityUpdate::Banner(data) => {
                 let len = data.len();
@@ -782,21 +777,20 @@ impl MultiPass for IpfsIdentity {
                     )
                     .await?;
 
-                let mut root_document = store.get_root_document().await?;
-                if let Some(DocumentType::UnixFS(banner_cid, _)) = root_document.banner {
+                if let Some(banner_cid) = identity.profile_banner {
                     if banner_cid == cid {
                         return Ok(());
                     }
 
-                    if let Some(DocumentType::UnixFS(picture_cid, _)) = root_document.picture {
+                    if let Some(picture_cid) = identity.profile_picture {
                         if picture_cid != banner_cid {
                             old_cid = Some(banner_cid);
                         }
                     }
                 }
 
-                root_document.banner = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
-                store.set_root_document(root_document).await?;
+                identity.profile_banner = Some(cid);
+                store.identity_update(identity).await?;
             }
             IdentityUpdate::BannerPath(path) => {
                 if !path.is_file() {
@@ -843,29 +837,27 @@ impl MultiPass for IpfsIdentity {
                     .store_photo(stream.boxed(), Some(2 * 1024 * 1024))
                     .await?;
 
-                let mut root_document = store.get_root_document().await?;
-                if let Some(DocumentType::UnixFS(banner_cid, _)) = root_document.banner {
+                if let Some(banner_cid) = identity.profile_banner {
                     if banner_cid == cid {
                         return Ok(());
                     }
 
-                    if let Some(DocumentType::UnixFS(picture_cid, _)) = root_document.picture {
+                    if let Some(picture_cid) = identity.profile_picture {
                         if picture_cid != banner_cid {
                             old_cid = Some(banner_cid);
                         }
                     }
                 }
 
-                root_document.banner = Some(DocumentType::UnixFS(cid, Some(2 * 1024 * 1024)));
-                store.set_root_document(root_document).await?;
+                identity.profile_banner = Some(cid);
+                store.identity_update(identity).await?;
             }
             IdentityUpdate::ClearBanner => {
-                let mut root_document = store.get_root_document().await?;
-                let document = root_document.banner.take();
-                if let Some(DocumentType::UnixFS(cid, _)) = document {
+                let document = identity.profile_banner.take();
+                if let Some(cid) = document {
                     old_cid = Some(cid);
                 }
-                store.set_root_document(root_document).await?;
+                store.identity_update(identity).await?;
             }
             IdentityUpdate::StatusMessage(status) => {
                 if let Some(status) = status.clone() {
@@ -879,11 +871,11 @@ impl MultiPass for IpfsIdentity {
                         });
                     }
                 }
-                identity.set_status_message(status);
+                identity.status_message = status;
                 store.identity_update(identity.clone()).await?;
             }
             IdentityUpdate::ClearStatusMessage => {
-                identity.set_status_message(None);
+                identity.status_message = None;
                 store.identity_update(identity.clone()).await?;
             }
         };

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -438,6 +438,7 @@ impl IpfsIdentity {
                 config.store_setting.override_ipld,
                 config.store_setting.share_platform,
                 config.store_setting.update_events,
+                config.store_setting.disable_images,
             ),
         )
         .await?;

--- a/extensions/warp-mp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-mp-ipfs/src/store/discovery.rs
@@ -5,7 +5,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc,
     },
-    time::Duration,
+    time::Duration, fmt::Debug,
 };
 
 use futures::{stream::FuturesUnordered, Stream, StreamExt};
@@ -111,7 +111,8 @@ impl Discovery {
         self.config.clone()
     }
 
-    pub async fn insert<P: Into<PeerType>>(&self, peer_type: P) -> Result<(), Error> {
+    #[tracing::instrument(skip(self))]
+    pub async fn insert<P: Into<PeerType> + Debug>(&self, peer_type: P) -> Result<(), Error> {
         let (peer_id, did_key) = match &peer_type.into() {
             PeerType::PeerId(peer_id) => (*peer_id, None),
             PeerType::DID(did_key) => {

--- a/extensions/warp-mp-ipfs/src/store/document.rs
+++ b/extensions/warp-mp-ipfs/src/store/document.rs
@@ -1,3 +1,5 @@
+pub mod identity;
+
 use futures::StreamExt;
 use ipfs::{Ipfs, IpfsPath};
 use libipld::{

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -1,0 +1,174 @@
+use either::Either;
+use futures::StreamExt;
+use libipld::Cid;
+use rust_ipfs::{Ipfs, IpfsPath};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use warp::{
+    crypto::{did_key::CoreSign, DID},
+    error::Error,
+    multipass::identity::{Identity, IdentityStatus, Platform, SHORT_ID_SIZE},
+};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct IdentityDocument {
+    pub username: String,
+
+    pub short_id: [u8; SHORT_ID_SIZE],
+
+    pub did: DID,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_message: Option<String>,
+
+    #[serde(with = "either::serde_untagged")]
+    pub profile_picture: Either<Cid, Option<String>>,
+
+    #[serde(with = "either::serde_untagged")]
+    pub profile_banner: Either<Cid, Option<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub platform: Option<Platform>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<IdentityStatus>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signature: Option<Vec<u8>>,
+}
+
+impl IdentityDocument {
+    pub async fn resolve(&self, ipfs: &Ipfs, with_image: bool) -> Result<Identity, Error> {
+        self.verify()?;
+        let mut identity = Identity::default();
+        identity.set_username(&self.username);
+        identity.set_did_key(self.did.clone());
+        identity.set_short_id(self.short_id);
+        identity.set_status_message(self.status_message.clone());
+        let mut graphics = identity.graphics();
+
+        if with_image {
+            match &self.profile_picture {
+                Either::Left(cid) => {
+                    match unixfs_fetch(ipfs, *cid, None, true, Some(2 * 1024 * 1024)).await {
+                        Ok(data) => {
+                            let picture: String = serde_json::from_slice(&data).unwrap_or_default();
+                            graphics.set_profile_picture(&picture);
+                        }
+                        _ => {
+                            tokio::spawn({
+                                let ipfs = ipfs.clone();
+                                let cid = *cid;
+                                async move {
+                                    unixfs_fetch(&ipfs, cid, None, false, Some(2 * 1024 * 1024))
+                                        .await
+                                }
+                            });
+                        }
+                    }
+                }
+                Either::Right(data) => {
+                    let data = data.clone().unwrap_or_default();
+                    graphics.set_profile_picture(&data);
+                }
+            }
+
+            match &self.profile_banner {
+                Either::Left(cid) => {
+                    match unixfs_fetch(ipfs, *cid, None, true, Some(2 * 1024 * 1024)).await {
+                        Ok(data) => {
+                            let banner: String = serde_json::from_slice(&data).unwrap_or_default();
+                            graphics.set_profile_banner(&banner);
+                        }
+                        _ => {
+                            tokio::spawn({
+                                let ipfs = ipfs.clone();
+                                let cid = *cid;
+                                async move {
+                                    unixfs_fetch(&ipfs, cid, None, false, Some(2 * 1024 * 1024))
+                                        .await
+                                }
+                            });
+                        }
+                    }
+                }
+                Either::Right(data) => {
+                    let data = data.clone().unwrap_or_default();
+                    graphics.set_profile_banner(&data);
+                }
+            }
+        }
+
+        identity.set_graphics(graphics);
+
+        Ok(identity)
+    }
+
+    pub fn sign(mut self, did: &DID) -> Result<Self, Error> {
+        let bytes = serde_json::to_vec(&self)?;
+        let signature = did.sign(&bytes);
+        self.signature = Some(signature);
+        Ok(self)
+    }
+
+    pub fn verify(&self) -> Result<(), Error> {
+        let mut payload = self.clone();
+
+        //TODO: Validate username, short id, and status message
+
+        let signature = std::mem::take(&mut payload.signature).ok_or(Error::InvalidSignature)?;
+
+        let bytes = serde_json::to_vec(&payload)?;
+        self.did
+            .verify(&bytes, &signature)
+            .map_err(|_| Error::InvalidSignature)?;
+        Ok(())
+    }
+}
+
+async fn unixfs_fetch(
+    ipfs: &Ipfs,
+    cid: Cid,
+    timeout: Option<Duration>,
+    local: bool,
+    limit: Option<usize>,
+) -> Result<Vec<u8>, Error> {
+    let fut = async {
+        let stream = ipfs
+            .unixfs()
+            .cat(IpfsPath::from(cid), None, &[], local)
+            .await
+            .map_err(anyhow::Error::from)?;
+
+        futures::pin_mut!(stream);
+
+        let mut data = vec![];
+
+        while let Some(stream) = stream.next().await {
+            if let Some(limit) = limit {
+                if data.len() >= limit {
+                    return Err(Error::InvalidLength {
+                        context: "data".into(),
+                        current: data.len(),
+                        minimum: None,
+                        maximum: Some(limit),
+                    });
+                }
+            }
+            match stream {
+                Ok(bytes) => {
+                    data.extend(bytes);
+                }
+                Err(e) => return Err(Error::from(anyhow::anyhow!("{e}"))),
+            }
+        }
+        Ok(data)
+    };
+
+    let timeout = timeout.unwrap_or(std::time::Duration::from_secs(15));
+    match tokio::time::timeout(timeout, fut).await {
+        Ok(Ok(data)) => serde_json::from_slice(&data).map_err(Error::from),
+        Ok(Err(e)) => Err(e),
+        Err(e) => Err(Error::from(anyhow::anyhow!("Timeout at {e}"))),
+    }
+}

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -57,14 +57,13 @@ impl IdentityDocument {
         identity.set_did_key(self.did.clone());
         identity.set_short_id(self.short_id);
         identity.set_status_message(self.status_message.clone());
-        let mut graphics = identity.graphics();
 
         if with_image {
             if let Some(cid) = self.profile_picture {
                 match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
                     Ok(data) => {
                         let picture: String = serde_json::from_slice(&data).unwrap_or_default();
-                        graphics.set_profile_picture(&picture);
+                        identity.set_profile_picture(&picture);
                     }
                     Err(_e) => {}
                 }
@@ -74,14 +73,12 @@ impl IdentityDocument {
                 match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
                     Ok(data) => {
                         let picture: String = serde_json::from_slice(&data).unwrap_or_default();
-                        graphics.set_profile_banner(&picture);
+                        identity.set_profile_banner(&picture);
                     }
                     Err(_e) => {}
                 }
             }
         }
-
-        identity.set_graphics(graphics);
 
         Ok(identity)
     }

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -66,9 +66,7 @@ impl IdentityDocument {
                         let picture: String = serde_json::from_slice(&data).unwrap_or_default();
                         graphics.set_profile_picture(&picture);
                     }
-                    Err(e) => {
-                        println!("{e}");
-                    }
+                    Err(_e) => {}
                 }
             }
 
@@ -78,9 +76,7 @@ impl IdentityDocument {
                         let picture: String = serde_json::from_slice(&data).unwrap_or_default();
                         graphics.set_profile_banner(&picture);
                     }
-                    Err(e) => {
-                        println!("{e}");
-                    }
+                    Err(_e) => {}
                 }
             }
         }

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -50,6 +50,27 @@ impl Hash for IdentityDocument {
 }
 
 impl IdentityDocument {
+    // Used to tell if another identity document is different but also valid
+    pub fn different(&self, other: &Self) -> bool {
+        if self.ne(other) {
+            return false;
+        }
+
+        if self.username != other.username
+            || self.status_message != other.status_message
+            || self.status != other.status
+            || self.profile_banner != other.profile_banner
+            || self.profile_picture != other.profile_picture
+            || self.platform != other.platform
+        {
+            return other.verify().is_ok();
+        }
+
+        false
+    }
+}
+
+impl IdentityDocument {
     pub async fn resolve(&self, ipfs: &Ipfs, with_image: bool) -> Result<Identity, Error> {
         self.verify()?;
         let mut identity = Identity::default();

--- a/extensions/warp-mp-ipfs/src/store/document/utils.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/utils.rs
@@ -1,0 +1,75 @@
+use std::time::Duration;
+
+use libipld::{
+    serde::{from_ipld, to_ipld},
+    Cid,
+};
+use rust_ipfs::{Ipfs, IpfsPath};
+use serde::{de::DeserializeOwned, Serialize};
+use warp::error::Error;
+
+#[async_trait::async_trait]
+pub(crate) trait ToCid: Sized {
+    async fn to_cid(&self, ipfs: &Ipfs) -> Result<Cid, Error>;
+}
+
+#[async_trait::async_trait]
+impl<T> ToCid for T
+where
+    T: Serialize + Clone + Send + Sync,
+{
+    async fn to_cid(&self, ipfs: &Ipfs) -> Result<Cid, Error> {
+        let ipld = to_ipld(self.clone()).map_err(anyhow::Error::from)?;
+        ipfs.put_dag(ipld).await.map_err(Error::from)
+    }
+}
+
+#[async_trait::async_trait]
+pub(crate) trait GetDag<D>: Sized {
+    async fn get_dag(&self, ipfs: &Ipfs, timeout: Option<Duration>) -> Result<D, Error>;
+}
+
+#[async_trait::async_trait]
+impl<D: DeserializeOwned> GetDag<D> for Cid {
+    async fn get_dag(&self, ipfs: &Ipfs, timeout: Option<Duration>) -> Result<D, Error> {
+        IpfsPath::from(*self).get_dag(ipfs, timeout).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<D: DeserializeOwned> GetDag<D> for IpfsPath {
+    async fn get_dag(&self, ipfs: &Ipfs, timeout: Option<Duration>) -> Result<D, Error> {
+        let timeout = timeout.unwrap_or(std::time::Duration::from_secs(10));
+        match tokio::time::timeout(timeout, ipfs.get_dag(self.clone())).await {
+            Ok(Ok(ipld)) => from_ipld(ipld)
+                .map_err(anyhow::Error::from)
+                .map_err(Error::from),
+            Ok(Err(e)) => Err(Error::Any(e)),
+            Err(e) => Err(Error::from(anyhow::anyhow!("Timeout at {e}"))),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub(crate) trait GetLocalDag<D>: Sized {
+    async fn get_local_dag(&self, ipfs: &Ipfs) -> Result<D, Error>;
+}
+
+#[async_trait::async_trait]
+impl<D: DeserializeOwned> GetLocalDag<D> for Cid {
+    async fn get_local_dag(&self, ipfs: &Ipfs) -> Result<D, Error> {
+        IpfsPath::from(*self).get_local_dag(ipfs).await
+    }
+}
+
+#[async_trait::async_trait]
+impl<D: DeserializeOwned> GetLocalDag<D> for IpfsPath {
+    async fn get_local_dag(&self, ipfs: &Ipfs) -> Result<D, Error> {
+        match ipfs.dag().get(self.clone(), &[], true).await {
+            Ok(ipld) => from_ipld(ipld)
+                .map_err(anyhow::Error::from)
+                .map_err(Error::from),
+            Err(e) => Err(Error::Any(e.into())),
+        }
+    }
+}

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -259,6 +259,7 @@ impl FriendsStore {
     }
 
     //TODO: Implement Errors
+    // #[tracing::instrument(skip(self, data))]
     async fn check_request_message(&mut self, data: Sata) -> anyhow::Result<()> {
         let data = data.decrypt::<PayloadEvent>(&self.did_key)?;
 
@@ -499,6 +500,7 @@ impl FriendsStore {
 }
 
 impl FriendsStore {
+    #[tracing::instrument(skip(self))]
     pub async fn send_request(&mut self, pubkey: &DID) -> Result<(), Error> {
         let (local_ipfs_public_key, _) = self.local().await?;
         let local_public_key = libp2p_pub_to_did(&local_ipfs_public_key)?;
@@ -541,6 +543,7 @@ impl FriendsStore {
         self.broadcast_request((pubkey, &payload), true, true).await
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn accept_request(&mut self, pubkey: &DID) -> Result<(), Error> {
         let (local_ipfs_public_key, _) = self.local().await?;
 
@@ -584,6 +587,7 @@ impl FriendsStore {
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn reject_request(&mut self, pubkey: &DID) -> Result<(), Error> {
         let (local_ipfs_public_key, _) = self.local().await?;
 
@@ -619,6 +623,7 @@ impl FriendsStore {
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn close_request(&mut self, pubkey: &DID) -> Result<(), Error> {
         let (local_ipfs_public_key, _) = self.local().await?;
 
@@ -660,6 +665,7 @@ impl FriendsStore {
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn has_request_from(&self, pubkey: &DID) -> Result<bool, Error> {
         self.list_incoming_request()
             .await
@@ -668,6 +674,7 @@ impl FriendsStore {
 }
 
 impl FriendsStore {
+    #[tracing::instrument(skip(self))]
     pub async fn block_list(&self) -> Result<Vec<DID>, Error> {
         let root_document = self.identity.get_root_document().await?;
         match root_document.blocks {
@@ -696,12 +703,14 @@ impl FriendsStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn is_blocked(&self, public_key: &DID) -> Result<bool, Error> {
         self.block_list()
             .await
             .map(|list| list.contains(public_key))
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn block(&mut self, pubkey: &DID) -> Result<(), Error> {
         let (local_ipfs_public_key, _) = self.local().await?;
 
@@ -755,6 +764,7 @@ impl FriendsStore {
             .await
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn unblock(&mut self, pubkey: &DID) -> Result<(), Error> {
         let (local_ipfs_public_key, _) = self.local().await?;
 
@@ -790,6 +800,7 @@ impl FriendsStore {
 }
 
 impl FriendsStore {
+    
     pub async fn block_by_list(&self) -> Result<Vec<DID>, Error> {
         let root_document = self.identity.get_root_document().await?;
         match root_document.block_by {
@@ -824,6 +835,7 @@ impl FriendsStore {
 }
 
 impl FriendsStore {
+    
     pub async fn friends_list(&self) -> Result<Vec<DID>, Error> {
         let root_document = self.identity.get_root_document().await?;
         match root_document.friends {
@@ -853,6 +865,7 @@ impl FriendsStore {
     }
 
     // Should not be called directly but only after a request is accepted
+    #[tracing::instrument(skip(self))]
     pub async fn add_friend(&mut self, pubkey: &DID) -> Result<(), Error> {
         if self.is_friend(pubkey).await? {
             return Err(Error::FriendExist);
@@ -889,6 +902,7 @@ impl FriendsStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, broadcast))]
     pub async fn remove_friend(&mut self, pubkey: &DID, broadcast: bool) -> Result<(), Error> {
         if !self.is_friend(pubkey).await? {
             return Err(Error::FriendDoesntExist);
@@ -930,6 +944,7 @@ impl FriendsStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn is_friend(&self, pubkey: &DID) -> Result<bool, Error> {
         self.friends_list().await.map(|list| list.contains(pubkey))
     }
@@ -970,6 +985,7 @@ impl FriendsStore {
             .map(|list| list.iter().any(|request| request.eq(did)))
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn list_incoming_request(&self) -> Result<Vec<DID>, Error> {
         self.list_all_raw_request().await.map(|list| {
             list.iter()
@@ -982,12 +998,14 @@ impl FriendsStore {
         })
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn sent_friend_request_to(&self, did: &DID) -> Result<bool, Error> {
         self.list_outgoing_request()
             .await
             .map(|list| list.iter().any(|request| request.eq(did)))
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn list_outgoing_request(&self) -> Result<Vec<DID>, Error> {
         self.list_all_raw_request().await.map(|list| {
             list.iter()
@@ -999,7 +1017,8 @@ impl FriendsStore {
                 .collect::<Vec<_>>()
         })
     }
-
+    
+    #[tracing::instrument(skip(self))]
     pub async fn broadcast_request(
         &mut self,
         (recipient, payload): (&DID, &PayloadEvent),

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -452,6 +452,7 @@ impl FriendsStore {
                 self.set_block_by_list(list).await?;
 
                 if completed {
+                    let _ = self.identity.push(&data.sender).await.ok();
                     if let Err(e) = self
                         .tx
                         .send(MultiPassEventKind::BlockedBy { did: data.sender })
@@ -469,6 +470,7 @@ impl FriendsStore {
                 let completed = list.remove_item(&data.sender);
                 self.set_block_by_list(list).await?;
                 if completed {
+                    let _ = self.identity.push(&data.sender).await.ok();
                     if let Err(e) = self
                         .tx
                         .send(MultiPassEventKind::UnblockedBy { did: data.sender })

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -689,9 +689,9 @@ impl FriendsStore {
         let old_document = root_document.blocks;
 
         if list.is_empty() {
-            root_document.block_by = None;
+            root_document.blocks = None;
         } else {
-            root_document.block_by = Some(list.to_cid(&self.ipfs).await?);
+            root_document.blocks = Some(list.to_cid(&self.ipfs).await?);
         }
 
         self.identity.set_root_document(root_document).await?;

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -259,6 +259,7 @@ impl FriendsStore {
     }
 
     //TODO: Implement Errors
+    //TODO: Uncomment below once sata is nolonger used here
     // #[tracing::instrument(skip(self, data))]
     async fn check_request_message(&mut self, data: Sata) -> anyhow::Result<()> {
         let data = data.decrypt::<PayloadEvent>(&self.did_key)?;

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -1131,6 +1131,7 @@ impl FriendsStore {
                 }
             }
             Event::Block => {
+                let _ = self.identity.push(recipient).await.ok();
                 if let Err(e) = self.tx.send(MultiPassEventKind::Blocked {
                     did: recipient.clone(),
                 }) {
@@ -1138,6 +1139,7 @@ impl FriendsStore {
                 }
             }
             Event::Unblock => {
+                let _ = self.identity.push(recipient).await.ok();
                 if let Err(e) = self.tx.send(MultiPassEventKind::Unblocked {
                     did: recipient.clone(),
                 }) {

--- a/extensions/warp-mp-ipfs/src/store/friends.rs
+++ b/extensions/warp-mp-ipfs/src/store/friends.rs
@@ -1074,6 +1074,10 @@ impl FriendsStore {
 
         let bytes = serde_json::to_vec(&e_payload)?;
 
+        log::trace!("Rquest Payload size: {} bytes", bytes.len());
+
+        log::info!("Sending event to {recipient}");
+
         let peers = self.ipfs.pubsub_peers(Some(topic.clone())).await?;
 
         let mut queued = false;
@@ -1101,9 +1105,12 @@ impl FriendsStore {
             self.signal.write().await.remove(recipient);
         }
 
-        if !queued && matches!(payload.event, Event::Request) {
+        if !queued {
             let end = start.elapsed();
             log::trace!("Took {}ms to send event", end.as_millis());
+        }
+
+        if !queued && matches!(payload.event, Event::Request) {
             if let Some(rx) = std::mem::take(&mut rx) {
                 if let Some(timeout) = self.wait_on_response {
                     let start = Instant::now();

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -177,7 +177,7 @@ impl IdentityStore {
             bool,
             bool,
             UpdateEvents,
-            bool
+            bool,
         ),
     ) -> Result<Self, Error> {
         if let Some(path) = path.as_ref() {
@@ -759,7 +759,7 @@ impl IdentityStore {
                                             )
                                             .await
                                         {
-                                            error!("Error requesting profile picture from {in_did}: {e}");
+                                            error!("Error requesting profile banner from {in_did}: {e}");
                                         }
                                     }
                                 }

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -617,7 +617,7 @@ impl IdentityStore {
 
         Ok(())
     }
-
+    
     #[tracing::instrument(skip(self, message))]
     async fn process_message(&mut self, in_did: DID, message: &[u8]) -> anyhow::Result<()> {
         let pk_did = self.get_keypair_did()?;

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -381,6 +381,7 @@ impl IdentityStore {
         self.push_iter(list).await
     }
 
+    #[tracing::instrument(skip(self))]
     async fn request(&self, out_did: &DID, option: RequestOption) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
@@ -406,6 +407,7 @@ impl IdentityStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn push(&self, out_did: &DID) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
@@ -432,6 +434,8 @@ impl IdentityStore {
                 self.update_event,
                 UpdateEvents::FriendsOnly | UpdateEvents::EmitFriendsOnly
             ) && is_friend;
+        
+        log::debug!("Including cid in push: {include_pictures}");
 
         identity.profile_picture = if include_pictures {
             profile_picture
@@ -474,6 +478,7 @@ impl IdentityStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn push_profile_picture(&self, out_did: &DID, cid: Cid) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
@@ -513,6 +518,7 @@ impl IdentityStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn push_profile_banner(&self, out_did: &DID, cid: Cid) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
@@ -552,6 +558,7 @@ impl IdentityStore {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, message))]
     async fn process_message(&mut self, in_did: DID, message: &[u8]) -> anyhow::Result<()> {
         let pk_did = self.get_keypair_did()?;
 
@@ -834,6 +841,7 @@ impl IdentityStore {
         }
     }
 
+    #[tracing::instrument(skip(self))]
     pub async fn create_identity(&mut self, username: Option<&str>) -> Result<Identity, Error> {
         let raw_kp = self.get_raw_keypair()?;
 

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -405,7 +405,7 @@ impl IdentityStore {
 
         let payload_bytes = serde_json::to_vec(&event)?;
 
-        let bytes = ecdh_encrypt(&pk_did, Some(out_did.clone()), payload_bytes)?;
+        let bytes = ecdh_encrypt(&pk_did, Some(out_did), payload_bytes)?;
 
         log::trace!("Payload size: {} bytes", bytes.len());
 
@@ -495,7 +495,7 @@ impl IdentityStore {
 
         let payload_bytes = serde_json::to_vec(&event)?;
 
-        let bytes = ecdh_encrypt(&pk_did, Some(out_did.clone()), payload_bytes)?;
+        let bytes = ecdh_encrypt(&pk_did, Some(out_did), payload_bytes)?;
 
         log::trace!("Payload size: {} bytes", bytes.len());
 
@@ -544,7 +544,7 @@ impl IdentityStore {
 
         let payload_bytes = serde_json::to_vec(&event)?;
 
-        let bytes = ecdh_encrypt(&pk_did, Some(out_did.clone()), payload_bytes)?;
+        let bytes = ecdh_encrypt(&pk_did, Some(out_did), payload_bytes)?;
 
         log::trace!("Payload size: {} bytes", bytes.len());
 
@@ -592,7 +592,7 @@ impl IdentityStore {
 
         let payload_bytes = serde_json::to_vec(&event)?;
 
-        let bytes = ecdh_encrypt(&pk_did, Some(out_did.clone()), payload_bytes)?;
+        let bytes = ecdh_encrypt(&pk_did, Some(out_did), payload_bytes)?;
 
         log::trace!("Payload size: {} bytes", bytes.len());
 
@@ -617,12 +617,12 @@ impl IdentityStore {
 
         Ok(())
     }
-    
+
     #[tracing::instrument(skip(self, message))]
     async fn process_message(&mut self, in_did: DID, message: &[u8]) -> anyhow::Result<()> {
         let pk_did = self.get_keypair_did()?;
 
-        let bytes = ecdh_decrypt(&pk_did, Some(in_did.clone()), message)?;
+        let bytes = ecdh_decrypt(&pk_did, Some(&in_did), message)?;
 
         log::info!("Received event from {in_did}");
         let event = serde_json::from_slice::<IdentityEvent>(&bytes)?;

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -398,7 +398,7 @@ impl IdentityStore {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn request(&self, out_did: &DID, option: RequestOption) -> Result<(), Error> {
+    pub async fn request(&self, out_did: &DID, option: RequestOption) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
         let event = IdentityEvent::Request { option };

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -409,13 +409,7 @@ impl IdentityStore {
     pub async fn push(&self, out_did: &DID) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
-        let root = self.get_root_document().await?;
-
-        let mut identity = self
-            .get_dag::<IdentityDocument>(IpfsPath::from(root.identity), None)
-            .await?;
-
-        identity.verify()?;
+        let mut identity = self.own_identity_document().await?;
 
         let _override_ipld = self.override_ipld.load(Ordering::Relaxed);
 
@@ -464,13 +458,7 @@ impl IdentityStore {
     pub async fn push_profile_picture(&self, out_did: &DID, cid: Cid) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
-        let root = self.get_root_document().await?;
-
-        let identity = self
-            .get_local_dag::<IdentityDocument>(IpfsPath::from(root.identity))
-            .await?;
-
-        identity.verify()?;
+        let identity = self.own_identity_document().await?;
 
         let Some(picture_cid) = identity.profile_picture else {
             return Ok(())
@@ -509,13 +497,7 @@ impl IdentityStore {
     pub async fn push_profile_banner(&self, out_did: &DID, cid: Cid) -> Result<(), Error> {
         let pk_did = self.get_keypair_did()?;
 
-        let root = self.get_root_document().await?;
-
-        let identity = self
-            .get_local_dag::<IdentityDocument>(IpfsPath::from(root.identity))
-            .await?;
-
-        identity.verify()?;
+        let identity = self.own_identity_document().await?;
 
         let Some(banner_cid) = identity.profile_banner else {
             return Ok(())

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -47,7 +47,7 @@ use super::{
     document::{
         identity::{unixfs_fetch, IdentityDocument},
         utils::GetLocalDag,
-        GetDag, RootDocument, ToCid,
+        RootDocument, ToCid,
     },
     ecdh_decrypt, ecdh_encrypt,
     friends::{FriendsStore, Request},
@@ -459,12 +459,11 @@ impl IdentityStore {
         let platform =
             (share_platform && (!is_blocked || !is_blocked_by)).then_some(self.own_platform());
 
-        let status = self
-            .online_status
-            .read()
-            .await
-            .clone()
-            .and_then(|status| (!is_blocked || !is_blocked_by).then_some(status).or(Some(IdentityStatus::Offline)));
+        let status = self.online_status.read().await.clone().and_then(|status| {
+            (!is_blocked || !is_blocked_by)
+                .then_some(status)
+                .or(Some(IdentityStatus::Offline))
+        });
 
         let profile_picture = identity.profile_picture;
         let profile_banner = identity.profile_banner;

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -96,7 +96,7 @@ pub async fn discovery<S: AsRef<str>>(ipfs: ipfs::Ipfs, topic: S) -> anyhow::Res
 
 fn ecdh_encrypt<K: AsRef<[u8]>>(
     did: &DID,
-    recipient: Option<DID>,
+    recipient: Option<&DID>,
     data: K,
 ) -> Result<Vec<u8>, Error> {
     let prikey = Ed25519KeyPair::from_secret_key(&did.private_key_bytes()).get_x25519();
@@ -114,7 +114,7 @@ fn ecdh_encrypt<K: AsRef<[u8]>>(
 
 fn ecdh_decrypt<K: AsRef<[u8]>>(
     did: &DID,
-    recipient: Option<DID>,
+    recipient: Option<&DID>,
     data: K,
 ) -> Result<Vec<u8>, Error> {
     let prikey = Ed25519KeyPair::from_secret_key(&did.private_key_bytes()).get_x25519();

--- a/extensions/warp-mp-ipfs/src/store/mod.rs
+++ b/extensions/warp-mp-ipfs/src/store/mod.rs
@@ -11,20 +11,14 @@ use futures::StreamExt;
 use rust_ipfs as ipfs;
 
 use ipfs::{Multiaddr, PeerId, Protocol};
-use serde::{Deserialize, Serialize};
 use warp::{
-    crypto::{
-        did_key::{CoreSign, Generate},
-        DIDKey, Ed25519KeyPair, KeyMaterial, DID,
-    },
+    crypto::{did_key::Generate, DIDKey, Ed25519KeyPair, KeyMaterial, DID},
     error::Error,
-    multipass::identity::{Identity, IdentityStatus, Platform},
+    multipass::identity::IdentityStatus,
     tesseract::Tesseract,
 };
 
 use crate::config::Discovery;
-
-use self::document::DocumentType;
 
 pub trait VecExt<T: Eq> {
     fn insert_item(&mut self, item: &T) -> bool;
@@ -53,51 +47,6 @@ where
             return true;
         }
         false
-    }
-}
-
-#[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct IdentityPayload {
-    pub did: DID,
-
-    /// Type that represents profile picturec
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub picture: Option<DocumentType<String>>,
-
-    /// Type that represents profile banner
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub banner: Option<DocumentType<String>>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<IdentityStatus>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub platform: Option<Platform>,
-
-    /// Type that represents identity or cid
-    pub payload: DocumentType<Identity>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub signature: Option<Vec<u8>>,
-}
-
-impl IdentityPayload {
-    pub fn sign(mut self, did: &DID) -> Result<IdentityPayload, Error> {
-        let bytes = serde_json::to_vec(&self)?;
-        let signature = did.sign(&bytes);
-        self.signature = Some(signature);
-        Ok(self)
-    }
-
-    pub fn verify(&self) -> Result<(), Error> {
-        let mut payload = self.clone();
-        let signature = std::mem::take(&mut payload.signature).ok_or(Error::InvalidSignature)?;
-
-        let bytes = serde_json::to_vec(&payload)?;
-        self.did
-            .verify(&bytes, &signature)
-            .map_err(|_| Error::InvalidSignature)?;
-        Ok(())
     }
 }
 

--- a/extensions/warp-mp-ipfs/src/store/queue.rs
+++ b/extensions/warp-mp-ipfs/src/store/queue.rs
@@ -271,7 +271,7 @@ impl QueueEntry {
                                 break;
                             }
                             Err(e) => {
-                                log::error!("Error sending request: {e}. Retrying in {}s", retry);
+                                log::error!("Error sending request for {}: {e}. Retrying in {}s", &entry.recipient, retry);
                                 tokio::time::sleep(Duration::from_secs(retry)).await;
                                 retry += 5;
                             }

--- a/extensions/warp-mp-ipfs/src/store/queue.rs
+++ b/extensions/warp-mp-ipfs/src/store/queue.rs
@@ -257,9 +257,13 @@ impl QueueEntry {
                                 .map_err(anyhow::Error::from)?;
 
                             let bytes = serde_json::to_vec(&payload)?;
+                            
+                            log::trace!("Payload size: {} bytes", bytes.len());
 
                             let topic = get_inbox_topic(&recipient);
-                            log::info!("Sending request to {}", recipient.clone());
+
+                            log::info!("Sending request to {}", recipient);
+
                             entry.ipfs.pubsub_publish(topic, bytes).await?;
 
                             Ok::<_, anyhow::Error>(())

--- a/warp/src/crypto/mod.rs
+++ b/warp/src/crypto/mod.rs
@@ -60,7 +60,7 @@ impl AsRef<DIDKey> for DID {
 
 impl std::fmt::Debug for DID {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("DID").field(&self.fingerprint()).finish()
+        write!(f, "{self}")
     }
 }
 

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -8,92 +8,6 @@ use warp_derive::FFIFree;
 
 pub const SHORT_ID_SIZE: usize = 8;
 
-#[derive(
-    Default, Hash, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, warp_derive::FFIVec, FFIFree,
-)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub struct Role {
-    /// Name of the role
-    name: String,
-
-    /// TBD
-    level: u8,
-}
-
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl Role {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn level(&self) -> u8 {
-        self.level
-    }
-}
-
-#[derive(
-    Default, Hash, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, warp_derive::FFIVec, FFIFree,
-)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub struct Badge {
-    /// TBD
-    name: String,
-
-    /// TBD
-    icon: String,
-}
-
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl Badge {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn name(&self) -> String {
-        self.name.clone()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn icon(&self) -> String {
-        self.icon.clone()
-    }
-}
-
-#[derive(Default, Hash, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, FFIFree)]
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-pub struct Graphics {
-    /// Hash to profile picture
-    profile_picture: String,
-
-    /// Hash to profile banner
-    profile_banner: String,
-}
-
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl Graphics {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(setter))]
-    pub fn set_profile_picture(&mut self, picture: &str) {
-        self.profile_picture = picture.to_string();
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(setter))]
-    pub fn set_profile_banner(&mut self, banner: &str) {
-        self.profile_banner = banner.to_string();
-    }
-}
-
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
-impl Graphics {
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn profile_picture(&self) -> String {
-        self.profile_picture.clone()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn profile_banner(&self) -> String {
-        self.profile_banner.clone()
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Display, FFIFree)]
 #[serde(rename_all = "lowercase")]
 #[repr(C)]
@@ -192,23 +106,14 @@ pub struct Identity {
     /// Public key for the identity
     did_key: DID,
 
-    /// TBD
-    graphics: Graphics,
+    /// Profile picture
+    profile_picture: String,
+
+    /// Profile banner
+    profile_banner: String,
 
     /// Status message
     status_message: Option<String>,
-
-    /// List of roles
-    roles: Vec<Role>,
-
-    /// List of available badges
-    available_badges: Vec<Badge>,
-
-    /// Active badge for identity
-    active_badge: Badge,
-
-    /// TBD
-    // linked_accounts: HashMap<String, String>,
 
     /// Signature of the identity
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -233,8 +138,13 @@ impl Identity {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(setter))]
-    pub fn set_graphics(&mut self, graphics: Graphics) {
-        self.graphics = graphics
+    pub fn set_profile_picture(&mut self, picture: &str) {
+        self.profile_picture = picture.to_string();
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(setter))]
+    pub fn set_profile_banner(&mut self, banner: &str) {
+        self.profile_banner = banner.to_string();
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(setter))]
@@ -246,11 +156,6 @@ impl Identity {
     pub fn set_signature(&mut self, signature: Option<String>) {
         self.signature = signature;
     }
-
-    // pub fn set_roles(&mut self) {}
-    // pub fn set_available_badges(&mut self) {}
-    // pub fn set_active_badge(&mut self) {}
-    // pub fn set_linked_accounts(&mut self) {}
 }
 
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
@@ -271,8 +176,13 @@ impl Identity {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn graphics(&self) -> Graphics {
-        self.graphics.clone()
+    pub fn profile_picture(&self) -> String {
+        self.profile_picture.clone()
+    }
+
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
+    pub fn profile_banner(&self) -> String {
+        self.profile_banner.clone()
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
@@ -281,43 +191,8 @@ impl Identity {
     }
 
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
-    pub fn active_badge(&self) -> Badge {
-        self.active_badge.clone()
-    }
-
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter))]
     pub fn signature(&self) -> Option<String> {
         self.signature.clone()
-    }
-
-    // #[cfg_attr(target_arch = "wasm32", wasm_bindgen(skip))]
-    // pub fn linked_accounts(&self) -> HashMap<String, String> {
-    //     self.linked_accounts.clone()
-    // }
-}
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-impl Identity {
-    #[wasm_bindgen]
-    pub fn roles(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.roles).unwrap()
-    }
-
-    #[wasm_bindgen]
-    pub fn available_badges(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(&self.available_badges).unwrap()
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Identity {
-    pub fn roles(&self) -> Vec<Role> {
-        self.roles.clone()
-    }
-
-    pub fn available_badges(&self) -> Vec<Badge> {
-        self.available_badges.clone()
     }
 }
 
@@ -354,9 +229,27 @@ impl From<DID> for Identifier {
     }
 }
 
-impl<S: AsRef<str>> From<S> for Identifier {
-    fn from(username: S) -> Self {
-        Self::Username(username.as_ref().to_string())
+impl From<String> for Identifier {
+    fn from(username: String) -> Self {
+        Self::Username(username)
+    }
+}
+
+impl From<&str> for Identifier {
+    fn from(username: &str) -> Self {
+        Self::Username(username.to_string())
+    }
+}
+
+impl From<Vec<DID>> for Identifier {
+    fn from(list: Vec<DID>) -> Self {
+        Self::DIDList(list)
+    }
+}
+
+impl From<&[DID]> for Identifier {
+    fn from(list: &[DID]) -> Self {
+        Self::DIDList(list.to_vec())
     }
 }
 
@@ -376,83 +269,24 @@ pub enum IdentityUpdate {
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ffi {
     use crate::crypto::DID;
-    use crate::multipass::identity::{
-        Badge, FFIVec_Badge, FFIVec_Role, Graphics, Identifier, Identity, IdentityUpdate, Role,
-    };
+    use crate::multipass::identity::{Identifier, Identity, IdentityUpdate};
     use std::ffi::{CStr, CString};
-    use std::os::raw::{c_char, c_void};
+    use std::os::raw::c_char;
 
     use super::Relationship;
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
-    pub unsafe extern "C" fn multipass_role_name(role: *const Role) -> *mut c_char {
-        if role.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let role = &*role;
-
-        match CString::new(role.name()) {
-            Ok(c) => c.into_raw(),
-            Err(_) => std::ptr::null_mut(),
-        }
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_role_level(role: *const Role) -> u8 {
-        if role.is_null() {
-            return 0;
-        }
-
-        let role = &*role;
-
-        role.level()
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_badge_name(badge: *const Badge) -> *mut c_char {
-        if badge.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let badge = &*badge;
-
-        match CString::new(badge.name()) {
-            Ok(c) => c.into_raw(),
-            Err(_) => std::ptr::null_mut(),
-        }
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_badge_icon(badge: *const Badge) -> *mut c_char {
-        if badge.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let badge = &*badge;
-
-        match CString::new(badge.icon()) {
-            Ok(c) => c.into_raw(),
-            Err(_) => std::ptr::null_mut(),
-        }
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_graphics_profile_picture(
-        graphics: *const Graphics,
+    pub unsafe extern "C" fn multipass_identity_profile_picture(
+        identity: *const Identity,
     ) -> *mut c_char {
-        if graphics.is_null() {
+        if identity.is_null() {
             return std::ptr::null_mut();
         }
 
-        let graphics = &*graphics;
+        let identity = &*identity;
 
-        match CString::new(graphics.profile_picture()) {
+        match CString::new(identity.profile_picture()) {
             Ok(c) => c.into_raw(),
             Err(_) => std::ptr::null_mut(),
         }
@@ -460,16 +294,16 @@ pub mod ffi {
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
-    pub unsafe extern "C" fn multipass_graphics_profile_banner(
-        graphics: *const Graphics,
+    pub unsafe extern "C" fn multipass_identity_profile_banner(
+        identity: *const Identity,
     ) -> *mut c_char {
-        if graphics.is_null() {
+        if identity.is_null() {
             return std::ptr::null_mut();
         }
 
-        let graphics = &*graphics;
+        let identity = &*identity;
 
-        match CString::new(graphics.profile_banner()) {
+        match CString::new(identity.profile_banner()) {
             Ok(c) => c.into_raw(),
             Err(_) => std::ptr::null_mut(),
         }
@@ -518,20 +352,6 @@ pub mod ffi {
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_graphics(
-        identity: *const Identity,
-    ) -> *mut Graphics {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let identity = &*identity;
-
-        Box::into_raw(Box::new(identity.graphics())) as *mut Graphics
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
     pub unsafe extern "C" fn multipass_identity_status_message(
         identity: *const Identity,
     ) -> *mut c_char {
@@ -548,61 +368,6 @@ pub mod ffi {
             },
             None => std::ptr::null_mut(),
         }
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_roles(identity: *mut Identity) -> *mut FFIVec_Role {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let identity = &*identity;
-
-        let contents = identity.roles();
-        Box::into_raw(Box::new(contents.into())) as *mut _
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_available_badge(
-        identity: *mut Identity,
-    ) -> *mut FFIVec_Badge {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let identity = &*identity;
-
-        let contents = identity.available_badges();
-        Box::into_raw(Box::new(contents.into())) as *mut _
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_active_badge(
-        identity: *const Identity,
-    ) -> *mut Badge {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let identity = &*identity;
-        Box::into_raw(Box::new(identity.active_badge())) as *mut Badge
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_linked_accounts(
-        identity: *const Identity,
-    ) -> *mut c_void {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let _identity = &*identity;
-        //TODO
-        std::ptr::null_mut()
     }
 
     #[allow(clippy::missing_safety_doc)]

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -33,22 +33,11 @@ pub enum MultiPassEventKind {
     FriendRemoved { did: DID },
     IdentityOnline { did: DID },
     IdentityOffline { did: DID },
-    IdentityUpdate { did: DID, kind: UpdateKind },
+    IdentityUpdate { did: DID },
     Blocked { did: DID },
     BlockedBy { did: DID },
     Unblocked { did: DID },
     UnblockedBy { did: DID },
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, warp_derive::FFIVec, FFIFree)]
-#[serde(rename_all = "snake_case")]
-#[allow(clippy::large_enum_variant)]
-pub enum UpdateKind {
-    Username { old: String, new: String },
-    Status { status: IdentityStatus },
-    Picture,
-    Banner,
-    Misc
 }
 
 #[derive(FFIFree)]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Previously, we would transmit the identity using `IdentityPayload` to any discovered and connected peers, which would contain data such as images for profile picture and banner, however, this payload would always include/transmit the image when there is an update to eg the username. This caused unnecessary data to be transmitted. This implementation changes the way it is transmitted. Using `IdentityDocument` (which now replaces `IdentityPayload`), it will contain the reference of the images by a cid, which would be compared internally by the cached reference, and if there is a difference, would request for the images to be transmitted and stored in the blockstore, otherwise it would only update the cached reference and transmit an event.

Additional changes:
- Remove `UpdateKind` to prevent unnecessary events from being emitted
- Remove `DocumentType`, which was used as a sort of `Either<T, Cid>` but for mapping between an actual type, or a `Cid` (which may be a simple dag or one stored as a filed). This is nolonger needed and just rely on the type either being correct or give an error at the time of fetching or decoding.
- Transmit a single event on an update (depending on the option to transmit an event is enabled)
- Remove `Graphics` and flatten the fields into `Identity`
- Remove unused structs and fields from `Identity`
- Optimization for when getting identities from the cache. 
- Minor cleanup

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This implementation will also make it easier to pave way for when bitswap is stabilized upstream to reduce transmitting data (eg images) over pubsub, as well as other future changes (which would reduce any breaking changes and make it more forward compatible)
- Due to changes in this PR, this is a breaking change and anything prior to this PR will not work going passed this PR