### PR TITLE
fix(audio): make blink audio work on windows and fix audio codecs

### DIFF
--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -32,7 +32,11 @@ pub trait SourceTrack {
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
     // should not require RTP renegotiation
-    fn change_input_device(&mut self, input_device: &cpal::Device) -> Result<()>;
+    fn change_input_device(
+        &mut self,
+        input_device: &cpal::Device,
+        source_codec: blink::AudioCodec,
+    ) -> Result<()>;
     fn init_mp4_logger(&mut self) -> Result<()>;
     fn remove_mp4_logger(&mut self) -> Result<()>;
 }
@@ -51,7 +55,11 @@ pub trait SinkTrack {
         Self: Sized;
     fn play(&self) -> Result<()>;
     fn pause(&self) -> Result<()>;
-    fn change_output_device(&mut self, output_device: &cpal::Device) -> anyhow::Result<()>;
+    fn change_output_device(
+        &mut self,
+        output_device: &cpal::Device,
+        sink_codec: blink::AudioCodec,
+    ) -> anyhow::Result<()>;
     fn set_audio_multiplier(&mut self, multiplier: f32) -> Result<()>;
     fn init_mp4_logger(&mut self) -> Result<()>;
     fn remove_mp4_logger(&mut self) -> Result<()>;

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -192,10 +192,12 @@ impl SinkTrack for OpusSink {
 
     fn play(&self) -> Result<()> {
         *self.muted.write() = false;
+        self.stream.play()?;
         Ok(())
     }
     fn pause(&self) -> Result<()> {
         *self.muted.write() = true;
+        self.stream.pause()?;
         Ok(())
     }
     fn change_output_device(&mut self, output_device: &cpal::Device) -> Result<()> {
@@ -211,6 +213,10 @@ impl SinkTrack for OpusSink {
             self.sink_codec.clone(),
         )?;
         *self = new_sink;
+        if !*self.muted.read() {
+            self.stream.play()?;
+        }
+
         Ok(())
     }
 

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -33,8 +33,6 @@ pub struct OpusSink {
     track: Arc<TrackRemote>,
     // same
     webrtc_codec: blink::AudioCodec,
-    // same
-    sink_codec: blink::AudioCodec,
     // want to keep this from getting dropped so it will continue to be read from
     stream: cpal::Stream,
     decoder_handle: JoinHandle<()>,
@@ -160,7 +158,6 @@ impl OpusSink {
             stream: output_stream,
             track,
             webrtc_codec,
-            sink_codec,
             decoder_handle: join_handle,
             event_ch,
             mp4_logger,
@@ -200,17 +197,20 @@ impl SinkTrack for OpusSink {
         self.stream.pause()?;
         Ok(())
     }
-    fn change_output_device(&mut self, output_device: &cpal::Device) -> Result<()> {
+    fn change_output_device(
+        &mut self,
+        output_device: &cpal::Device,
+        sink_codec: blink::AudioCodec,
+    ) -> Result<()> {
         self.stream.pause()?;
         self.decoder_handle.abort();
-
         let new_sink = OpusSink::init_internal(
             self.peer_id.clone(),
             self.event_ch.clone(),
             output_device,
             self.track.clone(),
             self.webrtc_codec.clone(),
-            self.sink_codec.clone(),
+            sink_codec,
         )?;
         *self = new_sink;
         if !*self.muted.read() {

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -152,7 +152,9 @@ pub async fn create_audio_sink_track(
         webrtc_codec,
         sink_codec,
     )?;
-    sink_track.play()?;
+    sink_track
+        .play()
+        .map_err(|e| anyhow::anyhow!("{e}: failed to play sink track"))?;
     unsafe {
         // don't want two tracks logging at the same time
         if let Some(mut track) = DATA.audio_sink_tracks.insert(peer_id.clone(), sink_track) {

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -173,7 +173,10 @@ pub async fn create_audio_sink_track(
     Ok(())
 }
 
-pub async fn change_audio_input(device: cpal::Device) -> anyhow::Result<()> {
+pub async fn change_audio_input(
+    device: cpal::Device,
+    source_codec: blink::AudioCodec,
+) -> anyhow::Result<()> {
     let _lock = LOCK.write().await;
 
     // change_input_device destroys the audio stream. if that function fails. there should be
@@ -183,7 +186,7 @@ pub async fn change_audio_input(device: cpal::Device) -> anyhow::Result<()> {
     }
 
     if let Some(source) = unsafe { DATA.audio_source_track.as_mut() } {
-        source.change_input_device(&device)?;
+        source.change_input_device(&device, source_codec)?;
     }
     unsafe {
         DATA.audio_input_device.replace(device);
@@ -191,12 +194,15 @@ pub async fn change_audio_input(device: cpal::Device) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn change_audio_output(device: cpal::Device) -> anyhow::Result<()> {
+pub async fn change_audio_output(
+    device: cpal::Device,
+    sink_codec: blink::AudioCodec,
+) -> anyhow::Result<()> {
     let _lock = LOCK.write().await;
 
     // todo: if this fails, return an error or keep going?
     for (_k, v) in unsafe { DATA.audio_sink_tracks.iter_mut() } {
-        if let Err(e) = v.change_output_device(&device) {
+        if let Err(e) = v.change_output_device(&device, sink_codec.clone()) {
             log::error!("failed to change output device: {e}");
         }
     }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -168,29 +168,33 @@ impl BlinkImpl {
 
         let cpal_host = cpal::default_host();
         if let Some(input_device) = cpal_host.default_input_device() {
-            if let Ok(mut configs) = input_device.supported_input_configs() {
-                if !configs.any(|c| c.channels() == 1) {
-                    source_codec.channels = 2;
+            if !input_device
+                .supported_input_configs()?
+                .any(|c| c.channels() == 1)
+            {
+                source_codec.channels = 2;
 
-                    if !configs.any(|c| c.channels() == 2) {
-                        bail!(
-                            "unsupported audio input device. doesn't support 1 or 2 channel audio"
-                        );
-                    }
+                if !input_device
+                    .supported_input_configs()?
+                    .any(|c| c.channels() == 2)
+                {
+                    bail!("unsupported audio input device. doesn't support 1 or 2 channel audio");
                 }
             }
         }
 
         if let Some(output_device) = cpal_host.default_output_device() {
-            if let Ok(mut configs) = output_device.supported_output_configs() {
-                if !configs.any(|c| c.channels() == 1) {
-                    sink_codec.channels = 2;
+            if !output_device
+                .supported_output_configs()?
+                .any(|c| c.channels() == 1)
+            {
+                sink_codec.channels = 2;
 
-                    if !configs.any(|c| c.channels() == 2) {
-                        bail!(
-                            "unsupported audio output device. doesn't support 1 or 2 channel audio"
-                        );
-                    }
+                if !output_device
+                    .supported_output_configs()?
+                    .any(|c| c.channels() == 2)
+                {
+                    bail!("unsupported audio output device. doesn't support 1 or 2 channel audio");
                 }
             }
         }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -169,9 +169,13 @@ impl BlinkImpl {
         let cpal_host = cpal::default_host();
         if let Some(input_device) = cpal_host.default_input_device() {
             if let Ok(mut configs) = input_device.supported_input_configs() {
-                if !configs.any(|c| c.channels() == source_codec.channels()) {
-                    if let Ok(default_config) = input_device.default_input_config() {
-                        source_codec.channels = default_config.channels();
+                if !configs.any(|c| c.channels() == 1) {
+                    source_codec.channels = 2;
+
+                    if !configs.any(|c| c.channels() == 2) {
+                        bail!(
+                            "unsupported audio input device. doesn't support 1 or 2 channel audio"
+                        );
                     }
                 }
             }
@@ -179,9 +183,13 @@ impl BlinkImpl {
 
         if let Some(output_device) = cpal_host.default_output_device() {
             if let Ok(mut configs) = output_device.supported_output_configs() {
-                if !configs.any(|c| c.channels() == sink_codec.channels()) {
-                    if let Ok(default_config) = output_device.default_output_config() {
-                        sink_codec.channels = default_config.channels();
+                if !configs.any(|c| c.channels() == 1) {
+                    sink_codec.channels = 2;
+
+                    if !configs.any(|c| c.channels() == 2) {
+                        bail!(
+                            "unsupported audio output device. doesn't support 1 or 2 channel audio"
+                        );
                     }
                 }
             }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -173,7 +173,6 @@ impl BlinkImpl {
                 .any(|c| c.channels() == 1)
             {
                 source_codec.channels = 2;
-
                 if !input_device
                     .supported_input_configs()?
                     .any(|c| c.channels() == 2)
@@ -181,6 +180,8 @@ impl BlinkImpl {
                     bail!("unsupported audio input device. doesn't support 1 or 2 channel audio");
                 }
             }
+        } else {
+            log::warn!("blink started with no input device");
         }
 
         if let Some(output_device) = cpal_host.default_output_device() {
@@ -189,7 +190,6 @@ impl BlinkImpl {
                 .any(|c| c.channels() == 1)
             {
                 sink_codec.channels = 2;
-
                 if !output_device
                     .supported_output_configs()?
                     .any(|c| c.channels() == 2)
@@ -197,6 +197,8 @@ impl BlinkImpl {
                     bail!("unsupported audio output device. doesn't support 1 or 2 channel audio");
                 }
             }
+        } else {
+            log::warn!("blink started with no output device");
         }
 
         let (ui_event_ch, _rx) = broadcast::channel(1024);

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -145,14 +145,6 @@ impl BlinkImpl {
     pub async fn new(account: Box<dyn MultiPass>) -> anyhow::Result<Box<Self>> {
         log::trace!("initializing WebRTC");
 
-        let cpal_host = cpal::platform::default_host();
-        if let Some(d) = cpal_host.default_input_device() {
-            host_media::change_audio_input(d).await?;
-        }
-        if let Some(d) = cpal_host.default_output_device() {
-            host_media::change_audio_output(d).await?;
-        }
-
         // check SupportedStreamConfigs. if those channels aren't supported, use the default.
         let mut source_codec = blink::AudioCodec {
             mime: MimeType::OPUS,
@@ -168,41 +160,15 @@ impl BlinkImpl {
 
         let cpal_host = cpal::default_host();
         if let Some(input_device) = cpal_host.default_input_device() {
-            let min_channels =
-                input_device
-                    .supported_input_configs()?
-                    .fold(None, |acc: Option<u16>, x| match x.channels() {
-                        1 => Some(1),
-                        2 => match acc {
-                            None => Some(2),
-                            Some(1) => acc,
-                            _ => unreachable!(""),
-                        },
-                        _ => acc,
-                    });
-            source_codec.channels = min_channels.ok_or(anyhow::anyhow!(
-                "unsupported audio input device. doesn't support 1 or 2 channel audio"
-            ))?;
+            source_codec.channels = Self::get_min_source_channels(&input_device)?;
+            host_media::change_audio_input(input_device, source_codec.clone()).await?;
         } else {
             log::warn!("blink started with no input device");
         }
 
         if let Some(output_device) = cpal_host.default_output_device() {
-            let min_channels =
-                output_device
-                    .supported_output_configs()?
-                    .fold(None, |acc: Option<u16>, x| match x.channels() {
-                        1 => Some(1),
-                        2 => match acc {
-                            None => Some(2),
-                            Some(1) => acc,
-                            _ => unreachable!(""),
-                        },
-                        _ => acc,
-                    });
-            sink_codec.channels = min_channels.ok_or(anyhow::anyhow!(
-                "unsupported audio output device. doesn't support 1 or 2 channel audio"
-            ))?;
+            sink_codec.channels = Self::get_min_sink_channels(&output_device)?;
+            host_media::change_audio_output(output_device, sink_codec.clone()).await?;
         } else {
             log::warn!("blink started with no output device");
         }
@@ -301,11 +267,12 @@ impl BlinkImpl {
 
         self.active_call.write().await.replace(call.clone().into());
         let audio_source_codec = self.audio_source_codec.read().await;
+        let webrtc_codec = call.codec();
         // ensure there is an audio source track
         let rtc_rtp_codec: RTCRtpCodecCapability = RTCRtpCodecCapability {
-            mime_type: audio_source_codec.mime_type(),
-            clock_rate: audio_source_codec.sample_rate(),
-            channels: audio_source_codec.channels(),
+            mime_type: webrtc_codec.mime_type(),
+            clock_rate: webrtc_codec.sample_rate(),
+            channels: webrtc_codec.channels(),
             ..Default::default()
         };
         let track = self
@@ -318,7 +285,7 @@ impl BlinkImpl {
             own_id.clone(),
             self.ui_event_ch.clone(),
             track,
-            call.codec(),
+            webrtc_codec,
             audio_source_codec.clone(),
         )
         .await?;
@@ -376,6 +343,62 @@ impl BlinkImpl {
 
         self.webrtc_handler.write().replace(webrtc_handle);
         Ok(())
+    }
+
+    async fn update_audio_source_codec(
+        &mut self,
+        input_device: &cpal::Device,
+    ) -> anyhow::Result<()> {
+        let min_channels = Self::get_min_source_channels(input_device)?;
+        self.audio_source_codec.write().await.channels = min_channels;
+        Ok(())
+    }
+
+    fn get_min_source_channels(input_device: &cpal::Device) -> anyhow::Result<u16> {
+        let min_channels =
+            input_device
+                .supported_input_configs()?
+                .fold(None, |acc: Option<u16>, x| match x.channels() {
+                    1 => Some(1),
+                    2 => match acc {
+                        None => Some(2),
+                        Some(1) => acc,
+                        _ => unreachable!(""),
+                    },
+                    _ => acc,
+                });
+        let channels = min_channels.ok_or(anyhow::anyhow!(
+            "unsupported audio input device. doesn't support 1 or 2 channel audio"
+        ))?;
+        Ok(channels)
+    }
+
+    async fn update_audio_sink_codec(
+        &mut self,
+        output_device: &cpal::Device,
+    ) -> anyhow::Result<()> {
+        let min_channels = Self::get_min_sink_channels(output_device)?;
+        self.audio_sink_codec.write().await.channels = min_channels;
+        Ok(())
+    }
+
+    fn get_min_sink_channels(output_device: &cpal::Device) -> anyhow::Result<u16> {
+        let min_channels =
+            output_device
+                .supported_output_configs()?
+                .fold(None, |acc: Option<u16>, x| match x.channels() {
+                    1 => Some(1),
+                    2 => match acc {
+                        None => Some(2),
+                        Some(1) => acc,
+                        _ => unreachable!(""),
+                    },
+                    _ => acc,
+                });
+        let channels = min_channels.ok_or(anyhow::anyhow!(
+            "unsupported audio output device. doesn't support 1 or 2 channel audio"
+        ))?;
+        Ok(channels)
     }
 }
 
@@ -1044,7 +1067,12 @@ impl Blink for BlinkImpl {
         for device in devices {
             if let Ok(name) = device.name() {
                 if name == device_name {
-                    host_media::change_audio_input(device).await?;
+                    self.update_audio_source_codec(&device).await?;
+                    host_media::change_audio_input(
+                        device,
+                        self.audio_source_codec.read().await.clone(),
+                    )
+                    .await?;
                     return Ok(());
                 }
             }
@@ -1061,7 +1089,9 @@ impl Blink for BlinkImpl {
             .ok_or(Error::OtherWithContext(String::from(
                 "no default input device",
             )))?;
-        host_media::change_audio_input(device).await?;
+        self.update_audio_source_codec(&device).await?;
+        host_media::change_audio_input(device, self.audio_source_codec.read().await.clone())
+            .await?;
         Ok(())
     }
     async fn get_available_speakers(&self) -> Result<Vec<String>, Error> {
@@ -1089,7 +1119,12 @@ impl Blink for BlinkImpl {
         for device in devices {
             if let Ok(name) = device.name() {
                 if name == device_name {
-                    host_media::change_audio_output(device).await?;
+                    self.update_audio_sink_codec(&device).await?;
+                    host_media::change_audio_output(
+                        device,
+                        self.audio_sink_codec.read().await.clone(),
+                    )
+                    .await?;
                     return Ok(());
                 }
             }
@@ -1106,7 +1141,8 @@ impl Blink for BlinkImpl {
             .ok_or(Error::OtherWithContext(String::from(
                 "no default input device",
             )))?;
-        host_media::change_audio_output(device).await?;
+        self.update_audio_sink_codec(&device).await?;
+        host_media::change_audio_output(device, self.audio_sink_codec.read().await.clone()).await?;
         Ok(())
     }
     async fn get_available_cameras(&self) -> Result<Vec<String>, Error> {

--- a/tools/audio-codec-cli/src/main.rs
+++ b/tools/audio-codec-cli/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use clap::Parser;
 
+use cpal::traits::{DeviceTrait, HostTrait};
 use log::LevelFilter;
 use once_cell::sync::Lazy;
 use play::*;
@@ -18,6 +19,10 @@ mod record;
 /// Test CPAL and OPUS
 #[derive(Parser, Debug, Clone)]
 enum Cli {
+    /// show the supported CPAL input stream configs
+    SupportedInputConfigs,
+    /// show the supported CPAL output stream configs
+    SupportedOutputConfigs,
     /// print help text regarding properly setting sample rate and
     /// frame size
     ConfigInfo,
@@ -331,6 +336,26 @@ Frame size (in samples) vs duration for various sampling rates:
             output_file_name,
         } => loudness::calculate_loudness_rms2(&input_file_name, &output_file_name)?,
         Cli::Feedback => feedback::feedback(sm.clone()).await?,
+        Cli::SupportedInputConfigs => {
+            let host = cpal::default_host();
+            let dev = host
+                .default_input_device()
+                .ok_or(anyhow::anyhow!("no input device"))?;
+            let configs = dev.supported_input_configs()?;
+            for config in configs {
+                println!("{config:#?}");
+            }
+        }
+        Cli::SupportedOutputConfigs => {
+            let host = cpal::default_host();
+            let dev = host
+                .default_output_device()
+                .ok_or(anyhow::anyhow!("no input device"))?;
+            let configs = dev.supported_output_configs()?;
+            for config in configs {
+                println!("{config:#?}");
+            }
+        }
     }
     Ok(())
 }

--- a/tools/blink-cli/src/main.rs
+++ b/tools/blink-cli/src/main.rs
@@ -129,7 +129,7 @@ async fn handle_command(
             let ids = ids.iter().map(|id| {
                 DID::from_str(id).map_err(|e| format!("error for peer id {}: {}", id, e))
             });
-            let errs = ids.clone().filter_map(|x| x.err()).map(|x| x.to_string());
+            let errs = ids.clone().filter_map(|x| x.err());
             let ids = ids.filter_map(|x| x.ok());
 
             let errs: Vec<String> = errs.collect();

--- a/tools/blink-cli/src/main.rs
+++ b/tools/blink-cli/src/main.rs
@@ -91,7 +91,6 @@ enum Repl {
     ConnectMicrophone { device_name: String },
     /// specify which speaker to use for output
     ConnectSpeaker { device_name: String },
-    /// set the sampling frequency used to send audio samples over webrtc
     /// set the default audio sample rate to low (8000Hz), medium (48000Hz) or high (96000Hz)
     /// the specified sample rate will be used when the host initiates a call.
     SetAudioRate { rate: String },

--- a/tools/blink-cli/src/main.rs
+++ b/tools/blink-cli/src/main.rs
@@ -258,7 +258,10 @@ async fn handle_command(
 async fn handle_blink_event_stream(mut stream: BlinkEventStream) -> anyhow::Result<()> {
     while let Some(evt) = stream.next().await {
         // get rid of noisy logs
-        if !matches!(evt, BlinkEventKind::ParticipantSpeaking { .. }) {
+        if !matches!(
+            evt,
+            BlinkEventKind::ParticipantSpeaking { .. } | BlinkEventKind::SelfSpeaking
+        ) {
             println!("BlinkEvent: {evt}");
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- calls [play](https://docs.rs/cpal/0.15.2/cpal/traits/trait.StreamTrait.html#tymethod.play) whenever an audio stream is created. Not all platforms play a CPAL stream automatically. `play()` is needed for these cases. 
- changes how audio data is encoded before  being transported over WebRTC. Blink allows the audio I/O devices to have different formats and encodes them to a common format before sending over WebRTC. But that common format wasn't being used - it just so happened that the `audio_source_codec` and `webrtc_codec` default to being the same. But if someone has a 2 channel audio device then the wrong codec was being used to send audio over WebRTC. 
- when an audio device is selected, the `audio_source_codec` and `audio_sink_codec` are now updated to reflect the supported configuration of the new device. 

- removes a command from `blink-cli` which has no effect
- explicitly sets the number of audio channels when initializing Blink. Before, the host's default configuration was used. 


**Which issue(s) this PR fixes** 🔨
#315 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤