### PR TITLE
feat(blink): add capability to test audio devices

### DIFF
--- a/extensions/warp-blink-wrtc/src/host_media/audio/hardware_config.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/hardware_config.rs
@@ -121,7 +121,7 @@ impl AudioDeviceConfig for DeviceConfig {
         let latency_ms = 500.0;
         let host = cpal::default_host();
         let output_device = self.selected_speaker.clone().unwrap_or_default();
-        let output_device = if output_device == "default" {
+        let output_device = if output_device.to_ascii_lowercase() == "default" {
             host.default_output_device()
         } else {
             host.output_devices()?
@@ -130,8 +130,8 @@ impl AudioDeviceConfig for DeviceConfig {
         .ok_or(anyhow::anyhow!("failed to find output device"))?;
 
         let input_device = self.selected_microphone.clone().unwrap_or_default();
-        let input_device = if input_device == "default" {
-            host.default_output_device()
+        let input_device = if input_device.to_ascii_lowercase() == "default" {
+            host.default_input_device()
         } else {
             host.input_devices()?
                 .find(|x| x.name().map(|y| y == input_device).unwrap_or(false))

--- a/extensions/warp-blink-wrtc/src/host_media/audio/hardware_config.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/hardware_config.rs
@@ -1,0 +1,73 @@
+use anyhow::Result;
+use cpal::traits::{DeviceTrait, HostTrait};
+use warp::blink::AudioDeviceConfig;
+
+#[derive(Clone)]
+pub struct DeviceConfig {
+    // device name
+    // defaults to the default device or None
+    // if no devices are connected
+    pub selected_speaker: Option<String>,
+    // device name
+    // defaults to the default device or None
+    // if no devices are connected
+    pub selected_microphone: Option<String>,
+}
+
+impl DeviceConfig {
+    pub fn new() -> Result<Self> {
+        let host = cpal::default_host();
+        let output_device = host
+            .default_output_device()
+            .ok_or(anyhow::anyhow!("no default output device"))?;
+
+        let input_device = host
+            .default_input_device()
+            .ok_or(anyhow::anyhow!("no default input device"))?;
+
+        Ok(Self {
+            selected_speaker: Some(output_device.name()?),
+            selected_microphone: Some(input_device.name()?),
+        })
+    }
+}
+
+impl AudioDeviceConfig for DeviceConfig {
+    fn test_speaker(&self) -> Result<()> {
+        todo!()
+    }
+
+    fn test_microphone(&self) -> Result<()> {
+        todo!()
+    }
+
+    fn set_speaker(&mut self, device_name: &str) {
+        self.selected_speaker.replace(device_name.to_string());
+    }
+
+    fn set_microphone(&mut self, device_name: &str) {
+        self.selected_microphone.replace(device_name.to_string());
+    }
+
+    fn microphone_device_name(&self) -> Option<String> {
+        self.selected_microphone.clone()
+    }
+
+    fn speaker_device_name(&self) -> Option<String> {
+        self.selected_speaker.clone()
+    }
+
+    fn get_available_microphones(&self) -> Result<Vec<String>> {
+        let device_iter = cpal::default_host().input_devices()?;
+        Ok(device_iter
+            .map(|device| device.name().unwrap_or(String::from("unknown device")))
+            .collect())
+    }
+
+    fn get_available_speakers(&self) -> Result<Vec<String>> {
+        let device_iter = cpal::default_host().output_devices()?;
+        Ok(device_iter
+            .map(|device| device.name().unwrap_or(String::from("unknown device")))
+            .collect())
+    }
+}

--- a/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/mod.rs
@@ -9,12 +9,14 @@ use webrtc::track::{
 };
 
 pub(crate) mod automute;
+mod hardware_config;
 mod loudness;
 mod opus;
 mod speech;
 
 pub use self::opus::sink::OpusSink;
 pub use self::opus::source::OpusSource;
+pub use hardware_config::*;
 
 // stores the TrackRemote at least
 pub trait SourceTrack {

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -321,3 +321,17 @@ pub async fn set_peer_audio_gain(peer_id: DID, multiplier: f32) -> anyhow::Resul
 
     Ok(())
 }
+
+pub async fn test_microphone(
+    device_name: &str,
+    ch: broadcast::Sender<BlinkEventKind>,
+) -> anyhow::Result<()> {
+    todo!()
+}
+
+pub async fn test_speaker(
+    device_name: &str,
+    ch: broadcast::Sender<BlinkEventKind>,
+) -> anyhow::Result<()> {
+    todo!()
+}

--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -323,15 +323,15 @@ pub async fn set_peer_audio_gain(peer_id: DID, multiplier: f32) -> anyhow::Resul
 }
 
 pub async fn test_microphone(
-    device_name: &str,
-    ch: broadcast::Sender<BlinkEventKind>,
+    _device_name: &str,
+    _ch: broadcast::Sender<BlinkEventKind>,
 ) -> anyhow::Result<()> {
     todo!()
 }
 
 pub async fn test_speaker(
-    device_name: &str,
-    ch: broadcast::Sender<BlinkEventKind>,
+    _device_name: &str,
+    _ch: broadcast::Sender<BlinkEventKind>,
 ) -> anyhow::Result<()> {
     todo!()
 }

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
     any::Any,
     collections::{HashMap, HashSet},
     str::FromStr,
-    sync::{Arc},
+    sync::Arc,
     time::Duration,
 };
 use webrtc::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
@@ -409,6 +409,7 @@ impl BlinkImpl {
 
     async fn select_microphone(&mut self, device_name: &str) -> Result<(), Error> {
         let host = cpal::default_host();
+        // todo: use different code path if device_name is "default"
         let devices = match host.input_devices() {
             Ok(d) => d,
             Err(e) => {
@@ -438,6 +439,7 @@ impl BlinkImpl {
 
     async fn select_speaker(&mut self, device_name: &str) -> Result<(), Error> {
         let host = cpal::default_host();
+        // todo: use different code path if device_name is "default"
         let devices = match host.output_devices() {
             Ok(d) => d,
             Err(e) => {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -1148,6 +1148,14 @@ impl Blink for BlinkImpl {
         Err(Error::Unimplemented)
     }
 
+    async fn test_speaker(&self, _device_name: &str) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
+    async fn test_microphone(&self, _device_name: &str) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
     // ------ Media controls ------
 
     async fn mute_self(&mut self) -> Result<(), Error> {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -24,7 +24,7 @@ use std::{
     any::Any,
     collections::{HashMap, HashSet},
     str::FromStr,
-    sync::{atomic::AtomicBool, Arc},
+    sync::{Arc},
     time::Duration,
 };
 use webrtc::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;

--- a/tools/blink-repl/src/main.rs
+++ b/tools/blink-repl/src/main.rs
@@ -9,8 +9,8 @@ use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 use warp::{
     blink::{
-        AudioCodec, AudioCodecBuiler, AudioDeviceConfig, AudioSampleRate, Blink, BlinkEventKind,
-        BlinkEventStream, MimeType, VideoCodec,
+        AudioCodec, AudioCodecBuiler, AudioSampleRate, Blink, BlinkEventKind, BlinkEventStream,
+        MimeType, VideoCodec,
     },
     multipass::{MultiPass, MultiPassEventKind, MultiPassEventStream},
 };

--- a/tools/blink-repl/src/main.rs
+++ b/tools/blink-repl/src/main.rs
@@ -139,6 +139,8 @@ enum Repl {
         multiplier: u32,
     },
     Quit,
+    /// shorthand for quit
+    Q,
 }
 
 async fn handle_command(
@@ -148,7 +150,7 @@ async fn handle_command(
     cmd: Repl,
 ) -> anyhow::Result<()> {
     match cmd {
-        Repl::Quit => unreachable!("quit cmd should have been handled already"),
+        Repl::Q | Repl::Quit => unreachable!("quit cmd should have been handled already"),
         Repl::ShowDid => {
             println!("own identity: {}", own_id.did_key());
         }
@@ -426,11 +428,14 @@ async fn main() -> anyhow::Result<()> {
         let mut v = vec![""];
         v.extend(line.split_ascii_whitespace());
         let cli = match Repl::try_parse_from(v) {
-            Ok(Repl::Quit) => {
-                println!("quitting");
-                break;
+            Ok(r) => {
+                if matches!(r, Repl::Quit | Repl::Q) {
+                    println!("quitting");
+                    break;
+                } else {
+                    r
+                }
             }
-            Ok(r) => r,
             Err(e) => {
                 println!("{e}");
                 continue;

--- a/warp/src/blink/audio_config.rs
+++ b/warp/src/blink/audio_config.rs
@@ -1,0 +1,14 @@
+use anyhow::Result;
+pub trait AudioDeviceConfig: Send + Sync {
+    fn test_speaker(&self) -> Result<()>;
+    fn test_microphone(&self) -> Result<()>;
+
+    fn set_speaker(&mut self, device_name: &str);
+    fn set_microphone(&mut self, device_name: &str);
+
+    fn microphone_device_name(&self) -> Option<String>;
+    fn speaker_device_name(&self) -> Option<String>;
+
+    fn get_available_microphones(&self) -> Result<Vec<String>>;
+    fn get_available_speakers(&self) -> Result<Vec<String>>;
+}

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -19,6 +19,8 @@ use uuid::Uuid;
 
 mod codecs;
 pub use codecs::*;
+mod audio_config;
+pub use audio_config::*;
 
 use crate::{
     crypto::DID,
@@ -63,20 +65,17 @@ pub trait Blink: Sync + Send + SingleHandle + DynClone {
 
     // ------ Select input/output devices ------
 
-    async fn get_available_microphones(&self) -> Result<Vec<String>, Error>;
-    async fn get_current_microphone(&self) -> Option<String>;
-    async fn select_microphone(&mut self, device_name: &str) -> Result<(), Error>;
-    async fn select_default_microphone(&mut self) -> Result<(), Error>;
-    async fn get_available_speakers(&self) -> Result<Vec<String>, Error>;
-    async fn get_current_speaker(&self) -> Option<String>;
-    async fn select_speaker(&mut self, device_name: &str) -> Result<(), Error>;
-    async fn select_default_speaker(&mut self) -> Result<(), Error>;
+    /// returns an AudioDeviceConfig which can be used to view, test, and select
+    /// a speaker and microphone
+    async fn get_audio_device_config(&self) -> Box<dyn AudioDeviceConfig>;
+    /// Tell Blink to use the given AudioDeviceConfig for calling
+    async fn set_audio_device_config(
+        &mut self,
+        config: Box<dyn AudioDeviceConfig>,
+    ) -> Result<(), Error>;
+
     async fn get_available_cameras(&self) -> Result<Vec<String>, Error>;
     async fn select_camera(&mut self, device_name: &str) -> Result<(), Error>;
-    async fn select_default_camera(&mut self) -> Result<(), Error>;
-
-    async fn test_speaker(&self, device_name: &str) -> Result<(), Error>;
-    async fn test_microphone(&self, device_name: &str) -> Result<(), Error>;
 
     // ------ Media controls ------
 
@@ -144,6 +143,13 @@ pub enum BlinkEventKind {
     AudioOutputDeviceNoLongerAvailable,
     #[display(fmt = "AudioInputDeviceNoLongerAvailable")]
     AudioInputDeviceNoLongerAvailable,
+
+    // these names are so ridiculously long but i don't know
+    // what else to call them.
+    #[display(fmt = "ReceivedInputFromMicrophoneTest")]
+    ReceivingInputFromMicrophoneTest,
+    #[display(fmt = "PlayingOutputForSpeakerTest")]
+    PlayingOutputForSpeakerTest,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -75,6 +75,9 @@ pub trait Blink: Sync + Send + SingleHandle + DynClone {
     async fn select_camera(&mut self, device_name: &str) -> Result<(), Error>;
     async fn select_default_camera(&mut self) -> Result<(), Error>;
 
+    async fn test_speaker(&self, device_name: &str) -> Result<(), Error>;
+    async fn test_microphone(&self, device_name: &str) -> Result<(), Error>;
+
     // ------ Media controls ------
 
     async fn mute_self(&mut self) -> Result<(), Error>;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
The audio device configuration is now represented as a `AudioDeviceConfig` which abstracts the behavior needed to enumerate speakers/microphones and interact with them. The library user can obtain a `AudioDeviceConfig`  from Blink, view the currently selected speaker/microphone, enumerate speakers/microphones, and select/test combinations of them. The library user can then send the modified `AudioDeviceConfig`  back to Blink, telling it to use the selected speaker/microphone. 

The main point of this is to let the user test their speaker and microphone. The rest is just a refactor. Hopefully it's an improvement but if not I can change the Blink API back to what it was before. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
