### PR TITLE
fix: Attempt public key extraction upon receiving event

### DIFF
--- a/extensions/warp-mp-ipfs/tests/accounts.rs
+++ b/extensions/warp-mp-ipfs/tests/accounts.rs
@@ -60,7 +60,7 @@ mod test {
         let (_, did_b, _) = accounts.last().expect("Account exist");
 
         //used to wait for the nodes to discover eachother and provide their identity to each other
-        let identity_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let identity_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Ok(Some(id)) = account_a
                     .get_identity(did_b.clone().into())
@@ -100,7 +100,7 @@ mod test {
 
         //used to wait for the nodes to discover eachother and provide their identity to each other
 
-        let identity_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let identity_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(id) = account_a
                     .get_identity(String::from("JaneDoe").into())
@@ -221,7 +221,7 @@ mod test {
 
         let (mut account_b, did_b, _) = accounts.last().cloned().unwrap();
 
-        let status_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let status_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Ok(status) = account_a.identity_status(&did_b).await {
                     break status;
@@ -234,7 +234,7 @@ mod test {
 
         account_b.set_identity_status(IdentityStatus::Away).await?;
 
-        let status = tokio::time::timeout(Duration::from_secs(5), async {
+        let status = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Ok(status) = account_a.identity_status(&did_b).await {
                     if status != status_b {
@@ -285,7 +285,7 @@ mod test {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        let platform_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let platform_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Ok(platform) = account_a.identity_platform(did_b).await {
                     break platform;

--- a/extensions/warp-mp-ipfs/tests/friends.rs
+++ b/extensions/warp-mp-ipfs/tests/friends.rs
@@ -22,7 +22,7 @@ mod test {
         let mut subscribe_b = account_b.subscribe().await?;
         account_a.send_request(&did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             let did = loop {
                 if let Some(MultiPassEventKind::FriendRequestReceived { from }) =
                     subscribe_b.next().await
@@ -34,7 +34,7 @@ mod test {
         })
         .await??;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendAdded { .. }) = subscribe_a.next().await {
                     break;
@@ -64,7 +64,7 @@ mod test {
 
         account_a.send_request(&did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             let did = loop {
                 if let Some(MultiPassEventKind::FriendRequestReceived { from }) =
                     subscribe_b.next().await
@@ -76,7 +76,7 @@ mod test {
         })
         .await??;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendAdded { .. }) = subscribe_a.next().await {
                     break;
@@ -90,7 +90,7 @@ mod test {
 
         account_a.remove_friend(&did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendRemoved { .. }) = subscribe_a.next().await {
                     break;
@@ -99,7 +99,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendRemoved { .. }) = subscribe_b.next().await {
                     break;
@@ -127,7 +127,7 @@ mod test {
 
         account_a.send_request(&did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             let did = loop {
                 if let Some(MultiPassEventKind::FriendRequestReceived { from }) =
                     subscribe_b.next().await
@@ -139,7 +139,7 @@ mod test {
         })
         .await??;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::OutgoingFriendRequestRejected { .. }) =
                     subscribe_a.next().await
@@ -168,7 +168,7 @@ mod test {
 
         account_a.send_request(&did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendRequestReceived { .. }) =
                     subscribe_b.next().await
@@ -181,7 +181,7 @@ mod test {
 
         account_a.close_request(&did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::IncomingFriendRequestClosed { .. }) =
                     subscribe_b.next().await
@@ -192,7 +192,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::OutgoingFriendRequestClosed { .. }) =
                     subscribe_a.next().await
@@ -220,7 +220,7 @@ mod test {
         let mut subscribe_b = account_b.subscribe().await?;
 
         account_a.send_request(&did_b).await?;
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendRequestSent { .. }) = subscribe_a.next().await
                 {
@@ -230,7 +230,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendRequestReceived { .. }) =
                     subscribe_b.next().await
@@ -262,7 +262,7 @@ mod test {
         let mut subscribe_a = account_a.subscribe().await?;
 
         account_a.send_request(&did_b).await?;
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MultiPassEventKind::FriendRequestSent { .. }) = subscribe_a.next().await
                 {
@@ -304,7 +304,7 @@ mod test {
         account_a.block(&did_b).await?;
         account_b.block(&did_a).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(
                     MultiPassEventKind::Blocked { did } | MultiPassEventKind::BlockedBy { did },
@@ -317,7 +317,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(
                     MultiPassEventKind::Blocked { did } | MultiPassEventKind::BlockedBy { did },
@@ -333,7 +333,7 @@ mod test {
         account_a.unblock(&did_b).await?;
         account_b.unblock(&did_a).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(
                     MultiPassEventKind::Unblocked { did } | MultiPassEventKind::UnblockedBy { did },
@@ -346,7 +346,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(
                     MultiPassEventKind::Unblocked { did } | MultiPassEventKind::UnblockedBy { did },

--- a/extensions/warp-rg-ipfs/tests/direct.rs
+++ b/extensions/warp-rg-ipfs/tests/direct.rs
@@ -26,7 +26,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -37,7 +37,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -82,7 +82,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -93,7 +93,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -109,7 +109,7 @@ mod test {
 
         chat_a.send(id_a, vec!["Hello, World".into()]).await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageSent {
                     conversation_id,
@@ -122,7 +122,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -163,7 +163,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -174,7 +174,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -190,7 +190,7 @@ mod test {
 
         chat_a.send(id_a, vec!["Hello, World".into()]).await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageSent {
                     conversation_id,
@@ -203,7 +203,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -221,7 +221,7 @@ mod test {
         chat_a.delete(id_a, Some(message_a.id())).await?;
 
         // Maybe cross check the message id and convo
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageDeleted { .. }) = conversation_a.next().await {
                     break;
@@ -230,7 +230,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageDeleted { .. }) = conversation_b.next().await {
                     break;
@@ -266,7 +266,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -277,7 +277,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -293,7 +293,7 @@ mod test {
 
         chat_a.send(id_a, vec!["Hello, World".into()]).await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageSent {
                     conversation_id,
@@ -306,7 +306,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -325,7 +325,7 @@ mod test {
             .edit(id_a, message_a.id(), vec!["New Message".into()])
             .await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageEdited {
                     conversation_id,
@@ -338,7 +338,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageEdited {
                     conversation_id,
@@ -379,7 +379,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -390,7 +390,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -406,7 +406,7 @@ mod test {
 
         chat_a.send(id_a, vec!["Hello, World".into()]).await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageSent {
                     conversation_id,
@@ -419,7 +419,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -438,7 +438,7 @@ mod test {
             .react(id_a, message_a.id(), ReactionState::Add, ":smile:".into())
             .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReactionAdded {
                     conversation_id,
@@ -469,7 +469,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReactionAdded {
                     conversation_id,
@@ -509,7 +509,7 @@ mod test {
             )
             .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReactionRemoved {
                     conversation_id,
@@ -534,7 +534,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReactionRemoved {
                     conversation_id,
@@ -578,7 +578,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -589,7 +589,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -605,7 +605,7 @@ mod test {
 
         chat_a.send(id_a, vec!["Hello, World".into()]).await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageSent {
                     conversation_id,
@@ -618,7 +618,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -635,7 +635,7 @@ mod test {
 
         chat_a.pin(id_a, message_a.id(), PinState::Pin).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessagePinned {
                     conversation_id,
@@ -655,7 +655,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessagePinned {
                     conversation_id,
@@ -677,7 +677,7 @@ mod test {
 
         chat_a.pin(id_a, message_a.id(), PinState::Unpin).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageUnpinned {
                     conversation_id,
@@ -697,7 +697,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageUnpinned {
                     conversation_id,
@@ -744,7 +744,7 @@ mod test {
 
         chat_a.create_conversation(&did_b).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -755,7 +755,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -770,7 +770,7 @@ mod test {
 
         chat_a.send_event(id_a, MessageEvent::Typing).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::EventReceived {
                     conversation_id,
@@ -789,7 +789,7 @@ mod test {
 
         chat_a.cancel_event(id_a, MessageEvent::Typing).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::EventCancelled {
                     conversation_id,

--- a/extensions/warp-rg-ipfs/tests/group.rs
+++ b/extensions/warp-rg-ipfs/tests/group.rs
@@ -22,7 +22,7 @@ mod test {
 
         chat_a.create_group_conversation(None, vec![]).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -56,7 +56,7 @@ mod test {
 
         chat_a.create_group_conversation(None, vec![]).await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -74,7 +74,7 @@ mod test {
 
         chat_a.update_conversation_name(id_a, "test").await?;
 
-        let name = tokio::time::timeout(Duration::from_secs(5), async {
+        let name = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::ConversationNameUpdated { name, .. }) =
                     conversation_a.next().await
@@ -90,7 +90,7 @@ mod test {
 
         chat_a.update_conversation_name(id_a, "").await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::ConversationNameUpdated { .. }) =
                     conversation_a.next().await
@@ -128,7 +128,7 @@ mod test {
             .create_group_conversation(None, vec![did_b.clone(), did_c.clone()])
             .await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -139,7 +139,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -150,7 +150,7 @@ mod test {
         })
         .await?;
 
-        let id_c = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_c = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_c.next().await
@@ -213,7 +213,7 @@ mod test {
             .create_group_conversation(None, vec![did_b.clone(), did_c.clone()])
             .await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -224,7 +224,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -235,7 +235,7 @@ mod test {
         })
         .await?;
 
-        let id_c = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_c = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_c.next().await
@@ -252,7 +252,7 @@ mod test {
 
         chat_a.add_recipient(id_a, &did_d).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientAdded {
                     conversation_id,
@@ -267,7 +267,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientAdded {
                     conversation_id,
@@ -282,7 +282,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientAdded {
                     conversation_id,
@@ -297,7 +297,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_d.next().await
@@ -359,7 +359,7 @@ mod test {
             .create_group_conversation(None, vec![did_b.clone(), did_c.clone()])
             .await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -370,7 +370,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -381,7 +381,7 @@ mod test {
         })
         .await?;
 
-        let id_c = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_c = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_c.next().await
@@ -400,7 +400,7 @@ mod test {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientAdded {
                     conversation_id,
@@ -415,7 +415,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientAdded {
                     conversation_id,
@@ -430,7 +430,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientAdded {
                     conversation_id,
@@ -445,7 +445,7 @@ mod test {
         })
         .await?;
 
-        let id_d = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_d = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_d.next().await
@@ -461,7 +461,7 @@ mod test {
 
         chat_a.remove_recipient(id_a, &did_b).await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientRemoved {
                     conversation_id,
@@ -476,7 +476,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientRemoved {
                     conversation_id,
@@ -491,7 +491,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::RecipientRemoved {
                     conversation_id,
@@ -506,7 +506,7 @@ mod test {
         })
         .await?;
 
-        tokio::time::timeout(Duration::from_secs(5), async {
+        tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationDeleted { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -569,7 +569,7 @@ mod test {
             .create_group_conversation(None, vec![did_b.clone(), did_c.clone(), did_d.clone()])
             .await?;
 
-        let id_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_a.next().await
@@ -580,7 +580,7 @@ mod test {
         })
         .await?;
 
-        let id_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_b.next().await
@@ -591,7 +591,7 @@ mod test {
         })
         .await?;
 
-        let id_c = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_c = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_c.next().await
@@ -602,7 +602,7 @@ mod test {
         })
         .await?;
 
-        let id_d = tokio::time::timeout(Duration::from_secs(5), async {
+        let id_d = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
                     chat_subscribe_d.next().await
@@ -622,7 +622,7 @@ mod test {
 
         chat_a.send(id_a, vec!["Hello, World".into()]).await?;
 
-        let message_a = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_a = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageSent {
                     conversation_id,
@@ -636,7 +636,7 @@ mod test {
         })
         .await??;
 
-        let message_b = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_b = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -650,7 +650,7 @@ mod test {
         })
         .await??;
 
-        let message_c = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_c = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,
@@ -664,7 +664,7 @@ mod test {
         })
         .await??;
 
-        let message_d = tokio::time::timeout(Duration::from_secs(5), async {
+        let message_d = tokio::time::timeout(Duration::from_secs(60), async {
             loop {
                 if let Some(MessageEventKind::MessageReceived {
                     conversation_id,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Attempt to extract public key from peer id if it is not apart of `Discovery` and attempt to insert it

**Which issue(s) this PR fixes** 🔨
N/A
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This should help improve on discovery when receiving an event from a user who is not apart of `Discovery`, however this depends solely on if the public key can be extracted, which should possible due to using ed25519. 
- In the future, we may reject and possibly block the peerid that does not contain an inline public key, or an invalid public key