### PR TITLE
feat(identity): Local importing and exporting functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Satellite-im/Warp"
 
 [workspace]
 members = ["extensions/*", "warp", "warp/warp-derive", "tools/*"]
-exclude = ["deprecated/*"]
+exclude = ["deprecated/*", "tools/opencv-test"]
 
 [workspace.dependencies]
 

--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -146,16 +146,20 @@ async fn main() -> anyhow::Result<()> {
 
     let (mut account, profile) = account(opt.path.clone(), None, &opt).await?;
 
-    if let Some(profile) = profile {
-        println!("Identity created");
-        if let Some(phrase) = profile.passphrase() {
-            println!("Identity mnemonic phrase: {phrase}");
+    let own_identity = match profile {
+        Some(profile) => {
+            println!("Identity created");
+            if let Some(phrase) = profile.passphrase() {
+                println!("Identity mnemonic phrase: {phrase}");
+            }
+            profile.identity().clone()
         }
-    } else {
-        println!("Obtained identity....");
-    }
+        None => {
+            println!("Obtained identity....");
+            account.get_own_identity().await?
+        }
+    };
 
-    let own_identity = account.get_own_identity().await?;
     println!(
         "Username: {}#{}",
         own_identity.username(),

--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use comfy_table::Table;
 use futures::prelude::*;
 use rustyline_async::{Readline, ReadlineError};
-use warp::crypto::keypair::PhraseType;
 use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -116,9 +115,10 @@ async fn account(
                     .await?;
             }
             _ => {
-                let (phrase, _) = warp::crypto::keypair::generate_keypair(PhraseType::Standard, None)?;
-                println!("Phrase: {phrase}");
-                account.create_identity(username, Some(&phrase)).await?;
+                let profile = account.create_identity(username, None).await?;
+                if let Some(phrase) = profile.passphrase() {
+                    println!("Phrase: {}", phrase);
+                }
             }
         };
     }

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -712,6 +712,7 @@ impl MultiPass for WarpIpfs {
                     phrase,
                     None,
                     self.config.save_phrase,
+                    false,
                 )?;
             }
         }
@@ -1035,6 +1036,7 @@ impl MultiPassImportExport for WarpIpfs {
                     &passphrase,
                     None,
                     self.config.save_phrase,
+                    false,
                 )?;
 
                 self.init_ipfs(
@@ -1068,6 +1070,7 @@ impl MultiPassImportExport for WarpIpfs {
                     &passphrase,
                     None,
                     self.config.save_phrase,
+                    false,
                 )?;
 
                 self.init_ipfs(

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -24,6 +24,7 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+use store::document::ExtractedRootDocument;
 use store::files::FileStore;
 use store::friends::FriendsStore;
 use store::identity::{IdentityStore, LookupBy};
@@ -60,16 +61,18 @@ use warp::crypto::DID;
 use warp::error::Error;
 use warp::multipass::identity::{Identifier, Identity, IdentityUpdate, Relationship};
 use warp::multipass::{
-    identity, Friends, FriendsEvent, IdentityInformation, MultiPass, MultiPassEventKind,
-    MultiPassEventStream,
+    identity, Friends, FriendsEvent, IdentityImportOption, IdentityInformation, ImportLocation,
+    MultiPass, MultiPassEventKind, MultiPassEventStream, MultiPassImportExport,
 };
 
 use crate::config::Bootstrap;
 use crate::store::discovery::Discovery;
+use crate::store::{ecdh_decrypt, ecdh_encrypt};
 
 #[derive(Clone)]
 pub struct WarpIpfs {
     config: Config,
+    identity_guard: Arc<warp::sync::Mutex<()>>,
     ipfs: Arc<RwLock<Option<Ipfs>>>,
     tesseract: Tesseract,
     friend_store: Arc<RwLock<Option<FriendsStore>>>,
@@ -138,7 +141,7 @@ impl WarpIpfs {
         let (raygun_tx, _) = tokio::sync::broadcast::channel(1024);
         let (constellation_tx, _) = tokio::sync::broadcast::channel(1024);
 
-        let mut identity = WarpIpfs {
+        let identity = WarpIpfs {
             config,
             tesseract,
             ipfs: Default::default(),
@@ -147,14 +150,14 @@ impl WarpIpfs {
             message_store: Default::default(),
             file_store: Default::default(),
             initialized: Default::default(),
-
+            identity_guard: Arc::default(),
             multipass_tx,
             raygun_tx,
             constellation_tx,
         };
 
         if !identity.tesseract.is_unlock() {
-            let mut inner = identity.clone();
+            let inner = identity.clone();
             tokio::spawn(async move {
                 let mut stream = inner.tesseract.subscribe();
                 while let Some(event) = stream.next().await {
@@ -170,7 +173,7 @@ impl WarpIpfs {
         Ok(identity)
     }
 
-    async fn initialize_store(&mut self, init: bool) -> anyhow::Result<()> {
+    async fn initialize_store(&self, init: bool) -> anyhow::Result<()> {
         let tesseract = self.tesseract.clone();
 
         if init && self.identity_store.read().is_some() && self.friend_store.read().is_some()
@@ -203,6 +206,13 @@ impl WarpIpfs {
             _ => anyhow::bail!("Unable to initialize store"),
         };
 
+        self.init_ipfs(keypair).await?;
+
+        Ok(())
+    }
+
+    pub(crate) async fn init_ipfs(&self, keypair: Keypair) -> Result<(), Error> {
+        let tesseract = self.tesseract.clone();
         info!(
             "Have keypair with peer id: {}",
             keypair.public().to_peer_id()
@@ -668,6 +678,7 @@ impl MultiPass for WarpIpfs {
         username: Option<&str>,
         passphrase: Option<&str>,
     ) -> Result<DID, Error> {
+        let _g = self.identity_guard.lock();
         info!(
             "create_identity with username: {username:?} and containing passphrase: {}",
             passphrase.is_some()
@@ -677,6 +688,8 @@ impl MultiPass for WarpIpfs {
             info!("Store is initialized with existing identity");
             return Err(Error::IdentityExist);
         }
+
+        // let _g = self.identity_guard.lock();
 
         if let Some(u) = username.map(|u| u.trim()) {
             let username_len = u.len();
@@ -987,6 +1000,57 @@ impl MultiPass for WarpIpfs {
         store.push_to_all().await;
 
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl MultiPassImportExport for WarpIpfs {
+    async fn import_identity(&mut self, option: IdentityImportOption) -> Result<Identity, Error> {
+        if self.initialized.load(Ordering::SeqCst) {
+            return Err(Error::IdentityExist);
+        }
+        let _g = self.identity_guard.lock();
+
+        match option {
+            IdentityImportOption::Locate {
+                location: ImportLocation::Local { path },
+                passphrase,
+            } => {
+                let keypair = warp::crypto::keypair::did_from_mnemonic(&passphrase, None)?;
+                let bytes = tokio::fs::read(path).await?;
+                let decrypted_bundle = ecdh_decrypt(&keypair, None, bytes)?;
+                let exported_document =
+                    serde_json::from_slice::<ExtractedRootDocument>(&decrypted_bundle)?;
+
+                exported_document.verify()?;
+
+                //TODO
+            }
+            IdentityImportOption::Locate {
+                location: ImportLocation::Remote,
+                ..
+            } => return Err(Error::Unimplemented),
+        }
+        unimplemented!()
+    }
+
+    async fn export_identity(&mut self, location: ImportLocation) -> Result<(), Error> {
+        let store = self.identity_store(true).await?;
+        let kp = store.get_keypair_did()?;
+        let ipfs = self.ipfs()?;
+        let document = store.get_root_document().await?;
+
+        let exported = document.export(&ipfs).await?;
+
+        match location {
+            ImportLocation::Local { path } => {
+                let bytes = serde_json::to_vec(&exported)?;
+                let encrypted_bundle = ecdh_encrypt(&kp, None, bytes)?;
+                tokio::fs::write(path, encrypted_bundle).await?;
+                Ok(())
+            }
+            ImportLocation::Remote => return Err(Error::Unimplemented),
+        }
     }
 }
 

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -189,7 +189,7 @@ impl RootDocument {
 
     pub async fn import(ipfs: &Ipfs, data: ExtractedRootDocument) -> Result<Self, Error> {
         data.verify()?;
-        
+
         let keypair = ipfs.keypair()?;
         let did_kp = get_keypair_did(keypair)?;
 
@@ -198,10 +198,23 @@ impl RootDocument {
         let document = document.sign(&did_kp)?;
 
         let identity = document.to_cid(ipfs).await?;
-        let friends = data.friends.to_cid(ipfs).await.ok();
-        let blocks = data.block_list.to_cid(ipfs).await.ok();
-        let block_by = data.block_by_list.to_cid(ipfs).await.ok();
-        let request = data.request.to_cid(ipfs).await.ok();
+        let has_friends = !data.friends.is_empty();
+        let has_blocks = !data.block_list.is_empty();
+        let has_block_by_list = !data.block_by_list.is_empty();
+        let has_requests = !data.request.is_empty();
+
+        let friends = has_friends
+            .then_some(data.friends.to_cid(ipfs).await.ok())
+            .flatten();
+        let blocks = has_blocks
+            .then_some(data.block_list.to_cid(ipfs).await.ok())
+            .flatten();
+        let block_by = has_block_by_list
+            .then_some(data.block_by_list.to_cid(ipfs).await.ok())
+            .flatten();
+        let request = has_requests
+            .then_some(data.request.to_cid(ipfs).await.ok())
+            .flatten();
 
         let mut root_document = RootDocument {
             identity,

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -189,12 +189,13 @@ impl RootDocument {
 
     pub async fn import(ipfs: &Ipfs, data: ExtractedRootDocument) -> Result<Self, Error> {
         data.verify()?;
+        
         let keypair = ipfs.keypair()?;
         let did_kp = get_keypair_did(keypair)?;
 
         let document: IdentityDocument = data.identity.into();
 
-        document.verify()?;
+        let document = document.sign(&did_kp)?;
 
         let identity = document.to_cid(ipfs).await?;
         let friends = data.friends.to_cid(ipfs).await.ok();
@@ -213,7 +214,7 @@ impl RootDocument {
         };
         root_document.sign(&did_kp)?;
 
-        unimplemented!()
+        Ok(root_document)
     }
 
     pub async fn export(&self, ipfs: &Ipfs) -> Result<ExtractedRootDocument, Error> {

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -36,6 +36,37 @@ pub struct IdentityDocument {
     pub signature: Option<String>,
 }
 
+impl From<Identity> for IdentityDocument {
+    fn from(identity: Identity) -> Self {
+        let username = identity.username();
+        let did = identity.did_key();
+        let short_id = *identity.short_id();
+        let status_message = identity.status_message();
+        IdentityDocument {
+            username,
+            short_id,
+            did,
+            status_message,
+            profile_picture: None,
+            profile_banner: None,
+            platform: None,
+            status: None,
+            signature: None,
+        }
+    }
+}
+
+impl From<IdentityDocument> for Identity {
+    fn from(document: IdentityDocument) -> Self {
+        let mut identity = Identity::default();
+        identity.set_did_key(document.did);
+        identity.set_short_id(document.short_id);
+        identity.set_status_message(document.status_message);
+        identity.set_username(&document.username);
+        identity
+    }
+}
+
 impl PartialEq for IdentityDocument {
     fn eq(&self, other: &Self) -> bool {
         self.did.eq(&other.did) && self.short_id.eq(&other.short_id)

--- a/extensions/warp-ipfs/src/store/friends.rs
+++ b/extensions/warp-ipfs/src/store/friends.rs
@@ -250,6 +250,10 @@ impl FriendsStore {
         Ok(store)
     }
 
+    pub(crate) fn phonebook(&self) -> Option<&PhoneBook> {
+        self.phonebook.as_ref()
+    }
+
     //TODO: Implement Errors
     #[tracing::instrument(skip(self, data))]
     async fn check_request_message(&mut self, did: &DID, data: &[u8]) -> anyhow::Result<()> {

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1404,6 +1404,17 @@ impl IdentityStore {
         self.save_cid(root_cid).await?;
         self.update_identity().await?;
         self.enable_event();
+
+        if let Ok(store) = self.friend_store().await {
+            log::info!("Loading friends list into phonebook");
+            if let Ok(friends) = store.friends_list().await {
+                if let Some(phonebook) = store.phonebook() {
+                    if let Err(_e) = phonebook.add_friend_list(friends).await {
+                        error!("Error adding friends in phonebook: {_e}");
+                    }
+                }
+            }
+        }
         Ok(identity)
     }
 

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -2137,13 +2137,11 @@ impl IdentityStore {
             let fingerprint = identity.did_key().fingerprint();
             let bytes = fingerprint.as_bytes();
 
-            let short_id = String::from_utf8_lossy(
-                bytes[bytes.len() - SHORT_ID_SIZE..]
-                    .try_into()
-                    .map_err(anyhow::Error::from)?,
-            );
+            let short_id: [u8; SHORT_ID_SIZE] = bytes[bytes.len() - SHORT_ID_SIZE..]
+                .try_into()
+                .map_err(anyhow::Error::from)?;
 
-            if identity.short_id() != short_id {
+            if identity.short_id() != short_id.into() {
                 return Err(Error::PublicKeyInvalid);
             }
         }

--- a/warp/src/crypto/keypair.rs
+++ b/warp/src/crypto/keypair.rs
@@ -80,12 +80,13 @@ pub fn mnemonic_into_tesseract(
     mnemonic: &str,
     passphrase: Option<&str>,
     save_mnemonic: bool,
+    override_key: bool,
 ) -> Result<(), Error> {
     if !tesseract.is_unlock() {
         return Err(Error::TesseractLocked);
     }
 
-    if tesseract.exist("keypair") {
+    if tesseract.exist("keypair") && !override_key {
         return Err(Error::Any(anyhow::anyhow!("Keypair already exist")));
     }
 
@@ -151,7 +152,7 @@ pub mod ffi {
 
         let phrase = CStr::from_ptr(phrase).to_string_lossy().to_string();
 
-        super::mnemonic_into_tesseract(&mut *tesseract, &phrase, None, save).into()
+        super::mnemonic_into_tesseract(&mut *tesseract, &phrase, None, save, false).into()
     }
 }
 

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::crypto::DID;
 use derive_more::Display;
 use serde::{Deserialize, Serialize};
@@ -86,6 +88,31 @@ impl Relationship {
         self.blocked_by
     }
 }
+
+#[derive(
+    Default, Hash, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Serialize, Deserialize, Ord,
+)]
+pub struct ShortId([u8; SHORT_ID_SIZE]);
+
+impl core::ops::Deref for ShortId {
+    type Target = [u8; SHORT_ID_SIZE];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<[u8; SHORT_ID_SIZE]> for ShortId {
+    fn from(id: [u8; SHORT_ID_SIZE]) -> Self {
+        ShortId(id)
+    }
+}
+
+impl Display for ShortId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(&self.0))
+    }
+}
+
 #[derive(
     Default, Hash, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, warp_derive::FFIVec, FFIFree,
 )]
@@ -94,7 +121,7 @@ pub struct Identity {
     username: String,
 
     /// Short id derived from the DID to be used along side `Identity::username` (eg `Username#0000`)
-    short_id: [u8; SHORT_ID_SIZE],
+    short_id: ShortId,
 
     /// Public key for the identity
     did_key: DID,
@@ -108,8 +135,8 @@ impl Identity {
         self.username = user.to_string()
     }
 
-    pub fn set_short_id(&mut self, id: [u8; SHORT_ID_SIZE]) {
-        self.short_id = id
+    pub fn set_short_id<I: Into<ShortId>>(&mut self, id: I) {
+        self.short_id = id.into()
     }
 
     pub fn set_did_key(&mut self, pubkey: DID) {
@@ -126,8 +153,8 @@ impl Identity {
         self.username.clone()
     }
 
-    pub fn short_id(&self) -> String {
-        String::from_utf8_lossy(&self.short_id).to_string()
+    pub fn short_id(&self) -> ShortId {
+        self.short_id
     }
 
     pub fn did_key(&self) -> DID {
@@ -241,7 +268,7 @@ pub mod ffi {
         }
 
         let identity = &*identity;
-        match CString::new(identity.short_id()) {
+        match CString::new(identity.short_id().to_string()) {
             Ok(c) => c.into_raw(),
             Err(_) => std::ptr::null_mut(),
         }

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -40,20 +40,23 @@ pub enum MultiPassEventKind {
     UnblockedBy { did: DID },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ImportLocation {
+#[derive(Debug, PartialEq, Eq)]
+pub enum ImportLocation<'a> {
     /// Remote location where the identity is stored
     Remote,
 
     /// Local path where the identity is stored
     Local { path: PathBuf },
+
+    /// Buffer memory of where identity is stored
+    Memory { buffer: &'a mut Vec<u8> }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IdentityImportOption {
+#[derive(Debug, PartialEq, Eq)]
+pub enum IdentityImportOption<'a> {
     Locate {
         /// Location of the identity
-        location: ImportLocation,
+        location: ImportLocation<'a>,
 
         /// Passphrase of the identity
         passphrase: String,
@@ -114,12 +117,12 @@ dyn_clone::clone_trait_object!(MultiPass);
 #[async_trait::async_trait]
 pub trait MultiPassImportExport: Sync + Send {
     /// Import identity from a specific location
-    async fn import_identity(&mut self, _: IdentityImportOption) -> Result<Identity, Error> {
+    async fn import_identity<'a>(&mut self, _: IdentityImportOption<'a>) -> Result<Identity, Error> {
         Err(Error::Unimplemented)
     }
 
     /// Manually export identity to a specific location
-    async fn export_identity(&mut self, _: ImportLocation) -> Result<(), Error> {
+    async fn export_identity<'a>(&mut self, _: ImportLocation<'a>) -> Result<(), Error> {
         Err(Error::Unimplemented)
     }
 }

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -78,12 +78,16 @@ impl core::ops::DerefMut for MultiPassEventStream {
 
 #[async_trait::async_trait]
 pub trait MultiPass:
-    Extension + IdentityInformation + Friends + FriendsEvent + Sync + Send + SingleHandle + DynClone
+    Extension
+    + IdentityInformation
+    + MultiPassImportExport
+    + Friends
+    + FriendsEvent
+    + Sync
+    + Send
+    + SingleHandle
+    + DynClone
 {
-    async fn import_identity(&mut self, _: IdentityImportOption) -> Result<Identity, Error> {
-        Err(Error::Unimplemented)
-    }
-
     /// Create an [`Identity`]
     async fn create_identity(
         &mut self,
@@ -106,6 +110,19 @@ pub trait MultiPass:
 }
 
 dyn_clone::clone_trait_object!(MultiPass);
+
+#[async_trait::async_trait]
+pub trait MultiPassImportExport: Sync + Send {
+    /// Import identity from a specific location
+    async fn import_identity(&mut self, _: IdentityImportOption) -> Result<Identity, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Manually export identity to a specific location
+    async fn export_identity(&mut self, _: ImportLocation) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+}
 
 #[async_trait::async_trait]
 pub trait Friends: Sync + Send {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Implements logic for local importing and exporting identity using mnemonic phrase
- Use `ShortId` in place of slice for the short id
- Split the initialization apart from creating and restoring (this will change again in the future)

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- Relates to #43 

**Special notes for reviewers** 🗒️
- This does not support remote exporting to another node at this time but will come later as this lays out the ground work for manual importing and exporting while internally, it may be done automatically, either at intervals or after each event.
- Exporting does not include messages at this time. This will be done separately as this interface handles the identity, friends list, requests, block list, etc. 
- Does not export internal cache. This will be rebuilt after the initial exchanges when friends or users come online and push their identity to discovered peers or friends.

**Additional comments** 🎤
- This PR will requires the knowledge of one own mnemonic phrase prior to importing. This can be obtain prior to creating the identity, from `IdentityProfile::passphrase`, or from tesseract if the configuration flag is set to save it there prior to creating the identity