### PR TITLE
refactor: Split file and directory to keystore

### DIFF
--- a/extensions/warp-fs-ipfs/examples/ipfs-persistent.rs
+++ b/extensions/warp-fs-ipfs/examples/ipfs-persistent.rs
@@ -60,7 +60,7 @@ async fn account_persistent<P: AsRef<Path>>(
 ) -> anyhow::Result<Box<dyn MultiPass>> {
     let path = path.as_ref();
 
-    let tesseract = Tesseract::open_or_create(path.join("tdatastore"))?;
+    let tesseract = Tesseract::open_or_create(path, "tdatastore")?;
 
     tesseract
         .unlock(b"this is my totally secured password that should nnever be embedded in code")?;

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -68,7 +68,7 @@ async fn account(
     opt: &Opt,
 ) -> anyhow::Result<Box<dyn MultiPass>> {
     let tesseract = match path.as_ref() {
-        Some(path) => Tesseract::open_or_create(path.join("tdatastore"))?,
+        Some(path) => Tesseract::open_or_create(path, "tdatastore")?,
         None => Tesseract::default(),
     };
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Changes `Tesseract::open_or_create` to support a path and file. 

**Which issue(s) this PR fixes** 🔨
Resolves #249 (indirectly)
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Tesseract, above all, is created first before the extensions is ever initialized. This would cause the keystore to be initialized without actually saving to disk in some cases. This change will not only allow us to create the directory to where the keystore will be located, but also allow better support for multiple keystores in the future (either in the backend, or frontend). 