### PR TITLE
feat(blink): emit event when a participant is speaking

### DIFF
--- a/extensions/warp-blink-wrtc/Cargo.toml
+++ b/extensions/warp-blink-wrtc/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = { version = "1" }
 async-trait = { version = "0.1" }
 async-stream = "0.3"
 bytes = "1.4.0"
-bs1770 = "1.0.0"
 bs58 = "0.4.0"
 derive_more = "0.99.17"
 futures = { version = "0.3" }

--- a/extensions/warp-blink-wrtc/Cargo.toml
+++ b/extensions/warp-blink-wrtc/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = { version = "1" }
 async-trait = { version = "0.1" }
 async-stream = "0.3"
 bytes = "1.4.0"
+bs1770 = "1.0.0"
 bs58 = "0.4.0"
 derive_more = "0.99.17"
 futures = { version = "0.3" }

--- a/extensions/warp-blink-wrtc/src/host_media/audio/loudness.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/loudness.rs
@@ -1,0 +1,39 @@
+/// calculates loudness using root mean square.
+/// is basically a moving average filter. has a delay (in samples) equal to the buffer size
+pub struct Calculator {
+    buf: Vec<f32>,
+    ss: f32,
+    idx: usize,
+    // equals 1/buf.size(). multiplication is faster than division
+    normalizer: f32,
+}
+
+impl Calculator {
+    pub fn new(buf_size: usize) -> Self {
+        let mut buf = Vec::new();
+        buf.resize(buf_size, 0.0);
+        Self {
+            buf,
+            ss: 0.0,
+            idx: 0,
+            normalizer: 1.0 / buf_size as f32,
+        }
+    }
+    pub fn insert(&mut self, sample: f32) {
+        let sq = sample.powf(2.0);
+        self.ss += sq;
+        self.ss -= self.buf[self.idx];
+        self.buf[self.idx] = sq;
+        self.idx = (self.idx + 1) % self.buf.len();
+    }
+
+    pub fn get_rms(&self) -> f32 {
+        f32::sqrt(self.ss * self.normalizer)
+    }
+
+    pub fn reset(&mut self) {
+        let mut buf = Vec::new();
+        buf.resize(self.buf.len(), 0.0);
+        self.buf = buf;
+    }
+}

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -10,7 +10,6 @@ use webrtc::track::{
 
 mod loudness;
 mod opus;
-mod recorder;
 mod speech;
 
 pub use self::opus::sink::OpusSink;

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -18,6 +18,7 @@ pub use self::opus::source::OpusSource;
 // stores the TrackRemote at least
 pub trait SourceTrack {
     fn init(
+        event_ch: broadcast::Sender<BlinkEventKind>,
         input_device: &cpal::Device,
         track: Arc<TrackLocalStaticRTP>,
         webrtc_codec: blink::AudioCodec,
@@ -56,6 +57,7 @@ pub trait SinkTrack {
 
 /// Uses the MIME type from codec to determine which implementation of SourceTrack to create
 pub fn create_source_track(
+    event_ch: broadcast::Sender<BlinkEventKind>,
     input_device: &cpal::Device,
     track: Arc<TrackLocalStaticRTP>,
     webrtc_codec: blink::AudioCodec,
@@ -66,6 +68,7 @@ pub fn create_source_track(
     }
     match MimeType::try_from(webrtc_codec.mime_type().as_str())? {
         MimeType::OPUS => Ok(Box::new(OpusSource::init(
+            event_ch,
             input_device,
             track,
             webrtc_codec,

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -30,8 +30,8 @@ pub trait SourceTrack {
 
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
-    fn record(&mut self, input_device: &cpal::Device, output_file_name: &str) -> Result<()>;
-    fn stop_recording(&mut self, input_device: &cpal::Device) -> Result<()>;
+    fn record(&mut self) -> Result<()>;
+    fn stop_recording(&mut self) -> Result<()>;
     // should not require RTP renegotiation
     fn change_input_device(&mut self, input_device: &cpal::Device) -> Result<()>;
 }
@@ -52,8 +52,8 @@ pub trait SinkTrack {
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
 
-    fn record(&mut self, output_device: &cpal::Device, output_file_name: &str) -> Result<()>;
-    fn stop_recording(&mut self, output_device: &cpal::Device) -> Result<()>;
+    fn record(&mut self) -> Result<()>;
+    fn stop_recording(&mut self) -> Result<()>;
 }
 
 /// Uses the MIME type from codec to determine which implementation of SourceTrack to create

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -8,9 +8,10 @@ use webrtc::track::{
     track_local::track_local_static_rtp::TrackLocalStaticRTP, track_remote::TrackRemote,
 };
 
-pub mod loudness;
+mod loudness;
 mod opus;
-pub mod speech;
+mod recorder;
+mod speech;
 
 pub use self::opus::sink::OpusSink;
 pub use self::opus::source::OpusSource;
@@ -29,8 +30,8 @@ pub trait SourceTrack {
 
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
-    fn record(&mut self, output_file_name: &str) -> Result<()>;
-    fn stop_recording(&mut self) -> Result<()>;
+    fn record(&mut self, input_device: &cpal::Device, output_file_name: &str) -> Result<()>;
+    fn stop_recording(&mut self, input_device: &cpal::Device) -> Result<()>;
     // should not require RTP renegotiation
     fn change_input_device(&mut self, input_device: &cpal::Device) -> Result<()>;
 }
@@ -51,8 +52,8 @@ pub trait SinkTrack {
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
 
-    fn record(&mut self, output_file_name: &str) -> Result<()>;
-    fn stop_recording(&mut self) -> Result<()>;
+    fn record(&mut self, output_device: &cpal::Device, output_file_name: &str) -> Result<()>;
+    fn stop_recording(&mut self, output_device: &cpal::Device) -> Result<()>;
 }
 
 /// Uses the MIME type from codec to determine which implementation of SourceTrack to create

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -30,8 +30,6 @@ pub trait SourceTrack {
 
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
-    fn record(&mut self) -> Result<()>;
-    fn stop_recording(&mut self) -> Result<()>;
     // should not require RTP renegotiation
     fn change_input_device(&mut self, input_device: &cpal::Device) -> Result<()>;
 }
@@ -51,9 +49,6 @@ pub trait SinkTrack {
     fn change_output_device(&mut self, output_device: &cpal::Device) -> anyhow::Result<()>;
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
-
-    fn record(&mut self) -> Result<()>;
-    fn stop_recording(&mut self) -> Result<()>;
 }
 
 /// Uses the MIME type from codec to determine which implementation of SourceTrack to create

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -6,6 +6,7 @@ use webrtc::track::{
     track_local::track_local_static_rtp::TrackLocalStaticRTP, track_remote::TrackRemote,
 };
 
+pub mod loudness;
 mod opus;
 
 pub use self::opus::sink::OpusSink;

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/mod.rs
@@ -1,5 +1,4 @@
 use std::{mem::MaybeUninit, sync::Arc};
-
 pub mod sink;
 pub mod source;
 

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/mod.rs
@@ -1,5 +1,12 @@
+use std::{mem::MaybeUninit, sync::Arc};
+
 pub mod sink;
 pub mod source;
+
+pub type AudioSampleProducer =
+    ringbuf::Producer<f32, Arc<ringbuf::SharedRb<f32, Vec<MaybeUninit<f32>>>>>;
+pub type AudioSampleConsumer =
+    ringbuf::Consumer<f32, Arc<ringbuf::SharedRb<f32, Vec<MaybeUninit<f32>>>>>;
 
 pub enum ResamplerConfig {
     None,

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -4,7 +4,7 @@ use cpal::{
     SampleRate,
 };
 use ringbuf::HeapRb;
-use std::{cmp::Ordering, mem::MaybeUninit, sync::Arc};
+use std::{cmp::Ordering, sync::Arc};
 use tokio::task::JoinHandle;
 use warp::blink;
 
@@ -13,7 +13,7 @@ use webrtc::{
     track::track_remote::TrackRemote, util::Unmarshal,
 };
 
-use crate::host_media::audio::SinkTrack;
+use crate::host_media::audio::{opus::AudioSampleProducer, SinkTrack};
 
 use super::{ChannelMixer, ChannelMixerConfig, ChannelMixerOutput, Resampler, ResamplerConfig};
 
@@ -156,7 +156,7 @@ impl SinkTrack for OpusSink {
 async fn decode_media_stream<T>(
     track: Arc<TrackRemote>,
     mut sample_builder: SampleBuilder<T>,
-    mut producer: ringbuf::Producer<f32, Arc<ringbuf::SharedRb<f32, Vec<MaybeUninit<f32>>>>>,
+    mut producer: AudioSampleProducer,
     mut decoder: opus::Decoder,
     mut resampler: Resampler,
     mut channel_mixer: ChannelMixer,

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -185,14 +185,6 @@ impl SinkTrack for OpusSink {
         *self = new_sink;
         Ok(())
     }
-
-    fn record(&mut self) -> Result<()> {
-        todo!()
-    }
-
-    fn stop_recording(&mut self) -> Result<()> {
-        todo!()
-    }
 }
 
 struct DecodeMediaStreamArgs<T: Depacketizer> {
@@ -241,9 +233,8 @@ where
                     }
                 };
 
-                // don't yet know how to set/get the header extension ID, but currently only one extension is being used.
                 if let Some(extension) = rtp_packet.header.extensions.first() {
-                    // too lazy to figure out how to use their api..I can extract the byte myself, thank you...
+                    // don't yet have the MediaEngine exposed. for now since there's only one extension being used, this way seems to be good enough
                     // copies extension::audio_level_extension::AudioLevelExtension from the webrtc-rs crate
                     // todo: use this:
                     // .media_engine

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -225,6 +225,12 @@ where
                 if let Some(extension) = rtp_packet.header.extensions.first() {
                     // too lazy to figure out how to use their api..I can extract the byte myself, thank you...
                     // copies extension::audio_level_extension::AudioLevelExtension from the webrtc-rs crate
+                    // todo: use this:
+                    // .media_engine
+                    // .get_header_extension_id(RTCRtpHeaderExtensionCapability {
+                    //     uri: ::sdp::extmap::SDES_MID_URI.to_owned(),
+                    // })
+                    // followed by this: header.get_extension(extension_id)
                     let audio_level = extension.payload.first().map(|x| x & 0x7F).unwrap_or(0);
                     if speech_detector.should_emit_event(audio_level) {
                         let _ = event_ch

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/framer.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/framer.rs
@@ -18,8 +18,19 @@ pub struct Framer {
     opus_out: Vec<u8>,
     // number of samples in a frame
     frame_size: usize,
+    // for splitting and merging audio channels
     channel_mixer: ChannelMixer,
+    // for upsampling and downsampling audio
     resampler: Resampler,
+    // this is needed by the bs1770 algorithm
+    output_sample_rate: u32,
+    loudness_meter: bs1770::ChannelLoudnessMeter,
+}
+
+pub struct FramerOutput {
+    pub bytes: Bytes,
+    // could be none if less than 100ms of audio have been processed
+    pub loudness: Option<bs1770::Power>,
 }
 
 impl Framer {
@@ -28,6 +39,7 @@ impl Framer {
         webrtc_codec: blink::AudioCodec,
         source_codec: blink::AudioCodec,
     ) -> anyhow::Result<Self> {
+        let loudness_meter = bs1770::ChannelLoudnessMeter::new(webrtc_codec.sample_rate());
         let mut buf = Vec::new();
         buf.reserve(frame_size);
         let mut opus_out = Vec::new();
@@ -64,10 +76,12 @@ impl Framer {
             frame_size,
             resampler: Resampler::new(resampler_config),
             channel_mixer: ChannelMixer::new(channel_mixer_config),
+            output_sample_rate: webrtc_codec.sample_rate(),
+            loudness_meter,
         })
     }
 
-    pub fn frame(&mut self, sample: f32) -> Option<Bytes> {
+    pub fn frame(&mut self, sample: f32) -> Option<FramerOutput> {
         match self.channel_mixer.process(sample) {
             ChannelMixerOutput::Single(sample) => {
                 self.resampler.process(sample, &mut self.raw_samples);
@@ -80,6 +94,7 @@ impl Framer {
         }
 
         if self.raw_samples.len() == self.frame_size {
+            self.loudness_meter.push(self.raw_samples.iter().cloned());
             match self.encoder.encode_float(
                 self.raw_samples.as_mut_slice(),
                 self.opus_out.as_mut_slice(),
@@ -88,7 +103,22 @@ impl Framer {
                     self.raw_samples.clear();
                     let slice = self.opus_out.as_slice();
                     let bytes = bytes::Bytes::copy_from_slice(&slice[0..size]);
-                    Some(bytes)
+
+                    let loudness = self
+                        .loudness_meter
+                        .as_100ms_windows()
+                        .inner
+                        .iter()
+                        .last()
+                        .cloned();
+                    if loudness.is_some() {
+                        // reset the algorithm
+                        self.loudness_meter =
+                            bs1770::ChannelLoudnessMeter::new(self.output_sample_rate);
+                        // this might be unnecessary but...it includes the last 10-20ms of samples in the next calculation
+                        self.loudness_meter.push(self.raw_samples.iter().cloned());
+                    }
+                    Some(FramerOutput { bytes, loudness })
                 }
                 Err(e) => {
                     log::error!("OpusPacketizer failed to encode: {}", e);

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -87,6 +87,14 @@ impl SourceTrack for OpusSource {
         self.packetizer_handle = handle;
         Ok(())
     }
+
+    fn record(&mut self, _output_file_name: &str) -> Result<()> {
+        todo!()
+    }
+
+    fn stop_recording(&mut self) -> Result<()> {
+        todo!()
+    }
 }
 
 fn create_source_track(
@@ -143,7 +151,7 @@ fn create_source_track(
                     {
                         Ok(packets) => {
                             let loudness = match output.loudness.mul(1000.0) {
-                                x if x >= 255.0 => 255,
+                                x if x >= 127.0 => 127,
                                 x => x as u8,
                             };
                             for packet in &packets {

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -93,14 +93,6 @@ impl SourceTrack for OpusSource {
         self.packetizer_handle = handle;
         Ok(())
     }
-
-    fn record(&mut self) -> Result<()> {
-        todo!()
-    }
-
-    fn stop_recording(&mut self) -> Result<()> {
-        todo!()
-    }
 }
 
 fn create_source_track(

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -125,7 +125,7 @@ fn create_source_track(
     let mut framer = Framer::init(
         source_codec.frame_size(),
         webrtc_codec.clone(),
-        source_codec.clone(),
+        source_codec,
     )?;
     let opus = Box::new(rtp::codecs::opus::OpusPayloader {});
     let seq = Box::new(rtp::sequence::new_random_sequencer());

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -5,13 +5,8 @@ use cpal::{
 };
 use rand::Rng;
 use ringbuf::HeapRb;
-use std::{fs::OpenOptions, slice};
-use std::{
-    io::{BufWriter, Write},
-    ops::Mul,
-    sync::Arc,
-    time::Duration,
-};
+
+use std::{ops::Mul, sync::Arc, time::Duration};
 use tokio::{sync::broadcast, task::JoinHandle};
 use warp::blink::{self, BlinkEventKind};
 
@@ -35,34 +30,11 @@ pub struct OpusSource {
     // used to cancel the current packetizer when the input device is changed.
     packetizer_handle: JoinHandle<()>,
     event_ch: broadcast::Sender<BlinkEventKind>,
-    output_file_name: Option<String>,
 }
 
 impl Drop for OpusSource {
     fn drop(&mut self) {
         self.packetizer_handle.abort();
-    }
-}
-
-impl OpusSource {
-    fn re_init(
-        &mut self,
-        output_file_name: Option<String>,
-        input_device: &cpal::Device,
-    ) -> Result<()> {
-        self.packetizer_handle.abort();
-        let (stream, handle) = create_source_track(
-            input_device,
-            output_file_name.clone(),
-            self.track.clone(),
-            self.webrtc_codec.clone(),
-            self.source_codec.clone(),
-            self.event_ch.clone(),
-        )?;
-        self.output_file_name = output_file_name;
-        self.stream = stream;
-        self.packetizer_handle = handle;
-        Ok(())
     }
 }
 
@@ -79,7 +51,6 @@ impl SourceTrack for OpusSource {
     {
         let (input_stream, join_handle) = create_source_track(
             input_device,
-            None,
             track.clone(),
             webrtc_codec.clone(),
             source_codec.clone(),
@@ -93,7 +64,6 @@ impl SourceTrack for OpusSource {
             source_codec,
             stream: input_stream,
             packetizer_handle: join_handle,
-            output_file_name: None,
         })
     }
 
@@ -111,41 +81,35 @@ impl SourceTrack for OpusSource {
     }
     // should not require RTP renegotiation
     fn change_input_device(&mut self, input_device: &cpal::Device) -> Result<()> {
-        self.re_init(self.output_file_name.clone(), input_device)
+        self.packetizer_handle.abort();
+        let (stream, handle) = create_source_track(
+            input_device,
+            self.track.clone(),
+            self.webrtc_codec.clone(),
+            self.source_codec.clone(),
+            self.event_ch.clone(),
+        )?;
+        self.stream = stream;
+        self.packetizer_handle = handle;
+        Ok(())
     }
 
-    fn record(&mut self, input_device: &cpal::Device, output_file_name: &str) -> Result<()> {
-        self.re_init(Some(output_file_name.into()), input_device)
+    fn record(&mut self) -> Result<()> {
+        todo!()
     }
 
-    fn stop_recording(&mut self, input_device: &cpal::Device) -> Result<()> {
-        self.re_init(None, input_device)
+    fn stop_recording(&mut self) -> Result<()> {
+        todo!()
     }
 }
 
 fn create_source_track(
     input_device: &cpal::Device,
-    output_file_name: Option<String>,
     track: Arc<TrackLocalStaticRTP>,
     webrtc_codec: blink::AudioCodec,
     source_codec: blink::AudioCodec,
     event_ch: broadcast::Sender<BlinkEventKind>,
 ) -> Result<(cpal::Stream, JoinHandle<()>)> {
-    let mut buf_writer = output_file_name.and_then(|name| {
-        let file = match OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(name)
-        {
-            Ok(r) => r,
-            Err(e) => {
-                log::error!("failed to open file for source track: {e}");
-                return None;
-            }
-        };
-        Some(BufWriter::new(file))
-    });
     let config = cpal::StreamConfig {
         channels: source_codec.channels(),
         sample_rate: SampleRate(source_codec.sample_rate()),
@@ -189,12 +153,6 @@ fn create_source_track(
         let mut speech_detector = speech::Detector::new(10, 100);
         loop {
             while let Some(sample) = consumer.pop() {
-                if let Some(bw) = buf_writer.as_mut() {
-                    let f: *const f32 = &sample;
-                    let p: *const u8 = f as _;
-                    let buf = unsafe { slice::from_raw_parts(p, 4) };
-                    let _ = bw.write(buf);
-                }
                 if let Some(output) = framer.frame(sample) {
                     let loudness = match output.loudness.mul(1000.0) {
                         x if x >= 127.0 => 127,

--- a/extensions/warp-blink-wrtc/src/host_media/audio/recorder.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/recorder.rs
@@ -1,4 +1,0 @@
-// todo: audio recorder
-// use separate thread and global channels. sent RTP Samples over the channels, along with the peer id.
-// need to use the timestamps to ensure each file is time synchronized.
-// save in .wav format, using the Hound crate.

--- a/extensions/warp-blink-wrtc/src/host_media/audio/recorder.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/recorder.rs
@@ -1,0 +1,4 @@
+// todo: audio recorder
+// use separate thread and global channels. sent RTP Samples over the channels, along with the peer id.
+// need to use the timestamps to ensure each file is time synchronized.
+// save in .wav format, using the Hound crate.

--- a/extensions/warp-blink-wrtc/src/host_media/audio/speech.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/speech.rs
@@ -1,0 +1,35 @@
+/// processes the loudness level from RTP packets. This value is a u8.
+/// it is created by taking the output of loudness::Calculator (a float), multiplying it by 1000, and casting it as a u8, saturating at 127.
+/// it seems that values >= 10 could be speech.
+///
+/// each RTP packet has a frame size which spans some timeframe, usually 10 or 20 milliseconds.
+/// delay is measured in frames.
+pub struct Detector {
+    min_delay_between_events: usize,
+    remaining_delay: usize,
+    speech_threshold: u8,
+}
+
+impl Detector {
+    pub fn new(speech_threshold: u8, min_delay: usize) -> Self {
+        Self {
+            min_delay_between_events: min_delay,
+            remaining_delay: 0,
+            speech_threshold,
+        }
+    }
+
+    pub fn should_emit_event(&mut self, sample: u8) -> bool {
+        if self.remaining_delay > 0 {
+            self.remaining_delay -= 1;
+            return false;
+        }
+
+        if sample >= self.speech_threshold {
+            self.remaining_delay = self.min_delay_between_events;
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -67,6 +67,7 @@ pub async fn has_audio_source() -> bool {
 // webrtc should remove the old media source before this is called.
 // use AUDIO_SOURCE_ID
 pub async fn create_audio_source_track(
+    event_ch: broadcast::Sender<BlinkEventKind>,
     track: Arc<TrackLocalStaticRTP>,
     webrtc_codec: blink::AudioCodec,
     source_codec: blink::AudioCodec,
@@ -79,8 +80,9 @@ pub async fn create_audio_source_track(
         }
     };
 
-    let source_track = create_source_track(input_device, track, webrtc_codec, source_codec)
-        .map_err(|e| anyhow::anyhow!("{e}: failed to create source track"))?;
+    let source_track =
+        create_source_track(event_ch, input_device, track, webrtc_codec, source_codec)
+            .map_err(|e| anyhow::anyhow!("{e}: failed to create source track"))?;
     source_track
         .play()
         .map_err(|e| anyhow::anyhow!("{e}: failed to play source track"))?;

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -114,7 +114,13 @@ pub async fn create_audio_sink_track(
         }
     };
 
-    let sink_track = create_sink_track(output_device, track, webrtc_codec, sink_codec)?;
+    let sink_track = create_sink_track(
+        peer_id.clone(),
+        output_device,
+        track,
+        webrtc_codec,
+        sink_codec,
+    )?;
     sink_track.play()?;
     unsafe {
         DATA.audio_sink_tracks.insert(peer_id, sink_track);

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -7,8 +7,8 @@ use std::{collections::HashMap, sync::Arc};
 use anyhow::bail;
 use cpal::traits::{DeviceTrait, HostTrait};
 use once_cell::sync::Lazy;
-use tokio::sync::RwLock;
-use warp::blink::{self};
+use tokio::sync::{broadcast, RwLock};
+use warp::blink::{self, BlinkEventKind};
 use warp::crypto::DID;
 use webrtc::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
 use webrtc::track::track_remote::TrackRemote;
@@ -101,6 +101,7 @@ pub async fn remove_audio_source_track() -> anyhow::Result<()> {
 
 pub async fn create_audio_sink_track(
     peer_id: DID,
+    event_ch: broadcast::Sender<BlinkEventKind>,
     track: Arc<TrackRemote>,
     // the format to decode to. Opus supports encoding and decoding to arbitrary sample rates and number of channels.
     webrtc_codec: blink::AudioCodec,
@@ -116,6 +117,7 @@ pub async fn create_audio_sink_track(
 
     let sink_track = create_sink_track(
         peer_id.clone(),
+        event_ch,
         output_device,
         track,
         webrtc_codec,

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -373,6 +373,7 @@ async fn handle_call_initiation(
             InitiationSignal::Offer { call_info } => {
                 let evt = BlinkEventKind::IncomingCall {
                     call_id: call_info.call_id(),
+                    conversation_id: call_info.conversation_id(),
                     sender,
                     participants: call_info.participants(),
                 };
@@ -730,7 +731,7 @@ impl Blink for BlinkImpl {
         conversation_id: Option<Uuid>,
         mut participants: Vec<DID>,
         webrtc_codec: AudioCodec,
-    ) -> Result<(), Error> {
+    ) -> Result<Uuid, Error> {
         if self.ipfs.read().await.is_none() {
             return Err(Error::OtherWithContext(
                 "received signal before blink is initialized".into(),
@@ -793,7 +794,7 @@ impl Blink for BlinkImpl {
                 log::error!("failed to send signal: {e}");
             }
         }
-        Ok(())
+        Ok(call_info.call_id())
     }
     /// accept/join a call. Automatically send and receive audio
     async fn answer_call(&mut self, call_id: Uuid) -> Result<(), Error> {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -875,7 +875,7 @@ impl Blink for BlinkImpl {
     async fn disable_camera(&mut self) -> Result<(), Error> {
         todo!()
     }
-    async fn record_call(&mut self, output_dir: &str) -> Result<(), Error> {
+    async fn record_call(&mut self, _output_dir: &str) -> Result<(), Error> {
         todo!()
     }
     async fn stop_recording(&mut self) -> Result<(), Error> {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -652,21 +652,21 @@ async fn handle_webrtc(params: WebRtcHandlerParams, mut webrtc_event_stream: Web
                             EmittedEvents::CallInitiated { dest, sdp } => {
                                 let topic = ipfs_routes::peer_signal_route(&dest, &call_id);
                                 let signal = PeerSignal::Dial(*sdp);
-                                if let Err(e) = send_signal_ecdh(&ipfs, &own_id, &dest, signal, topic).await {
+                                if let Err(e) = send_signal_ecdh(ipfs, own_id, &dest, signal, topic).await {
                                     log::error!("failed to send signal: {e}");
                                 }
                             }
                             EmittedEvents::Sdp { dest, sdp } => {
                                 let topic = ipfs_routes::peer_signal_route(&dest, &call_id);
                                 let signal = PeerSignal::Sdp(*sdp);
-                                if let Err(e) = send_signal_ecdh(&ipfs, &own_id, &dest, signal, topic).await {
+                                if let Err(e) = send_signal_ecdh(ipfs, own_id, &dest, signal, topic).await {
                                     log::error!("failed to send signal: {e}");
                                 }
                             }
                             EmittedEvents::Ice { dest, candidate } => {
                                let topic = ipfs_routes::peer_signal_route(&dest, &call_id);
                                let signal = PeerSignal::Ice(*candidate);
-                                if let Err(e) = send_signal_ecdh(&ipfs, &own_id, &dest, signal, topic).await {
+                                if let Err(e) = send_signal_ecdh(ipfs, own_id, &dest, signal, topic).await {
                                     log::error!("failed to send signal: {e}");
                                 }
                             }
@@ -753,7 +753,7 @@ impl Blink for BlinkImpl {
                 }
             };
 
-            if !participants.contains(&own_id) {
+            if !participants.contains(own_id) {
                 participants.push(DID::from_str(&own_id.fingerprint())?);
             };
         }
@@ -788,7 +788,7 @@ impl Blink for BlinkImpl {
                 call_info: call_info.clone(),
             };
 
-            if let Err(e) = send_signal_ecdh(&ipfs, &own_id, &dest, signal, topic).await {
+            if let Err(e) = send_signal_ecdh(ipfs, own_id, &dest, signal, topic).await {
                 log::error!("failed to send signal: {e}");
             }
         }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -875,7 +875,7 @@ impl Blink for BlinkImpl {
     async fn disable_camera(&mut self) -> Result<(), Error> {
         todo!()
     }
-    async fn record_call(&mut self, _output_file: &str) -> Result<(), Error> {
+    async fn record_call(&mut self, output_dir: &str) -> Result<(), Error> {
         todo!()
     }
     async fn stop_recording(&mut self) -> Result<(), Error> {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -230,8 +230,13 @@ impl BlinkImpl {
             .await
             .add_media_source(host_media::AUDIO_SOURCE_ID.into(), rtc_rtp_codec)
             .await?;
-        host_media::create_audio_source_track(track, call.codec(), audio_source_codec.clone())
-            .await?;
+        host_media::create_audio_source_track(
+            self.ui_event_ch.clone(),
+            track,
+            call.codec(),
+            audio_source_codec.clone(),
+        )
+        .await?;
 
         // next, create event streams and pass them to a task
         let call_signaling_stream = self

--- a/extensions/warp-blink-wrtc/src/simple_webrtc/mod.rs
+++ b/extensions/warp-blink-wrtc/src/simple_webrtc/mod.rs
@@ -34,7 +34,6 @@ use webrtc::interceptor::registry::Registry;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::RTCPeerConnection;
-use webrtc::rtp::extension::HeaderExtension;
 use webrtc::rtp_transceiver::rtp_codec::{RTCRtpCodecParameters, RTPCodecType};
 use webrtc::rtp_transceiver::rtp_transceiver_direction::RTCRtpTransceiverDirection;
 use webrtc::sdp::extmap::AUDIO_LEVEL_URI;

--- a/extensions/warp-blink-wrtc/src/simple_webrtc/mod.rs
+++ b/extensions/warp-blink-wrtc/src/simple_webrtc/mod.rs
@@ -34,7 +34,10 @@ use webrtc::interceptor::registry::Registry;
 use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::RTCPeerConnection;
+use webrtc::rtp::extension::HeaderExtension;
 use webrtc::rtp_transceiver::rtp_codec::{RTCRtpCodecParameters, RTPCodecType};
+use webrtc::rtp_transceiver::rtp_transceiver_direction::RTCRtpTransceiverDirection;
+use webrtc::sdp::extmap::AUDIO_LEVEL_URI;
 
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
@@ -510,6 +513,15 @@ impl Controller {
 // todo: add support for more codecs. perhaps make it configurable
 fn create_api() -> Result<webrtc::api::API> {
     let mut media = MediaEngine::default();
+
+    media.register_header_extension(
+        webrtc::rtp_transceiver::rtp_codec::RTCRtpHeaderExtensionCapability {
+            uri: AUDIO_LEVEL_URI.into(),
+        },
+        RTPCodecType::Audio,
+        Some(RTCRtpTransceiverDirection::Sendrecv),
+    )?;
+
     media.register_codec(
         RTCRtpCodecParameters {
             capability: RTCRtpCodecCapability {

--- a/tools/audio-codec-cli/Cargo.toml
+++ b/tools/audio-codec-cli/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 bytes = "1.4.0"
+bs1770 = "1.0.0"
 clap = { version = "4.0", features = ["derive"] }
 cpal = "0.15.0"
 log = { version = "0.4.17", features = ["std"]}

--- a/tools/audio-codec-cli/src/loudness.rs
+++ b/tools/audio-codec-cli/src/loudness.rs
@@ -17,12 +17,11 @@ pub fn calculate_loudness_bs177(
     let mut output_file = File::create(output_file_name)?;
     let mut loudness_meter = bs1770::ChannelLoudnessMeter::new(args.sample_rate);
     let header = "loudness\n";
-    output_file.write(header.as_bytes())?;
+    let _ = output_file.write(header.as_bytes())?;
     let mut buf = [0_f32; 48000];
     let bp: *mut u8 = buf.as_mut_ptr() as _;
-    let mut bs: &mut [u8] =
-        unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
-    while let Ok(len) = input_file.read(&mut bs) {
+    let bs: &mut [u8] = unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
+    while let Ok(len) = input_file.read(bs) {
         if len == 0 {
             break;
         }
@@ -32,7 +31,7 @@ pub fn calculate_loudness_bs177(
         if loudness.is_some() {
             for sample in loudness_meter.as_100ms_windows().inner {
                 let s = format!("{}\n", sample.loudness_lkfs());
-                output_file.write(s.as_bytes())?;
+                let _ = output_file.write(s.as_bytes())?;
             }
             // reset the algorithm
             loudness_meter = bs1770::ChannelLoudnessMeter::new(args.sample_rate);
@@ -47,13 +46,12 @@ pub fn calculate_loudness_rms(input_file_name: &str, output_file_name: &str) -> 
     let mut input_file = File::open(input_file_name)?;
     let mut output_file = File::create(output_file_name)?;
     let header = "loudness\n";
-    output_file.write(header.as_bytes())?;
+    let _ = output_file.write(header.as_bytes())?;
     // 100 ms samples, for easy comparison with bs177
     let mut buf = [0_f32; 4800];
     let bp: *mut u8 = buf.as_mut_ptr() as _;
-    let mut bs: &mut [u8] =
-        unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
-    while let Ok(len) = input_file.read(&mut bs) {
+    let bs: &mut [u8] = unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
+    while let Ok(len) = input_file.read(bs) {
         if len == 0 {
             break;
         }
@@ -66,7 +64,7 @@ pub fn calculate_loudness_rms(input_file_name: &str, output_file_name: &str) -> 
         sum = sum.div(num_samples as f32);
         sum = f32::sqrt(sum);
         let s = format!("{}\n", sum);
-        output_file.write(s.as_bytes())?;
+        let _ = output_file.write(s.as_bytes())?;
     }
 
     println!("finished calculating loudness");
@@ -110,13 +108,12 @@ pub fn calculate_loudness_rms2(
     let mut output_file = File::create(output_file_name)?;
     let mut loudness_calculator = LoudnessCalculator::new();
     let header = "loudness\n";
-    output_file.write(header.as_bytes())?;
+    let _ = output_file.write(header.as_bytes())?;
     // 100 ms samples, for easy comparison with bs177
     let mut buf = [0_f32; 4800];
     let bp: *mut u8 = buf.as_mut_ptr() as _;
-    let mut bs: &mut [u8] =
-        unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
-    while let Ok(len) = input_file.read(&mut bs) {
+    let bs: &mut [u8] = unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
+    while let Ok(len) = input_file.read(bs) {
         if len == 0 {
             break;
         }
@@ -125,7 +122,7 @@ pub fn calculate_loudness_rms2(
             loudness_calculator.insert(*sample);
         }
         let s = format!("{}\n", loudness_calculator.get_rms());
-        output_file.write(s.as_bytes())?;
+        let _ = output_file.write(s.as_bytes())?;
     }
 
     println!("finished calculating loudness");

--- a/tools/audio-codec-cli/src/loudness.rs
+++ b/tools/audio-codec-cli/src/loudness.rs
@@ -43,11 +43,7 @@ pub fn calculate_loudness_bs177(
     Ok(())
 }
 
-pub fn calculate_loudness_rms(
-    args: StaticArgs,
-    input_file_name: &str,
-    output_file_name: &str,
-) -> anyhow::Result<()> {
+pub fn calculate_loudness_rms(input_file_name: &str, output_file_name: &str) -> anyhow::Result<()> {
     let mut input_file = File::open(input_file_name)?;
     let mut output_file = File::create(output_file_name)?;
     let header = "loudness\n";
@@ -79,7 +75,7 @@ pub fn calculate_loudness_rms(
 
 // reminds me of C code
 struct LoudnessCalculator {
-    buf: [f32; 4800],
+    buf: [f32; 480],
     // sum of squares
     ss: f32,
     idx: usize,
@@ -89,7 +85,7 @@ struct LoudnessCalculator {
 impl LoudnessCalculator {
     fn new() -> Self {
         Self {
-            buf: [0.0; 4800],
+            buf: [0.0; 480],
             ss: 0.0,
             idx: 0,
             len: 0,
@@ -107,7 +103,7 @@ impl LoudnessCalculator {
         }
 
         self.ss += sq;
-        self.idx = (self.idx + 1) % 4800;
+        self.idx = (self.idx + 1) % self.buf.len();
     }
 
     fn get_rms(&self) -> f32 {
@@ -125,7 +121,7 @@ pub fn calculate_loudness_rms2(
     let header = "loudness\n";
     output_file.write(header.as_bytes())?;
     // 100 ms samples, for easy comparison with bs177
-    let mut buf = [0_f32; 4800];
+    let mut buf = [0_f32; 480];
     let bp: *mut u8 = buf.as_mut_ptr() as _;
     let mut bs: &mut [u8] =
         unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };

--- a/tools/audio-codec-cli/src/loudness.rs
+++ b/tools/audio-codec-cli/src/loudness.rs
@@ -1,0 +1,146 @@
+use std::{
+    fs::File,
+    io::{Read, Write},
+    mem,
+    ops::Div,
+    slice,
+};
+
+use crate::StaticArgs;
+
+pub fn calculate_loudness_bs177(
+    args: StaticArgs,
+    input_file_name: &str,
+    output_file_name: &str,
+) -> anyhow::Result<()> {
+    let mut input_file = File::open(input_file_name)?;
+    let mut output_file = File::create(output_file_name)?;
+    let mut loudness_meter = bs1770::ChannelLoudnessMeter::new(args.sample_rate);
+    let header = "loudness\n";
+    output_file.write(header.as_bytes())?;
+    let mut buf = [0_f32; 48000];
+    let bp: *mut u8 = buf.as_mut_ptr() as _;
+    let mut bs: &mut [u8] =
+        unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
+    while let Ok(len) = input_file.read(&mut bs) {
+        if len == 0 {
+            break;
+        }
+        let num_samples = len / mem::size_of::<f32>();
+        loudness_meter.push(buf[0..num_samples].iter().cloned());
+        let loudness = loudness_meter.as_100ms_windows().inner.iter().last();
+        if loudness.is_some() {
+            for sample in loudness_meter.as_100ms_windows().inner {
+                let s = format!("{}\n", sample.loudness_lkfs());
+                output_file.write(s.as_bytes())?;
+            }
+            // reset the algorithm
+            loudness_meter = bs1770::ChannelLoudnessMeter::new(args.sample_rate);
+        }
+    }
+
+    println!("finished calculating loudness");
+    Ok(())
+}
+
+pub fn calculate_loudness_rms(
+    args: StaticArgs,
+    input_file_name: &str,
+    output_file_name: &str,
+) -> anyhow::Result<()> {
+    let mut input_file = File::open(input_file_name)?;
+    let mut output_file = File::create(output_file_name)?;
+    let header = "loudness\n";
+    output_file.write(header.as_bytes())?;
+    // 100 ms samples, for easy comparison with bs177
+    let mut buf = [0_f32; 4800];
+    let bp: *mut u8 = buf.as_mut_ptr() as _;
+    let mut bs: &mut [u8] =
+        unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
+    while let Ok(len) = input_file.read(&mut bs) {
+        if len == 0 {
+            break;
+        }
+        let num_samples = len / mem::size_of::<f32>();
+        let mut sum = 0_f32;
+        for sample in buf[0..num_samples].iter() {
+            let sq = sample * sample;
+            sum += sq;
+        }
+        sum = sum.div(num_samples as f32);
+        sum = f32::sqrt(sum);
+        let s = format!("{}\n", sum);
+        output_file.write(s.as_bytes())?;
+    }
+
+    println!("finished calculating loudness");
+    Ok(())
+}
+
+// reminds me of C code
+struct LoudnessCalculator {
+    buf: [f32; 4800],
+    // sum of squares
+    ss: f32,
+    idx: usize,
+    len: usize,
+}
+
+impl LoudnessCalculator {
+    fn new() -> Self {
+        Self {
+            buf: [0.0; 4800],
+            ss: 0.0,
+            idx: 0,
+            len: 0,
+        }
+    }
+    fn insert(&mut self, sample: f32) {
+        let sq = sample * sample;
+
+        if self.len < 4800 {
+            self.len += 1;
+            self.buf[self.idx] = sq;
+        } else {
+            self.ss -= self.buf[self.idx];
+            self.buf[self.idx] = sq;
+        }
+
+        self.ss += sq;
+        self.idx = (self.idx + 1) % 4800;
+    }
+
+    fn get_rms(&self) -> f32 {
+        f32::sqrt(self.ss.div(self.len as f32))
+    }
+}
+
+pub fn calculate_loudness_rms2(
+    input_file_name: &str,
+    output_file_name: &str,
+) -> anyhow::Result<()> {
+    let mut input_file = File::open(input_file_name)?;
+    let mut output_file = File::create(output_file_name)?;
+    let mut loudness_calculator = LoudnessCalculator::new();
+    let header = "loudness\n";
+    output_file.write(header.as_bytes())?;
+    // 100 ms samples, for easy comparison with bs177
+    let mut buf = [0_f32; 4800];
+    let bp: *mut u8 = buf.as_mut_ptr() as _;
+    let mut bs: &mut [u8] =
+        unsafe { slice::from_raw_parts_mut(bp, mem::size_of::<f32>() * buf.len()) };
+    while let Ok(len) = input_file.read(&mut bs) {
+        if len == 0 {
+            break;
+        }
+        let num_samples = len / mem::size_of::<f32>();
+        for sample in buf[0..num_samples].iter() {
+            loudness_calculator.insert(*sample);
+        }
+        let s = format!("{}\n", loudness_calculator.get_rms());
+        output_file.write(s.as_bytes())?;
+    }
+
+    println!("finished calculating loudness");
+    Ok(())
+}

--- a/tools/audio-codec-cli/src/main.rs
+++ b/tools/audio-codec-cli/src/main.rs
@@ -11,6 +11,7 @@ use tokio::sync::Mutex;
 
 mod encode;
 mod feedback;
+mod loudness;
 mod packetizer;
 mod play;
 mod record;
@@ -75,6 +76,19 @@ enum Cli {
     Play {
         file_name: String,
         sample_rate: Option<u32>,
+    },
+    LoudnessBs177 {
+        input_file_name: String,
+        output_file_name: String,
+    },
+    LoudnessRms {
+        input_file_name: String,
+        output_file_name: String,
+    },
+    /// basically a moving average filter
+    LoudnessRms2 {
+        input_file_name: String,
+        output_file_name: String,
     },
     /// print the current config
     ShowConfig,
@@ -285,6 +299,18 @@ Frame size (in samples) vs duration for various sampling rates:
             }
         }
         Cli::ShowConfig => println!("{:#?}", sm),
+        Cli::LoudnessBs177 {
+            input_file_name,
+            output_file_name,
+        } => loudness::calculate_loudness_bs177(sm.clone(), &input_file_name, &output_file_name)?,
+        Cli::LoudnessRms {
+            input_file_name,
+            output_file_name,
+        } => loudness::calculate_loudness_rms(sm.clone(), &input_file_name, &output_file_name)?,
+        Cli::LoudnessRms2 {
+            input_file_name,
+            output_file_name,
+        } => loudness::calculate_loudness_rms2(&input_file_name, &output_file_name)?,
         Cli::Feedback => feedback::feedback(sm.clone()).await?,
     }
     Ok(())

--- a/tools/audio-codec-cli/src/main.rs
+++ b/tools/audio-codec-cli/src/main.rs
@@ -306,7 +306,7 @@ Frame size (in samples) vs duration for various sampling rates:
         Cli::LoudnessRms {
             input_file_name,
             output_file_name,
-        } => loudness::calculate_loudness_rms(sm.clone(), &input_file_name, &output_file_name)?,
+        } => loudness::calculate_loudness_rms(&input_file_name, &output_file_name)?,
         Cli::LoudnessRms2 {
             input_file_name,
             output_file_name,

--- a/tools/audio-codec-cli/src/main.rs
+++ b/tools/audio-codec-cli/src/main.rs
@@ -77,10 +77,12 @@ enum Cli {
         file_name: String,
         sample_rate: Option<u32>,
     },
+    /// calculates loudness in 100ms intervals using the bs177 algorithm
     LoudnessBs177 {
         input_file_name: String,
         output_file_name: String,
     },
+    /// calculates loudness in 100ms intervals using root mean square
     LoudnessRms {
         input_file_name: String,
         output_file_name: String,

--- a/tools/audio-codec-cli/src/main.rs
+++ b/tools/audio-codec-cli/src/main.rs
@@ -87,7 +87,7 @@ enum Cli {
         input_file_name: String,
         output_file_name: String,
     },
-    /// basically a moving average filter
+    /// basically a moving average filter.
     LoudnessRms2 {
         input_file_name: String,
         output_file_name: String,

--- a/tools/blink-webrtc-cli/src/main.rs
+++ b/tools/blink-webrtc-cli/src/main.rs
@@ -238,6 +238,7 @@ async fn handle_event_stream(mut stream: BlinkEventStream) -> anyhow::Result<()>
         match evt {
             BlinkEventKind::IncomingCall {
                 call_id,
+                conversation_id: _,
                 sender,
                 participants: _,
             } => {

--- a/tools/blink-webrtc-cli/src/main.rs
+++ b/tools/blink-webrtc-cli/src/main.rs
@@ -237,6 +237,12 @@ async fn handle_event_stream(mut stream: BlinkEventStream) -> anyhow::Result<()>
                 println!("incoming call. id is: {call_id}. sender is: {sender}");
                 lock.replace(call_id);
             }
+            BlinkEventKind::ParticipantSpeaking { peer_id } => {
+                println!("participant is speaking: {}", peer_id);
+            }
+            BlinkEventKind::SelfSpeaking => {
+                println!("you are speaking");
+            }
             _ => {}
         }
     }

--- a/tools/blink-webrtc-cli/src/main.rs
+++ b/tools/blink-webrtc-cli/src/main.rs
@@ -237,12 +237,6 @@ async fn handle_event_stream(mut stream: BlinkEventStream) -> anyhow::Result<()>
                 println!("incoming call. id is: {call_id}. sender is: {sender}");
                 lock.replace(call_id);
             }
-            BlinkEventKind::ParticipantSpeaking { peer_id } => {
-                println!("participant is speaking: {}", peer_id);
-            }
-            BlinkEventKind::SelfSpeaking => {
-                println!("you are speaking");
-            }
             _ => {}
         }
     }

--- a/tools/blink-webrtc-cli/src/main.rs
+++ b/tools/blink-webrtc-cli/src/main.rs
@@ -99,6 +99,10 @@ enum Repl {
     ShowInputConfig,
     /// show the default output config
     ShowOutputConfig,
+    /// separately record audio of each participant
+    RecordAudio { output_dir: String },
+    /// stop recording audio
+    StopRecording,
 }
 
 async fn handle_command(
@@ -219,6 +223,8 @@ async fn handle_command(
                 blink.get_audio_sink_codec().await
             );
         }
+        Repl::RecordAudio { output_dir } => blink.record_call(&output_dir).await?,
+        Repl::StopRecording => blink.stop_recording().await?,
     }
     Ok(())
 }

--- a/tools/blink-webrtc-cli/src/main.rs
+++ b/tools/blink-webrtc-cli/src/main.rs
@@ -117,7 +117,9 @@ async fn handle_command(
         Repl::Dial { id } => {
             let did = DID::from_str(&id)?;
             let codecs = CODECS.read().await;
-            blink.offer_call(vec![did], codecs.webrtc.clone()).await?;
+            blink
+                .offer_call(None, vec![did], codecs.webrtc.clone())
+                .await?;
         }
         Repl::Answer { id } => {
             let mut lock = OFFERED_CALL.lock().await;

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -109,11 +109,14 @@ pub enum BlinkEventKind {
     ParticipantLeft { call_id: Uuid, peer_id: DID },
     /// A participant is speaking
     #[display(fmt = "ParticipantSpeaking")]
-    ParticipantSpeaking { call_id: Uuid, peer_id: DID },
+    ParticipantSpeaking { peer_id: DID },
     // todo: maybe don't use this event and just use a timeout.
     /// A participant stopped speaking
     #[display(fmt = "ParticipantNotSpeaking")]
-    ParticipantNotSpeaking { call_id: Uuid, peer_id: DID },
+    ParticipantNotSpeaking { peer_id: DID },
+    /// audio packets were dropped for the peer
+    #[display(fmt = "AudioDegredation")]
+    AudioDegredation { peer_id: DID },
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -105,23 +105,12 @@ pub enum BlinkEventKind {
         // the total set of participants who are invited to the call
         participants: Vec<DID>,
     },
-    /// A call has been offered
-    #[display(fmt = "CallOffered")]
-    CallOffered {
-        call_id: Uuid,
-        participants: Vec<DID>,
-    },
-    /// You accepted the call
-    CallAccepted { call_id: Uuid },
     /// Someone joined the call
     #[display(fmt = "ParticipantJoined")]
     ParticipantJoined { call_id: Uuid, peer_id: DID },
     /// Someone left the call
     #[display(fmt = "ParticipantLeft")]
     ParticipantLeft { call_id: Uuid, peer_id: DID },
-    /// You left the call
-    #[display(fmt = "LeftCall")]
-    LeftCall { call_id: Uuid },
     /// A participant is speaking
     #[display(fmt = "ParticipantSpeaking")]
     ParticipantSpeaking { peer_id: DID },

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -92,7 +92,7 @@ pub trait Blink: Sync + Send {
 /// Drives the UI
 #[derive(Clone, Display)]
 pub enum BlinkEventKind {
-    /// A call has been offered
+    /// A call is being offered
     #[display(fmt = "IncomingCall")]
     IncomingCall {
         call_id: Uuid,
@@ -101,12 +101,23 @@ pub enum BlinkEventKind {
         // the total set of participants who are invited to the call
         participants: Vec<DID>,
     },
+    /// A call has been offered
+    #[display(fmt = "CallOffered")]
+    CallOffered {
+        call_id: Uuid,
+        participants: Vec<DID>,
+    },
+    /// You accepted the call
+    CallAccepted { call_id: Uuid },
     /// Someone joined the call
     #[display(fmt = "ParticipantJoined")]
     ParticipantJoined { call_id: Uuid, peer_id: DID },
     /// Someone left the call
     #[display(fmt = "ParticipantLeft")]
     ParticipantLeft { call_id: Uuid, peer_id: DID },
+    /// You left the call
+    #[display(fmt = "LeftCall")]
+    LeftCall { call_id: Uuid },
     /// A participant is speaking
     #[display(fmt = "ParticipantSpeaking")]
     ParticipantSpeaking { peer_id: DID },

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -32,7 +32,7 @@ use crate::{
 // todo: add functions for screen sharing
 /// Provides teleconferencing capabilities
 #[async_trait]
-pub trait Blink {
+pub trait Blink: Sync + Send {
     // ------ Misc ------
     /// The event stream notifies the UI of call related events
     async fn get_event_stream(&mut self) -> Result<BlinkEventStream, Error>;

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -110,10 +110,8 @@ pub enum BlinkEventKind {
     /// A participant is speaking
     #[display(fmt = "ParticipantSpeaking")]
     ParticipantSpeaking { peer_id: DID },
-    // todo: maybe don't use this event and just use a timeout.
-    /// A participant stopped speaking
-    #[display(fmt = "ParticipantNotSpeaking")]
-    ParticipantNotSpeaking { peer_id: DID },
+    #[display(fmt = "SelfSpeaking")]
+    SelfSpeaking,
     /// audio packets were dropped for the peer
     #[display(fmt = "AudioDegredation")]
     AudioDegredation { peer_id: DID },

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -75,7 +75,7 @@ pub trait Blink {
     async fn unmute_self(&mut self) -> Result<(), Error>;
     async fn enable_camera(&mut self) -> Result<(), Error>;
     async fn disable_camera(&mut self) -> Result<(), Error>;
-    async fn record_call(&mut self, output_file: &str) -> Result<(), Error>;
+    async fn record_call(&mut self, output_dir: &str) -> Result<(), Error>;
     async fn stop_recording(&mut self) -> Result<(), Error>;
 
     async fn get_audio_source_codec(&self) -> AudioCodec;

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -45,6 +45,7 @@ pub trait Blink: Sync + Send + SingleHandle + DynClone {
     /// cannot offer a call if another call is in progress.
     /// During a call, WebRTC connections should only be made to
     /// peers included in the Vec<DID>.
+    /// returns the Uuid of the call
     async fn offer_call(
         &mut self,
         // May want to associate a call with a RayGun conversation.
@@ -52,7 +53,7 @@ pub trait Blink: Sync + Send + SingleHandle + DynClone {
         conversation_id: Option<Uuid>,
         participants: Vec<DID>,
         webrtc_codec: AudioCodec,
-    ) -> Result<(), Error>;
+    ) -> Result<Uuid, Error>;
     /// accept/join a call. Automatically send and receive audio
     async fn answer_call(&mut self, call_id: Uuid) -> Result<(), Error>;
     /// notify a sender/group that you will not join a call
@@ -103,6 +104,7 @@ pub enum BlinkEventKind {
     #[display(fmt = "IncomingCall")]
     IncomingCall {
         call_id: Uuid,
+        conversation_id: Option<Uuid>,
         // the person who is offering you to join the call
         sender: DID,
         // the total set of participants who are invited to the call


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
first of all, apologies for branching an unmerged branch and continuing work on it. It made the # of commits look enormous. 

Created the following modules
- loudness: calculates loudness using root mean square. Is optimized to minimize the number of mathematical operations required. 
- speech: uses the output of `loudness` to determine when to emit an event, indicating that someone is speaking. uses the loudness level and the time since the last event was emitted. 

Modified `audio::SinkTrack` and `audio::SourceTrack`
- the `init` function now receives a channel, used to emit `BlinkEvent`s when someone is speaking. 
- also initialized with the peer's id (a `DID`) which is intended to be used when recording audio. I plan to forward the RTP packets to a thread, and the peer id is needed there. 

Misc:
- the audio level is sent via a RTP header extension. I don't have an easy way to expose the `MediaEngine` which is needed to get the identifier correctly. For now there's a hack and a comment which describes how the implementation may be changed in the future. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
