### PR TITLE
chore: set minimum chrono version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ cfg-if = "1.0"
 once_cell = "1.16"
 
 # Time crate
-chrono = { version = "0.4" }
+chrono = { version = "~0.4.27" }
 
 # Encoding and Serializing Crates
 serde = { version = "1.0", features = ["derive", "rc"] }


### PR DESCRIPTION
The old minimum version of chrono was 0.4 (so 0.4.0 to 0.4.31 which is current).

Raygun has a method, from_naive_utc_and_offset, which was not added to chrono until 0.4.27 https://docs.rs/chrono/0.4.27/chrono/index.html?search=from_naive_utc_and_offset

Setting it to that as the minimum helps with issues if another library has a lower minimum

**What this PR does** 📖

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
