### PR TITLE
feat(blink): emit events when user mutes or deafens themself. 

### DIFF
--- a/extensions/warp-blink-wrtc/src/host_media/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/mod.rs
@@ -266,9 +266,6 @@ pub async fn deafen() -> anyhow::Result<()> {
     let _lock = LOCK.write().await;
     unsafe {
         DATA.deafened = true;
-    }
-
-    unsafe {
         for (_id, track) in DATA.audio_sink_tracks.iter() {
             track
                 .pause()
@@ -283,9 +280,6 @@ pub async fn undeafen() -> anyhow::Result<()> {
     let _lock = LOCK.write().await;
     unsafe {
         DATA.deafened = false;
-    }
-
-    unsafe {
         for (_id, track) in DATA.audio_sink_tracks.iter() {
             track
                 .play()

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -1132,9 +1132,7 @@ impl Blink for BlinkImpl {
         if self.active_call.read().await.is_none() {
             return Err(Error::CallNotInProgress);
         }
-        host_media::mute_self()
-            .await
-            .map_err(|e| warp::error::Error::OtherWithContext(e.to_string()))?;
+        host_media::mute_self().await?;
 
         let lock = self.ipfs.read().await;
         let ipfs = match lock.as_ref() {
@@ -1162,9 +1160,7 @@ impl Blink for BlinkImpl {
         if self.active_call.read().await.is_none() {
             return Err(Error::CallNotInProgress);
         }
-        host_media::unmute_self()
-            .await
-            .map_err(|e| warp::error::Error::OtherWithContext(e.to_string()))?;
+        host_media::unmute_self().await?;
 
         let lock = self.ipfs.read().await;
         let ipfs = match lock.as_ref() {

--- a/extensions/warp-blink-wrtc/src/lib.rs
+++ b/extensions/warp-blink-wrtc/src/lib.rs
@@ -629,7 +629,27 @@ async fn handle_webrtc(params: WebRtcHandlerParams, mut webrtc_event_stream: Web
                         }
                         webrtc_controller.write().await.hang_up(&sender).await;
                         if let Err(e) = ch.send(BlinkEventKind::ParticipantLeft { call_id, peer_id: sender }) {
-                            log::error!("failed to send ParticipantLeft Event: {e}");
+                            log::error!("failed to send ParticipantLeft event: {e}");
+                        }
+                    },
+                    CallSignal::Muted => {
+                        if let Err(e) = ch.send(BlinkEventKind::ParticipantMuted { peer_id: sender }) {
+                            log::error!("failed to send ParticipantMuted event: {e}");
+                        }
+                    },
+                    CallSignal::Unmuted => {
+                        if let Err(e) = ch.send(BlinkEventKind::ParticipantUnmuted { peer_id: sender }) {
+                            log::error!("failed to send ParticipantUnmuted event: {e}");
+                        }
+                    }
+                    CallSignal::Deafened => {
+                        if let Err(e) = ch.send(BlinkEventKind::ParticipantDeafened { peer_id: sender }) {
+                            log::error!("failed to send ParticipantDeafened event: {e}");
+                        }
+                    },
+                    CallSignal::Undeafened => {
+                        if let Err(e) = ch.send(BlinkEventKind::ParticipantUndeafened { peer_id: sender }) {
+                            log::error!("failed to send ParticipantUndeafened event: {e}");
                         }
                     },
                 }
@@ -1134,6 +1154,12 @@ impl Blink for BlinkImpl {
         host_media::unmute_self()
             .await
             .map_err(|e| warp::error::Error::OtherWithContext(e.to_string()))
+    }
+    async fn silence_call(&mut self) -> Result<(), Error> {
+        todo!()
+    }
+    async fn unsilence_call(&mut self) -> Result<(), Error> {
+        todo!()
     }
     async fn enable_camera(&mut self) -> Result<(), Error> {
         Err(Error::Unimplemented)

--- a/extensions/warp-blink-wrtc/src/signaling.rs
+++ b/extensions/warp-blink-wrtc/src/signaling.rs
@@ -28,6 +28,15 @@ pub enum CallSignal {
     Join { call_id: Uuid },
     #[display(fmt = "Leave")]
     Leave { call_id: Uuid },
+
+    #[display(fmt = "Muted")]
+    Muted,
+    #[display(fmt = "Unmuted")]
+    Unmuted,
+    #[display(fmt = "Deafened")]
+    Deafened,
+    #[display(fmt = "Undeafened")]
+    Undeafened,
 }
 
 #[derive(Serialize, Deserialize, Display)]

--- a/tools/blink-repl/src/main.rs
+++ b/tools/blink-repl/src/main.rs
@@ -59,6 +59,10 @@ enum Repl {
     MuteSelf,
     /// unmute self
     UnmuteSelf,
+    /// silence the call
+    Deafen,
+    /// unsilence the call
+    Undeafen,
     /// enable automute (enabled by default)
     EnableAutomute,
     /// disable automute
@@ -157,6 +161,8 @@ async fn handle_command(
         Repl::UnmuteSelf => {
             blink.unmute_self().await?;
         }
+        Repl::Deafen => blink.silence_call().await?,
+        Repl::Undeafen => blink.unsilence_call().await?,
         Repl::EnableAutomute => {
             blink.enable_automute()?;
         }

--- a/warp/src/blink/call_config.rs
+++ b/warp/src/blink/call_config.rs
@@ -1,0 +1,10 @@
+use crate::crypto::DID;
+
+#[derive(Default, Debug, Clone)]
+pub struct CallConfig {
+    pub recording: bool,
+    pub self_muted: bool,
+    pub self_deafened: bool,
+    pub participants_muted: Vec<DID>,
+    pub participants_deafened: Vec<DID>,
+}

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -77,6 +77,8 @@ pub trait Blink: Sync + Send + SingleHandle + DynClone {
 
     async fn mute_self(&mut self) -> Result<(), Error>;
     async fn unmute_self(&mut self) -> Result<(), Error>;
+    async fn silence_call(&mut self) -> Result<(), Error>;
+    async fn unsilence_call(&mut self) -> Result<(), Error>;
     async fn enable_camera(&mut self) -> Result<(), Error>;
     async fn disable_camera(&mut self) -> Result<(), Error>;
     async fn record_call(&mut self, output_dir: &str) -> Result<(), Error>;
@@ -127,6 +129,14 @@ pub enum BlinkEventKind {
     ParticipantSpeaking { peer_id: DID },
     #[display(fmt = "SelfSpeaking")]
     SelfSpeaking,
+    #[display(fmt = "ParticipantMuted")]
+    ParticipantMuted { peer_id: DID },
+    #[display(fmt = "ParticipantUnmuted")]
+    ParticipantUnmuted { peer_id: DID },
+    #[display(fmt = "ParticipantDeafened")]
+    ParticipantDeafened { peer_id: DID },
+    #[display(fmt = "ParticipantUndeafened")]
+    ParticipantUndeafened { peer_id: DID },
     /// audio packets were dropped for the peer
     #[display(fmt = "AudioDegradation")]
     AudioDegradation { peer_id: DID },

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -18,6 +18,8 @@ use mime_types::*;
 use uuid::Uuid;
 mod audio_config;
 pub use audio_config::*;
+mod call_config;
+pub use call_config::*;
 
 use crate::{
     crypto::DID,
@@ -83,6 +85,8 @@ pub trait Blink: Sync + Send + SingleHandle + DynClone {
     async fn disable_camera(&mut self) -> Result<(), Error>;
     async fn record_call(&mut self, output_dir: &str) -> Result<(), Error>;
     async fn stop_recording(&mut self) -> Result<(), Error>;
+
+    async fn get_call_config(&self) -> Result<Option<CallConfig>, Error>;
 
     fn enable_automute(&mut self) -> Result<(), Error>;
     fn disable_automute(&mut self) -> Result<(), Error>;

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -222,6 +222,10 @@ pub enum Error {
     // indicates a problem enumerating audio I/O devices
     #[error("AudioHostError: {_0}")]
     AudioHostError(String),
+    #[error("CallNotInProgress")]
+    CallNotInProgress,
+    #[error("BlinkNotInitialized")]
+    BlinkNotInitialized,
 
     //Misc
     #[error("Length for '{context}' is invalid. Current length: {current}. Minimum Length: {minimum:?}, Maximum: {maximum:?}")]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
emits signals when the user mutes/unmutes. 
emits signals when the user deafens/undeafens. 
when the user mutes themself, pause the source track. 
when the user deafens, pause the sink tracks, and don't play any newly created tracks. 
adds a `CallConfig` to blink, so the library user can request a struct that tells who is muted/deafened and if the call is being recorded. 

Resolve #347 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
