### PR TITLE
feat(blink): improve call quality during network delays

### DIFF
--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -292,7 +292,6 @@ where
     // let logger = crate::rtp_logger::get_instance(format!("{}-audio", peer_id));
     // let logger_start_time = std::time::Instant::now();
 
-    let mut samples_to_skip = 0;
     loop {
         match track.read(&mut b).await {
             Ok((siz, _attr)) => {

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -290,7 +290,8 @@ where
     let automute_tx = host_media::audio::automute::AUDIO_CMD_CH.tx.clone();
 
     // let logger = crate::rtp_logger::get_instance(format!("{}-audio", peer_id));
-    // let logger_start_time = std::time::Instant::now();
+    let task_start_time = std::time::Instant::now();
+    let mut last_degradation_time = 0;
 
     loop {
         match track.read(&mut b).await {
@@ -314,7 +315,7 @@ where
                 }
 
                 // if let Some(logger) = logger.as_ref() {
-                //     logger.log(rtp_packet.header.clone(), logger_start_time.elapsed().as_millis());
+                //     logger.log(rtp_packet.header.clone(), task_start_time.elapsed().as_millis());
                 // }
 
                 if let Some(extension) = rtp_packet.header.extensions.first() {
@@ -340,6 +341,10 @@ where
                 sample_builder.push(rtp_packet);
                 // check if a sample can be created
                 while let Some(media_sample) = sample_builder.pop() {
+                    // discard overflow packets
+                    if task_start_time.elapsed().as_millis() - last_degradation_time < 10 {
+                        continue;
+                    }
                     // discard samples if muted
                     if *muted.read() {
                         continue;
@@ -355,7 +360,7 @@ where
                             // hopefully each opus packet is still 10ms
                             let _ = automute_tx
                                 .send(host_media::audio::automute::AutoMuteCmd::MuteFor(110));
-                            for audio_sample in to_send {
+                            'PROCESS_DECODED_SAMPLES: for audio_sample in to_send {
                                 match channel_mixer.process(*audio_sample * multiplier) {
                                     ChannelMixerOutput::Single(sample) => {
                                         resampler.process(sample, &mut raw_samples);
@@ -366,13 +371,19 @@ where
                                     }
                                     ChannelMixerOutput::None => {}
                                 }
-                                'SEND_RAW_SAMPLES: for sample in raw_samples.drain(..) {
+                                for sample in raw_samples.drain(..) {
                                     if let Err(_e) = producer.push(sample) {
                                         *dump_consumer_queue.write() = true;
                                         let _ = event_ch.send(BlinkEventKind::AudioDegradation {
                                             peer_id: peer_id.clone(),
                                         });
-                                        break 'SEND_RAW_SAMPLES;
+                                        //log::error!(
+                                        //    "audio degradation: {}",
+                                        //    task_start_time.elapsed().as_millis()
+                                        //);
+                                        last_degradation_time =
+                                            task_start_time.elapsed().as_millis();
+                                        break 'PROCESS_DECODED_SAMPLES;
                                     }
                                 }
                             }

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -330,7 +330,7 @@ where
                 // check if a sample can be created
                 while let Some(media_sample) = sample_builder.pop() {
                     if samples_to_skip > 0 {
-                        samples_to_skip = samples_to_skip - 1;
+                        samples_to_skip -= 1;
                         continue;
                     }
 

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/sink/mod.rs
@@ -278,7 +278,7 @@ where
         mp4_writer,
         muted,
         audio_multiplier,
-        dump_consumer_queue,
+        dump_consumer_queue: _,
     } = args;
     // speech_detector should emit at most 1 event per second
     let mut speech_detector = speech::Detector::new(10, 100);
@@ -373,7 +373,7 @@ where
                                 }
                                 for sample in raw_samples.drain(..) {
                                     if let Err(_e) = producer.push(sample) {
-                                        *dump_consumer_queue.write() = true;
+                                        //*dump_consumer_queue.write() = true;
                                         let _ = event_ch.send(BlinkEventKind::AudioDegradation {
                                             peer_id: peer_id.clone(),
                                         });

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -235,9 +235,9 @@ fn create_source_track(
                     {
                         Ok(packets) => {
                             if let Some(packet) = packets.first() {
-                                if let Some(writer) = mp4_writer.write().as_mut() {
+                                if let Some(mp4_writer) = mp4_writer.write().as_mut() {
                                     // todo: use the audio codec to determine number of samples and duration
-                                    writer.log(packet.payload.clone());
+                                    mp4_writer.log(packet.payload.clone());
                                 }
                             }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- emit AudioDegradation event
- improve call quality during network delay

This PR improves the scenario where network delay causes a large number of audio samples to be decoded and received all at the same time. Previously when this happened, the sound would skip and there would be a large number of random sound bytes. This PR removes said sound bytes. The skipping still happens but that is unavoidable. 

Network delay is detected when the ringbuf in OpusSink overflows. In response, OpusSink drops the incoming samples and all future samples that are received in the next 10ms. Note that each audio frame lasts 10ms (and thus takes 10ms to create).  Anything received within 10ms is assumed to have been affected by the network delay. 

I experimented with using a different size for the ringbuf in OpusSink, clearing the ringbuf, and dropping future samples.  Simply dropping incoming samples resulted in the best sound. 

Testing was conducted with a 2 computer setup, one of which was a macbook using the network link conditioner (part of the [additional tools for xcode](https://developer.apple.com/download/more/?q=Additional%20Tools) package) software. The network link conditioner allows one to simulate a slow network.

**Which issue(s) this PR fixes** 🔨
#304 
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
