### PR TITLE
feat: Add callback in config for default profile picture

### DIFF
--- a/extensions/warp-mp-ipfs/src/config.rs
+++ b/extensions/warp-mp-ipfs/src/config.rs
@@ -1,6 +1,7 @@
 use ipfs::Multiaddr;
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
+use warp::multipass::identity::Identity;
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -214,7 +215,10 @@ pub enum UpdateEvents {
     Disable,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+pub type DefaultPfpFn =
+    std::sync::Arc<dyn Fn(&Identity) -> Result<Vec<u8>, std::io::Error> + Send + Sync + 'static>;
+
+#[derive(Clone, Serialize, Deserialize)]
 pub struct StoreSetting {
     /// Interval for broadcasting out identity (cannot be less than 3 minutes)
     /// Note:
@@ -243,6 +247,15 @@ pub struct StoreSetting {
     pub update_events: UpdateEvents,
     /// Disable providing images for identities
     pub disable_images: bool,
+    /// Function to call to provide data for a default profile picture if one is not apart of the identity
+    #[serde(skip)]
+    pub default_profile_picture: Option<DefaultPfpFn>,
+}
+
+impl std::fmt::Debug for StoreSetting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StoreSetting").finish()
+    }
 }
 
 impl Default for StoreSetting {
@@ -259,6 +272,7 @@ impl Default for StoreSetting {
             emit_online_event: false,
             update_events: Default::default(),
             disable_images: false,
+            default_profile_picture: None,
         }
     }
 }

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -452,6 +452,7 @@ impl IpfsIdentity {
             tesseract.clone(),
             config.store_setting.auto_push,
             self.tx.clone(),
+            config.store_setting.default_profile_picture.clone(),
             (
                 discovery.clone(),
                 relays,

--- a/extensions/warp-mp-ipfs/src/store/document.rs
+++ b/extensions/warp-mp-ipfs/src/store/document.rs
@@ -131,7 +131,7 @@ impl RootDocument {
                 from_ipld::<IdentityDocument>(ipld)
                     .map_err(anyhow::Error::from)
                     .map_err(Error::from)?
-                    .resolve(ipfs, true)
+                    .resolve(ipfs, true, None)
                     .await?
             }
             Err(_) => return Err(Error::IdentityInvalid),

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -105,6 +105,10 @@ impl IdentityDocument {
             if fallback {
                 if let Some(callback) = callback {
                     let picture = callback(&identity).unwrap_or_default();
+                    // Note: Probably move the callback into a blocking task in case the underlining function make calls that blocks the current thread? 
+                    // let picture = tokio::task::spawn_blocking(move || callback(&owned_identity).unwrap_or_default())
+                    //  .await
+                    //  .unwrap_or_default();
                     if !picture.is_empty() {
                         let buffer = String::from_utf8_lossy(&picture).to_string();
                         identity.set_profile_picture(&buffer);

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -86,7 +86,7 @@ impl IdentityDocument {
         identity.set_short_id(self.short_id);
         identity.set_status_message(self.status_message.clone());
 
-        let mut fallback = false;
+        let mut fallback = true;
 
         if with_image {
             if let Some(cid) = self.profile_picture {
@@ -95,16 +95,11 @@ impl IdentityDocument {
                         let picture: String = serde_json::from_slice(&data).unwrap_or_default();
                         if !picture.is_empty() {
                             identity.set_profile_picture(&picture);
-                        } else {
-                            fallback = true;
+                            fallback = false;
                         }
                     }
-                    Err(_e) => {
-                        fallback = true;
-                    }
+                    Err(_e) => {}
                 }
-            } else {
-                fallback = true;
             }
 
             if fallback {

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -2,7 +2,7 @@
 //onto the lock.
 #![allow(clippy::clone_on_copy)]
 use crate::{
-    config::{Discovery as DiscoveryConfig, UpdateEvents},
+    config::{Discovery as DiscoveryConfig, UpdateEvents, DefaultPfpFn},
     store::{did_to_libp2p_pub, discovery::Discovery, PeerIdExt, PeerTopic, VecExt},
 };
 use futures::{
@@ -94,6 +94,8 @@ pub struct IdentityStore {
     disable_image: bool,
 
     friend_store: Arc<tokio::sync::RwLock<Option<FriendsStore>>>,
+
+    default_pfp_callback: Option<DefaultPfpFn>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -178,6 +180,7 @@ impl IdentityStore {
         tesseract: Tesseract,
         interval: Option<Duration>,
         tx: broadcast::Sender<MultiPassEventKind>,
+        default_pfp_callback: Option<DefaultPfpFn>,
         (discovery, relay, fetch_over_bitswap, share_platform, update_event, disable_image): (
             Discovery,
             Option<Vec<Multiaddr>>,
@@ -225,6 +228,7 @@ impl IdentityStore {
             friend_store,
             update_event,
             disable_image,
+            default_pfp_callback
         };
 
         if store.path.is_some() {
@@ -1434,7 +1438,7 @@ impl IdentityStore {
         // Pin the dag
         self.ipfs.insert_pin(&root_cid, true).await?;
 
-        let identity = identity.resolve(&self.ipfs, false).await?;
+        let identity = identity.resolve(&self.ipfs, false, None).await?;
 
         self.save_cid(root_cid).await?;
         self.update_identity().await?;
@@ -1577,7 +1581,7 @@ impl IdentityStore {
         let list = futures::stream::FuturesUnordered::from_iter(
             idents_docs
                 .iter()
-                .map(|doc| doc.resolve(&self.ipfs, !self.disable_image).boxed()),
+                .map(|doc| doc.resolve(&self.ipfs, !self.disable_image, self.default_pfp_callback.clone()).boxed()),
         )
         .filter_map(|res| async { res.ok() })
         .chain(stream::iter(preidentity))
@@ -1901,7 +1905,7 @@ impl IdentityStore {
         let identity = self
             .get_local_dag::<IdentityDocument>(path)
             .await?
-            .resolve(&ipfs, with_images)
+            .resolve(&ipfs, with_images, self.default_pfp_callback.clone())
             .await?;
 
         let public_key = identity.did_key();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add a configuration option to create a callback function that is called in the event of profile pictures is missing. 

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
N/A

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
When a profile picture is missing and there is an available callback, it will execute that function so the implementation can provide a default profile picture. This can be static content or generated content. Note however that this function should not be used for any explicit IO calls. 