### PR TITLE
feat(raygun): use MessageOptions.limit when fetching messages

### DIFF
--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -391,23 +391,19 @@ impl ConversationDocument {
                         continue
                     }
                 }
-
                 if let Ok(message) = document.resolve(&ipfs, &did, keystore.as_ref()).await {
                     if option.pinned() && !message.pinned() {
                         continue;
                     }
-                    if let Some(keyword) = option.keyword() {
-                        if message
+                    let should_yield = if let Some(keyword) = option.keyword() {
+                         message
                             .value()
                             .iter()
                             .any(|line| line.to_lowercase().contains(&keyword.to_lowercase()))
-                        {
-                            if let Some(remaining) = remaining.as_mut() {
-                                *remaining = remaining.saturating_sub(1);
-                            }
-                            yield message;
-                        }
                     } else {
+                        true
+                    };
+                    if should_yield {
                         if let Some(remaining) = remaining.as_mut() {
                             *remaining = remaining.saturating_sub(1);
                         }

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -376,7 +376,7 @@ impl ConversationDocument {
 
         let ipfs = ipfs.clone();
         let stream = async_stream::stream! {
-            let mut remaining: Option<i64> = option.limit();
+            let mut remaining = option.limit();
             for (index, document) in messages.iter().enumerate() {
                 if remaining.as_ref().map(|x| *x == 0).unwrap_or_default() {
                     break;

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -201,11 +201,13 @@ impl MessageOptions {
 
     pub fn set_range(mut self, range: Range<usize>) -> MessageOptions {
         self.range = Some(range);
+        self.limit = None;
         self
     }
 
     pub fn set_limit(mut self, limit: i64) -> MessageOptions {
         self.limit = Some(limit);
+        self.range = None;
         self
     }
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -201,13 +201,11 @@ impl MessageOptions {
 
     pub fn set_range(mut self, range: Range<usize>) -> MessageOptions {
         self.range = Some(range);
-        self.limit = None;
         self
     }
 
     pub fn set_limit(mut self, limit: u8) -> MessageOptions {
         self.limit = Some(limit);
-        self.range = None;
         self
     }
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -189,7 +189,7 @@ pub struct MessageOptions {
     keyword: Option<String>,
     pinned: bool,
     range: Option<Range<usize>>,
-    limit: Option<i64>,
+    limit: Option<u8>,
     skip: Option<i64>,
 }
 
@@ -205,7 +205,7 @@ impl MessageOptions {
         self
     }
 
-    pub fn set_limit(mut self, limit: i64) -> MessageOptions {
+    pub fn set_limit(mut self, limit: u8) -> MessageOptions {
         self.limit = Some(limit);
         self.range = None;
         self
@@ -255,7 +255,7 @@ impl MessageOptions {
 }
 
 impl MessageOptions {
-    pub fn limit(&self) -> Option<i64> {
+    pub fn limit(&self) -> Option<u8> {
         self.limit
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
if set, the `limit` will limit the number of messages yielded. This makes it easier to fetch the next X messages when scrolling up/down and makes it possible to fetch X messages before/after a pinned message. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
