### PR TITLE
fix(audio): make blink audio work on windows

### DIFF
--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -192,10 +192,12 @@ impl SinkTrack for OpusSink {
 
     fn play(&self) -> Result<()> {
         *self.muted.write() = false;
+        self.stream.play()?;
         Ok(())
     }
     fn pause(&self) -> Result<()> {
         *self.muted.write() = true;
+        self.stream.pause()?;
         Ok(())
     }
     fn change_output_device(&mut self, output_device: &cpal::Device) -> Result<()> {
@@ -211,6 +213,10 @@ impl SinkTrack for OpusSink {
             self.sink_codec.clone(),
         )?;
         *self = new_sink;
+        if !*self.muted.read() {
+            self.stream.play()?;
+        }
+
         Ok(())
     }
 

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -152,7 +152,9 @@ pub async fn create_audio_sink_track(
         webrtc_codec,
         sink_codec,
     )?;
-    sink_track.play()?;
+    sink_track
+        .play()
+        .map_err(|e| anyhow::anyhow!("{e}: failed to play sink track"))?;
     unsafe {
         // don't want two tracks logging at the same time
         if let Some(mut track) = DATA.audio_sink_tracks.insert(peer_id.clone(), sink_track) {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -168,29 +168,33 @@ impl BlinkImpl {
 
         let cpal_host = cpal::default_host();
         if let Some(input_device) = cpal_host.default_input_device() {
-            if let Ok(mut configs) = input_device.supported_input_configs() {
-                if !configs.any(|c| c.channels() == 1) {
-                    source_codec.channels = 2;
+            if !input_device
+                .supported_input_configs()?
+                .any(|c| c.channels() == 1)
+            {
+                source_codec.channels = 2;
 
-                    if !configs.any(|c| c.channels() == 2) {
-                        bail!(
-                            "unsupported audio input device. doesn't support 1 or 2 channel audio"
-                        );
-                    }
+                if !input_device
+                    .supported_input_configs()?
+                    .any(|c| c.channels() == 2)
+                {
+                    bail!("unsupported audio input device. doesn't support 1 or 2 channel audio");
                 }
             }
         }
 
         if let Some(output_device) = cpal_host.default_output_device() {
-            if let Ok(mut configs) = output_device.supported_output_configs() {
-                if !configs.any(|c| c.channels() == 1) {
-                    sink_codec.channels = 2;
+            if !output_device
+                .supported_output_configs()?
+                .any(|c| c.channels() == 1)
+            {
+                sink_codec.channels = 2;
 
-                    if !configs.any(|c| c.channels() == 2) {
-                        bail!(
-                            "unsupported audio output device. doesn't support 1 or 2 channel audio"
-                        );
-                    }
+                if !output_device
+                    .supported_output_configs()?
+                    .any(|c| c.channels() == 2)
+                {
+                    bail!("unsupported audio output device. doesn't support 1 or 2 channel audio");
                 }
             }
         }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -169,9 +169,13 @@ impl BlinkImpl {
         let cpal_host = cpal::default_host();
         if let Some(input_device) = cpal_host.default_input_device() {
             if let Ok(mut configs) = input_device.supported_input_configs() {
-                if !configs.any(|c| c.channels() == source_codec.channels()) {
-                    if let Ok(default_config) = input_device.default_input_config() {
-                        source_codec.channels = default_config.channels();
+                if !configs.any(|c| c.channels() == 1) {
+                    source_codec.channels = 2;
+
+                    if !configs.any(|c| c.channels() == 2) {
+                        bail!(
+                            "unsupported audio input device. doesn't support 1 or 2 channel audio"
+                        );
                     }
                 }
             }
@@ -179,9 +183,13 @@ impl BlinkImpl {
 
         if let Some(output_device) = cpal_host.default_output_device() {
             if let Ok(mut configs) = output_device.supported_output_configs() {
-                if !configs.any(|c| c.channels() == sink_codec.channels()) {
-                    if let Ok(default_config) = output_device.default_output_config() {
-                        sink_codec.channels = default_config.channels();
+                if !configs.any(|c| c.channels() == 1) {
+                    sink_codec.channels = 2;
+
+                    if !configs.any(|c| c.channels() == 2) {
+                        bail!(
+                            "unsupported audio output device. doesn't support 1 or 2 channel audio"
+                        );
                     }
                 }
             }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -173,7 +173,6 @@ impl BlinkImpl {
                 .any(|c| c.channels() == 1)
             {
                 source_codec.channels = 2;
-
                 if !input_device
                     .supported_input_configs()?
                     .any(|c| c.channels() == 2)
@@ -181,6 +180,8 @@ impl BlinkImpl {
                     bail!("unsupported audio input device. doesn't support 1 or 2 channel audio");
                 }
             }
+        } else {
+            log::warn!("blink started with no input device");
         }
 
         if let Some(output_device) = cpal_host.default_output_device() {
@@ -189,7 +190,6 @@ impl BlinkImpl {
                 .any(|c| c.channels() == 1)
             {
                 sink_codec.channels = 2;
-
                 if !output_device
                     .supported_output_configs()?
                     .any(|c| c.channels() == 2)
@@ -197,6 +197,8 @@ impl BlinkImpl {
                     bail!("unsupported audio output device. doesn't support 1 or 2 channel audio");
                 }
             }
+        } else {
+            log::warn!("blink started with no output device");
         }
 
         let (ui_event_ch, _rx) = broadcast::channel(1024);

--- a/tools/audio-codec-cli/src/main.rs
+++ b/tools/audio-codec-cli/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use clap::Parser;
 
+use cpal::traits::{DeviceTrait, HostTrait};
 use log::LevelFilter;
 use once_cell::sync::Lazy;
 use play::*;
@@ -18,6 +19,10 @@ mod record;
 /// Test CPAL and OPUS
 #[derive(Parser, Debug, Clone)]
 enum Cli {
+    /// show the supported CPAL input stream configs
+    SupportedInputConfigs,
+    /// show the supported CPAL output stream configs
+    SupportedOutputConfigs,
     /// print help text regarding properly setting sample rate and
     /// frame size
     ConfigInfo,
@@ -331,6 +336,26 @@ Frame size (in samples) vs duration for various sampling rates:
             output_file_name,
         } => loudness::calculate_loudness_rms2(&input_file_name, &output_file_name)?,
         Cli::Feedback => feedback::feedback(sm.clone()).await?,
+        Cli::SupportedInputConfigs => {
+            let host = cpal::default_host();
+            let dev = host
+                .default_input_device()
+                .ok_or(anyhow::anyhow!("no input device"))?;
+            let configs = dev.supported_input_configs()?;
+            for config in configs {
+                println!("{config:#?}");
+            }
+        }
+        Cli::SupportedOutputConfigs => {
+            let host = cpal::default_host();
+            let dev = host
+                .default_output_device()
+                .ok_or(anyhow::anyhow!("no input device"))?;
+            let configs = dev.supported_output_configs()?;
+            for config in configs {
+                println!("{config:#?}");
+            }
+        }
     }
     Ok(())
 }

--- a/tools/blink-cli/src/main.rs
+++ b/tools/blink-cli/src/main.rs
@@ -129,7 +129,7 @@ async fn handle_command(
             let ids = ids.iter().map(|id| {
                 DID::from_str(id).map_err(|e| format!("error for peer id {}: {}", id, e))
             });
-            let errs = ids.clone().filter_map(|x| x.err()).map(|x| x.to_string());
+            let errs = ids.clone().filter_map(|x| x.err());
             let ids = ids.filter_map(|x| x.ok());
 
             let errs: Vec<String> = errs.collect();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- calls [this](https://docs.rs/cpal/0.15.2/cpal/traits/trait.StreamTrait.html#tymethod.play) function. Not all platforms play a CPAL stream automatically. `play()` is needed for these cases. 
- removes a command from `blink-cli` which has no effect
- explicitly sets the number of audio channels when initializing Blink. Before, the host's default configuration was used. 


**Which issue(s) this PR fixes** 🔨
#315 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- needs to be tested using the `blink-cli` with a windows device. 
- testing changing the output device during a call would also be helpful. 