### PR TITLE
chore: Remove enter context

### DIFF
--- a/extensions/warp-fs-ipfs/src/lib.rs
+++ b/extensions/warp-fs-ipfs/src/lib.rs
@@ -365,9 +365,6 @@ impl Constellation for IpfsFileSystem {
         }
 
         let ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         let path = PathBuf::from(path);
         if !path.is_file() {
@@ -541,9 +538,6 @@ impl Constellation for IpfsFileSystem {
 
     async fn get(&self, name: &str, path: &str) -> Result<()> {
         let ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         let item = self.current_directory()?.get_item_by_path(name)?;
         let file = item.get_file()?;
@@ -589,9 +583,6 @@ impl Constellation for IpfsFileSystem {
         }
 
         let ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         if self.current_directory()?.get_item_by_path(name).is_ok() {
             return Err(Error::FileExist);
@@ -670,9 +661,6 @@ impl Constellation for IpfsFileSystem {
 
     async fn get_buffer(&self, name: &str) -> Result<Vec<u8>> {
         let ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         let item = self.current_directory()?.get_item_by_path(name)?;
         let file = item.get_file()?;
@@ -878,10 +866,6 @@ impl Constellation for IpfsFileSystem {
     /// Used to remove data from the filesystem
     async fn remove(&mut self, name: &str, _: bool) -> Result<()> {
         let ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
-
         //TODO: Recursively delete directory but for now only support deleting a file
         let directory = self.current_directory()?;
 
@@ -953,9 +937,6 @@ impl Constellation for IpfsFileSystem {
     async fn rename(&mut self, current: &str, new: &str) -> Result<()> {
         //Used as guard in the event its not available but will be used in the future
         let _ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         //Note: This will only support renaming the file or directory in the index
         let directory = self.current_directory()?;
@@ -979,9 +960,6 @@ impl Constellation for IpfsFileSystem {
     async fn create_directory(&mut self, name: &str, recursive: bool) -> Result<()> {
         //Used as guard in the event its not available but will be used in the future
         let _ipfs = self.ipfs()?;
-        //Used to enter the tokio context
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         let directory = self.current_directory()?;
 
@@ -1002,8 +980,6 @@ impl Constellation for IpfsFileSystem {
 
     async fn sync_ref(&mut self, path: &str) -> Result<()> {
         let ipfs = self.ipfs()?;
-        let handle = warp::async_handle();
-        let _g = handle.enter();
 
         let directory = self.current_directory()?;
         let file = directory


### PR DESCRIPTION
(cherry picked from commit 8a3be76b2c9f640bb791b480750105b1ac31db97)

<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Remove the enter context due to compile errors from a tokio update as well as no longer needed (especially after #222 is resolved)

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- N/A

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
