### PR TITLE
chore: Use and prioritize custom relay 

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -85,7 +85,6 @@ async fn account(
     }
     if opt.disable_relay {
         config.ipfs_setting.relay_client.enable = false;
-        config.ipfs_setting.relay_client.dcutr = false;
     }
     if opt.upnp {
         config.ipfs_setting.portmapping = true;

--- a/extensions/warp-mp-ipfs/src/config.rs
+++ b/extensions/warp-mp-ipfs/src/config.rs
@@ -60,12 +60,8 @@ pub struct Mdns {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RelayClient {
-    /// Enables relay client in libp2p
+    /// Enables relay (and dcutr) client in libp2p
     pub enable: bool,
-    /// Enables DCUtR (requires relay to be enabled)
-    pub dcutr: bool,
-    /// Uses a single relay connection
-    pub single: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     /// List of relays to use
     pub relay_address: Vec<Multiaddr>,
@@ -75,8 +71,6 @@ impl Default for RelayClient {
     fn default() -> Self {
         Self {
             enable: false,
-            dcutr: false,
-            single: false,
             relay_address: vec!["/ip4/24.199.86.91/tcp/46315/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap()]
         }
     }
@@ -314,7 +308,6 @@ impl MpIpfsConfig {
                 mdns: Mdns { enable: true },
                 relay_client: RelayClient {
                     enable: true,
-                    dcutr: true,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -336,7 +329,6 @@ impl MpIpfsConfig {
                 bootstrap: false,
                 relay_client: RelayClient {
                     enable: true,
-                    dcutr: true,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -359,7 +351,6 @@ impl MpIpfsConfig {
                 bootstrap: false,
                 relay_client: RelayClient {
                     enable: true,
-                    dcutr: true,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -385,7 +376,6 @@ impl MpIpfsConfig {
                 bootstrap: true,
                 relay_client: RelayClient {
                     enable: true,
-                    dcutr: true,
                     ..Default::default()
                 },
                 ..Default::default()

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -337,12 +337,12 @@ impl IpfsIdentity {
                                 .await
                             {
                                 Ok(addr) => {
-                                    debug!("Listening on {}", addr);
+                                    info!("Listening on {}", addr);
                                     relayed.push(addr);
                                     break;
                                 }
                                 Err(e) => {
-                                    info!(
+                                    error!(
                                         "Error listening on relay {}: {e}",
                                         addr.clone().with(Protocol::P2pCircuit)
                                     );

--- a/extensions/warp-rg-ipfs/examples/messenger.rs
+++ b/extensions/warp-rg-ipfs/examples/messenger.rs
@@ -107,7 +107,6 @@ async fn create_account<P: AsRef<Path>>(
     }
     if opt.disable_relay {
         config.ipfs_setting.relay_client.enable = false;
-        config.ipfs_setting.relay_client.dcutr = false;
     }
     if opt.upnp {
         config.ipfs_setting.portmapping = true;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Previously, we would connect to relays and make a reservation with all of them, in attempts to create a stable connection with peers over relays, however it would seem that when peers connect doing so with multiple reservation does not allow full connection, causing some data to be loss when being transmitted.

In this PR, it will:
- Connect and use custom relays first, prioritizing them over bootstrap relays
- Use a single relay instead of multiple, except that if a reservation could not be made, to continue through the list
- If any custom relays could not be used to fallback to bootstrap relays, repeating same process.

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
It is possible to extend over all addresses of the peer(s) when dialing so we could be sure we have a establish connection to relays, but may not be exactly practical for now. 