### PR TITLE
refactor: Decouple images from Identity and into trait functions 

### DIFF
--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -719,12 +719,14 @@ async fn main() -> anyhow::Result<()> {
                             for identity in idents {
                                 let status = account.identity_status(&identity.did_key()).await.unwrap_or(IdentityStatus::Offline);
                                 let platform = account.identity_platform(&identity.did_key()).await.unwrap_or_default();
+                                let profile_picture = account.identity_picture(&identity.did_key()).await.unwrap_or_default();
+                                let profile_banner = account.identity_banner(&identity.did_key()).await.unwrap_or_default();
                                 table.add_row(vec![
                                     identity.username(),
                                     identity.did_key().to_string(),
                                     identity.status_message().unwrap_or_default(),
-                                    (!identity.profile_banner().is_empty()).to_string(),
-                                    (!identity.profile_picture().is_empty()).to_string(),
+                                    (!profile_picture.is_empty()).to_string(),
+                                    (!profile_banner.is_empty()).to_string(),
                                     platform.to_string(),
                                     format!("{status:?}"),
                                 ]);

--- a/extensions/warp-mp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-mp-ipfs/examples/identity-interface.rs
@@ -725,8 +725,8 @@ async fn main() -> anyhow::Result<()> {
                                     identity.username(),
                                     identity.did_key().to_string(),
                                     identity.status_message().unwrap_or_default(),
-                                    (!profile_picture.is_empty()).to_string(),
                                     (!profile_banner.is_empty()).to_string(),
+                                    (!profile_picture.is_empty()).to_string(),
                                     platform.to_string(),
                                     format!("{status:?}"),
                                 ]);

--- a/extensions/warp-mp-ipfs/src/lib.rs
+++ b/extensions/warp-mp-ipfs/src/lib.rs
@@ -649,7 +649,7 @@ impl MultiPass for IpfsIdentity {
             Identifier::DID(pk) => store.lookup(LookupBy::DidKey(pk)).await,
             Identifier::Username(username) => store.lookup(LookupBy::Username(username)).await,
             Identifier::DIDList(list) => store.lookup(LookupBy::DidKeys(list)).await,
-            Identifier::Own => return store.own_identity(true).await.map(|i| vec![i]),
+            Identifier::Own => return store.own_identity().await.map(|i| vec![i]),
         }?;
 
         Ok(idents)
@@ -1014,6 +1014,16 @@ impl FriendsEvent for IpfsIdentity {
 
 #[async_trait::async_trait]
 impl IdentityInformation for IpfsIdentity {
+    async fn identity_picture(&self, did: &DID) -> Result<String, Error> {
+        let store = self.identity_store(true).await?;
+        store.identity_picture(did).await
+    }
+
+    async fn identity_banner(&self, did: &DID) -> Result<String, Error> {
+        let store = self.identity_store(true).await?;
+        store.identity_banner(did).await
+    }
+
     async fn identity_status(&self, did: &DID) -> Result<identity::IdentityStatus, Error> {
         let store = self.identity_store(true).await?;
         store.identity_status(did).await

--- a/extensions/warp-mp-ipfs/src/store/document.rs
+++ b/extensions/warp-mp-ipfs/src/store/document.rs
@@ -131,13 +131,10 @@ impl RootDocument {
             .get(IpfsPath::from(self.identity), &[], true)
             .await
         {
-            Ok(ipld) => {
-                from_ipld::<IdentityDocument>(ipld)
-                    .map_err(anyhow::Error::from)
-                    .map_err(Error::from)?
-                    .resolve(ipfs, true, None)
-                    .await?
-            }
+            Ok(ipld) => from_ipld::<IdentityDocument>(ipld)
+                .map_err(anyhow::Error::from)
+                .map_err(Error::from)?
+                .resolve()?,
             Err(_) => return Err(Error::IdentityInvalid),
         };
 

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -78,48 +78,6 @@ impl IdentityDocument {
         identity.set_did_key(self.did.clone());
         identity.set_short_id(self.short_id);
         identity.set_status_message(self.status_message.clone());
-
-        // let mut fallback = true;
-
-        // if with_image {
-        //     if let Some(cid) = self.profile_picture {
-        //         match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
-        //             Ok(data) => {
-        //                 let picture: String = serde_json::from_slice(&data).unwrap_or_default();
-        //                 if !picture.is_empty() {
-        //                     identity.set_profile_picture(&picture);
-        //                     fallback = false;
-        //                 }
-        //             }
-        //             Err(_e) => {}
-        //         }
-        //     }
-
-        //     if fallback {
-        //         if let Some(callback) = callback {
-        //             let picture = callback(&identity).unwrap_or_default();
-        //             // Note: Probably move the callback into a blocking task in case the underlining function make calls that blocks the current thread?
-        //             // let picture = tokio::task::spawn_blocking(move || callback(&owned_identity).unwrap_or_default())
-        //             //  .await
-        //             //  .unwrap_or_default();
-        //             if !picture.is_empty() {
-        //                 let buffer = String::from_utf8_lossy(&picture).to_string();
-        //                 identity.set_profile_picture(&buffer);
-        //             }
-        //         }
-        //     }
-
-        //     if let Some(cid) = self.profile_banner {
-        //         match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
-        //             Ok(data) => {
-        //                 let picture: String = serde_json::from_slice(&data).unwrap_or_default();
-        //                 identity.set_profile_banner(&picture);
-        //             }
-        //             Err(_e) => {}
-        //         }
-        //     }
-        // }
-
         Ok(identity)
     }
 

--- a/extensions/warp-mp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/document/identity.rs
@@ -9,8 +9,6 @@ use warp::{
     multipass::identity::{Identity, IdentityStatus, Platform, SHORT_ID_SIZE},
 };
 
-use crate::config::DefaultPfpFn;
-
 #[derive(Debug, Clone, Deserialize, Serialize, Eq)]
 pub struct IdentityDocument {
     pub username: String,
@@ -73,12 +71,7 @@ impl IdentityDocument {
 }
 
 impl IdentityDocument {
-    pub async fn resolve(
-        &self,
-        ipfs: &Ipfs,
-        with_image: bool,
-        callback: Option<DefaultPfpFn>,
-    ) -> Result<Identity, Error> {
+    pub fn resolve(&self) -> Result<Identity, Error> {
         self.verify()?;
         let mut identity = Identity::default();
         identity.set_username(&self.username);
@@ -86,46 +79,46 @@ impl IdentityDocument {
         identity.set_short_id(self.short_id);
         identity.set_status_message(self.status_message.clone());
 
-        let mut fallback = true;
+        // let mut fallback = true;
 
-        if with_image {
-            if let Some(cid) = self.profile_picture {
-                match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
-                    Ok(data) => {
-                        let picture: String = serde_json::from_slice(&data).unwrap_or_default();
-                        if !picture.is_empty() {
-                            identity.set_profile_picture(&picture);
-                            fallback = false;
-                        }
-                    }
-                    Err(_e) => {}
-                }
-            }
+        // if with_image {
+        //     if let Some(cid) = self.profile_picture {
+        //         match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
+        //             Ok(data) => {
+        //                 let picture: String = serde_json::from_slice(&data).unwrap_or_default();
+        //                 if !picture.is_empty() {
+        //                     identity.set_profile_picture(&picture);
+        //                     fallback = false;
+        //                 }
+        //             }
+        //             Err(_e) => {}
+        //         }
+        //     }
 
-            if fallback {
-                if let Some(callback) = callback {
-                    let picture = callback(&identity).unwrap_or_default();
-                    // Note: Probably move the callback into a blocking task in case the underlining function make calls that blocks the current thread?
-                    // let picture = tokio::task::spawn_blocking(move || callback(&owned_identity).unwrap_or_default())
-                    //  .await
-                    //  .unwrap_or_default();
-                    if !picture.is_empty() {
-                        let buffer = String::from_utf8_lossy(&picture).to_string();
-                        identity.set_profile_picture(&buffer);
-                    }
-                }
-            }
+        //     if fallback {
+        //         if let Some(callback) = callback {
+        //             let picture = callback(&identity).unwrap_or_default();
+        //             // Note: Probably move the callback into a blocking task in case the underlining function make calls that blocks the current thread?
+        //             // let picture = tokio::task::spawn_blocking(move || callback(&owned_identity).unwrap_or_default())
+        //             //  .await
+        //             //  .unwrap_or_default();
+        //             if !picture.is_empty() {
+        //                 let buffer = String::from_utf8_lossy(&picture).to_string();
+        //                 identity.set_profile_picture(&buffer);
+        //             }
+        //         }
+        //     }
 
-            if let Some(cid) = self.profile_banner {
-                match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
-                    Ok(data) => {
-                        let picture: String = serde_json::from_slice(&data).unwrap_or_default();
-                        identity.set_profile_banner(&picture);
-                    }
-                    Err(_e) => {}
-                }
-            }
-        }
+        //     if let Some(cid) = self.profile_banner {
+        //         match unixfs_fetch(ipfs, cid, None, true, Some(2 * 1024 * 1024)).await {
+        //             Ok(data) => {
+        //                 let picture: String = serde_json::from_slice(&data).unwrap_or_default();
+        //                 identity.set_profile_banner(&picture);
+        //             }
+        //             Err(_e) => {}
+        //         }
+        //     }
+        // }
 
         Ok(identity)
     }

--- a/extensions/warp-mp-ipfs/src/store/identity.rs
+++ b/extensions/warp-mp-ipfs/src/store/identity.rs
@@ -7,8 +7,8 @@ use crate::{
 };
 use futures::{
     channel::{mpsc, oneshot},
-    stream::{self, BoxStream},
-    FutureExt, StreamExt,
+    stream::BoxStream,
+    StreamExt,
 };
 use ipfs::{Ipfs, IpfsPath, Keypair, Multiaddr};
 use libipld::Cid;
@@ -236,7 +236,7 @@ impl IdentityStore {
 
         store.start_root_task().await;
 
-        if let Ok(ident) = store.own_identity(false).await {
+        if let Ok(ident) = store.own_identity().await {
             log::info!("Identity loaded with {}", ident.did_key());
             *store.identity.write().await = Some(ident);
             store.start_event.store(true, Ordering::SeqCst);
@@ -1390,7 +1390,7 @@ impl IdentityStore {
     pub async fn create_identity(&mut self, username: Option<&str>) -> Result<Identity, Error> {
         let raw_kp = self.get_raw_keypair()?;
 
-        if self.own_identity(false).await.is_ok() {
+        if self.own_identity().await.is_ok() {
             return Err(Error::IdentityExist);
         }
 
@@ -1435,7 +1435,7 @@ impl IdentityStore {
         // Pin the dag
         self.ipfs.insert_pin(&root_cid, true).await?;
 
-        let identity = identity.resolve(&self.ipfs, false, None).await?;
+        let identity = identity.resolve()?;
 
         self.save_cid(root_cid).await?;
         self.update_identity().await?;
@@ -1467,7 +1467,7 @@ impl IdentityStore {
             LookupBy::DidKey(pubkey) => {
                 //Maybe we should omit our own key here?
                 if *pubkey == own_did {
-                    return self.own_identity(true).await.map(|i| vec![i]);
+                    return self.own_identity().await.map(|i| vec![i]);
                 }
                 tokio::spawn({
                     let discovery = self.discovery.clone();
@@ -1507,7 +1507,7 @@ impl IdentityStore {
 
                 for pubkey in list {
                     if own_did.eq(pubkey) {
-                        let own_identity = match self.own_identity(true).await {
+                        let own_identity = match self.own_identity().await {
                             Ok(id) => id,
                             Err(_) => continue,
                         };
@@ -1575,18 +1575,12 @@ impl IdentityStore {
                 .collect::<Vec<_>>(),
         };
 
-        let list = futures::stream::FuturesUnordered::from_iter(idents_docs.iter().map(|doc| {
-            doc.resolve(
-                &self.ipfs,
-                !self.disable_image,
-                self.default_pfp_callback.clone(),
-            )
-            .boxed()
-        }))
-        .filter_map(|res| async { res.ok() })
-        .chain(stream::iter(preidentity))
-        .collect::<Vec<_>>()
-        .await;
+        let mut list = idents_docs
+            .iter()
+            .filter_map(|doc| doc.resolve().ok())
+            .collect::<Vec<_>>();
+
+        list.extend(preidentity);
 
         Ok(list)
     }
@@ -1865,16 +1859,14 @@ impl IdentityStore {
         Ok(identity)
     }
 
-    pub async fn own_identity(&self, with_images: bool) -> Result<Identity, Error> {
+    pub async fn own_identity(&self) -> Result<Identity, Error> {
         let root_document = self.get_root_document().await?;
 
-        let ipfs = self.ipfs.clone();
         let path = IpfsPath::from(root_document.identity);
         let identity = self
             .get_local_dag::<IdentityDocument>(path)
             .await?
-            .resolve(&ipfs, with_images, self.default_pfp_callback.clone())
-            .await?;
+            .resolve()?;
 
         let public_key = identity.did_key();
         let kp_public_key = libp2p_pub_to_did(&self.get_keypair()?.public())?;
@@ -1967,6 +1959,76 @@ impl IdentityStore {
     }
 
     #[tracing::instrument(skip(self))]
+    pub async fn identity_picture(&self, did: &DID) -> Result<String, Error> {
+        if self.disable_image {
+            return Err(Error::InvalidIdentityPicture);
+        }
+
+        let document = self
+            .cache()
+            .await
+            .iter()
+            .find(|ident| ident.did == *did)
+            .cloned()
+            .ok_or(Error::IdentityDoesntExist)?;
+
+        let cb = self.default_pfp_callback.clone();
+
+        if let Some(cid) = document.profile_picture {
+            if let Ok(data) = unixfs_fetch(&self.ipfs, cid, None, true, Some(2 * 1024 * 1024)).await
+            {
+                let picture: String = serde_json::from_slice(&data).unwrap_or_default();
+                if !picture.is_empty() {
+                    return Ok(picture);
+                }
+            }
+        }
+
+        if let Some(cb) = cb {
+            let identity = document.resolve()?;
+            let picture = cb(&identity)?;
+            return Ok(String::from_utf8_lossy(&picture).to_string());
+        }
+
+        Err(Error::InvalidIdentityPicture)
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn identity_banner(&self, did: &DID) -> Result<String, Error> {
+        if self.disable_image {
+            return Err(Error::InvalidIdentityBanner);
+        }
+
+        let document = self
+            .cache()
+            .await
+            .iter()
+            .find(|ident| ident.did == *did)
+            .cloned()
+            .ok_or(Error::IdentityDoesntExist)?;
+
+        let cb = self.default_pfp_callback.clone();
+
+        if let Some(cid) = document.profile_banner {
+            if let Ok(data) = unixfs_fetch(&self.ipfs, cid, None, true, Some(2 * 1024 * 1024)).await
+            {
+                let picture: String = serde_json::from_slice(&data).unwrap_or_default();
+                if !picture.is_empty() {
+                    return Ok(picture);
+                }
+            }
+        }
+
+        if let Some(cb) = cb {
+            let identity = document.resolve()?;
+            let picture = cb(&identity)?;
+            return Ok(String::from_utf8_lossy(&picture).to_string());
+        }
+
+        Err(Error::InvalidIdentityBanner)
+    }
+
+    #[tracing::instrument(skip(self))]
     pub async fn delete_photo(&mut self, cid: Cid) -> Result<(), Error> {
         let ipfs = self.ipfs.clone();
 
@@ -2040,7 +2102,7 @@ impl IdentityStore {
     }
 
     pub async fn update_identity(&self) -> Result<(), Error> {
-        let ident = self.own_identity(false).await?;
+        let ident = self.own_identity().await?;
         self.validate_identity(&ident)?;
         *self.identity.write().await = Some(ident);
         Ok(())

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -63,6 +63,10 @@ pub enum Error {
     IdentityDoesntExist,
     #[error("Identity was invalid")]
     IdentityInvalid,
+    #[error("Picture is invalid or unavailable")]
+    InvalidIdentityPicture,
+    #[error("Banner is invalid or unavailable")]
+    InvalidIdentityBanner,
     #[error("Username cannot be updated for identity")]
     CannotUpdateIdentityUsername,
     #[error("Picture cannot be updated for identity")]

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -99,12 +99,6 @@ pub struct Identity {
     /// Public key for the identity
     did_key: DID,
 
-    /// Profile picture
-    profile_picture: String,
-
-    /// Profile banner
-    profile_banner: String,
-
     /// Status message
     status_message: Option<String>,
 
@@ -124,14 +118,6 @@ impl Identity {
 
     pub fn set_did_key(&mut self, pubkey: DID) {
         self.did_key = pubkey
-    }
-
-    pub fn set_profile_picture(&mut self, picture: &str) {
-        self.profile_picture = picture.to_string();
-    }
-
-    pub fn set_profile_banner(&mut self, banner: &str) {
-        self.profile_banner = banner.to_string();
     }
 
     pub fn set_status_message(&mut self, message: Option<String>) {
@@ -154,14 +140,6 @@ impl Identity {
 
     pub fn did_key(&self) -> DID {
         self.did_key.clone()
-    }
-
-    pub fn profile_picture(&self) -> String {
-        self.profile_picture.clone()
-    }
-
-    pub fn profile_banner(&self) -> String {
-        self.profile_banner.clone()
     }
 
     pub fn status_message(&self) -> Option<String> {
@@ -251,40 +229,6 @@ pub mod ffi {
     use std::os::raw::c_char;
 
     use super::Relationship;
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_profile_picture(
-        identity: *const Identity,
-    ) -> *mut c_char {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let identity = &*identity;
-
-        match CString::new(identity.profile_picture()) {
-            Ok(c) => c.into_raw(),
-            Err(_) => std::ptr::null_mut(),
-        }
-    }
-
-    #[allow(clippy::missing_safety_doc)]
-    #[no_mangle]
-    pub unsafe extern "C" fn multipass_identity_profile_banner(
-        identity: *const Identity,
-    ) -> *mut c_char {
-        if identity.is_null() {
-            return std::ptr::null_mut();
-        }
-
-        let identity = &*identity;
-
-        match CString::new(identity.profile_banner()) {
-            Ok(c) => c.into_raw(),
-            Err(_) => std::ptr::null_mut(),
-        }
-    }
 
     #[allow(clippy::missing_safety_doc)]
     #[no_mangle]

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -101,10 +101,6 @@ pub struct Identity {
 
     /// Status message
     status_message: Option<String>,
-
-    /// Signature of the identity
-    #[serde(skip_serializing_if = "Option::is_none")]
-    signature: Option<String>,
 }
 
 impl Identity {
@@ -123,10 +119,6 @@ impl Identity {
     pub fn set_status_message(&mut self, message: Option<String>) {
         self.status_message = message
     }
-
-    pub fn set_signature(&mut self, signature: Option<String>) {
-        self.signature = signature;
-    }
 }
 
 impl Identity {
@@ -144,10 +136,6 @@ impl Identity {
 
     pub fn status_message(&self) -> Option<String> {
         self.status_message.clone()
-    }
-
-    pub fn signature(&self) -> Option<String> {
-        self.signature.clone()
     }
 }
 

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -170,12 +170,12 @@ pub trait FriendsEvent: Sync + Send {
 #[async_trait::async_trait]
 pub trait IdentityInformation: Send + Sync {
     /// Profile picture belonging to the `Identity`
-    async fn profile_picture(&self, _: &DID) -> Result<String, Error> {
+    async fn identity_picture(&self, _: &DID) -> Result<String, Error> {
         Err(Error::Unimplemented)
     }
 
     /// Profile banner belonging to the `Identity`
-    async fn profile_banner(&self, _: &DID) -> Result<String, Error> {
+    async fn identity_banner(&self, _: &DID) -> Result<String, Error> {
         Err(Error::Unimplemented)
     }
 

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -169,6 +169,16 @@ pub trait FriendsEvent: Sync + Send {
 
 #[async_trait::async_trait]
 pub trait IdentityInformation: Send + Sync {
+    /// Profile picture belonging to the `Identity`
+    async fn profile_picture(&self, _: &DID) -> Result<String, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Profile banner belonging to the `Identity`
+    async fn profile_banner(&self, _: &DID) -> Result<String, Error> {
+        Err(Error::Unimplemented)
+    }
+
     /// Identity status to determine if they are online or offline
     async fn identity_status(&self, _: &DID) -> Result<IdentityStatus, Error> {
         Err(Error::Unimplemented)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Introduces `MultiPass::identity_picture` and `MultiPass::identity_banner`
- Removes `Identity::profile_picture` and `Identity::profile_banner`
- Removes unused `Identity::signature` field

**Which issue(s) this PR fixes** 🔨
- Resolves #268 
<!--AP-X-->

**Special notes for reviewers** 🗒️
While this is an external breaking change, the internals are not broken so there would be no need to migrate images at this time. 

**Additional comments** 🎤
This would reduce the size of the `Identity` since the images would no longer be apart of the object but instead can be fetched from a separate function for the given identity. 