### PR TITLE
feat(blink): improve error handling

### DIFF
--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -83,16 +83,18 @@ impl SourceTrack for OpusSource {
     }
 
     fn play(&self) -> Result<(), Error> {
-        self.stream
-            .play()
-            .map_err(|x| Error::OtherWithContext(x.to_string()))?;
+        self.stream.play().map_err(|err| match err {
+            cpal::PlayStreamError::DeviceNotAvailable => Error::AudioDeviceDisconnected,
+            _ => Error::OtherWithContext(err.to_string()),
+        })?;
         *self.muted.write() = false;
         Ok(())
     }
     fn pause(&self) -> Result<(), Error> {
-        self.stream
-            .pause()
-            .map_err(|x| Error::OtherWithContext(x.to_string()))?;
+        self.stream.pause().map_err(|err| match err {
+            cpal::PauseStreamError::DeviceNotAvailable => Error::AudioDeviceDisconnected,
+            _ => Error::OtherWithContext(err.to_string()),
+        })?;
         *self.muted.write() = true;
         Ok(())
     }
@@ -118,9 +120,10 @@ impl SourceTrack for OpusSource {
         self.stream = stream;
         self.packetizer_handle = handle;
         if !*self.muted.read() {
-            self.stream
-                .play()
-                .map_err(|x| Error::OtherWithContext(x.to_string()))?;
+            self.stream.play().map_err(|err| match err {
+                cpal::PlayStreamError::DeviceNotAvailable => Error::AudioDeviceDisconnected,
+                _ => Error::OtherWithContext(err.to_string()),
+            })?;
         }
         Ok(())
     }

--- a/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
+++ b/extensions/warp-blink-wrtc/src/host_media/audio/opus/source/mod.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use cpal::{
     traits::{DeviceTrait, StreamTrait},
     SampleRate,
@@ -8,7 +7,7 @@ use ringbuf::HeapRb;
 
 use std::{ops::Mul, sync::Arc, time::Duration};
 use tokio::{sync::broadcast, task::JoinHandle};
-use warp::{blink::BlinkEventKind, crypto::DID};
+use warp::{blink::BlinkEventKind, crypto::DID, error::Error};
 
 use webrtc::{
     rtp::{self, extension::audio_level_extension::AudioLevelExtension, packetizer::Packetizer},
@@ -54,7 +53,7 @@ impl SourceTrack for OpusSource {
         track: Arc<TrackLocalStaticRTP>,
         webrtc_codec: AudioCodec,
         source_config: AudioHardwareConfig,
-    ) -> Result<Self>
+    ) -> Result<Self, Error>
     where
         Self: Sized,
     {
@@ -83,13 +82,17 @@ impl SourceTrack for OpusSource {
         })
     }
 
-    fn play(&self) -> Result<()> {
-        self.stream.play()?;
+    fn play(&self) -> Result<(), Error> {
+        self.stream
+            .play()
+            .map_err(|x| Error::OtherWithContext(x.to_string()))?;
         *self.muted.write() = false;
         Ok(())
     }
-    fn pause(&self) -> Result<()> {
-        self.stream.pause()?;
+    fn pause(&self) -> Result<(), Error> {
+        self.stream
+            .pause()
+            .map_err(|x| Error::OtherWithContext(x.to_string()))?;
         *self.muted.write() = true;
         Ok(())
     }
@@ -98,8 +101,10 @@ impl SourceTrack for OpusSource {
         &mut self,
         input_device: &cpal::Device,
         source_config: AudioHardwareConfig,
-    ) -> Result<()> {
-        self.stream.pause()?;
+    ) -> Result<(), Error> {
+        self.stream
+            .pause()
+            .map_err(|x| Error::OtherWithContext(x.to_string()))?;
         self.packetizer_handle.abort();
         let (stream, handle) = create_source_track(
             input_device,
@@ -113,18 +118,20 @@ impl SourceTrack for OpusSource {
         self.stream = stream;
         self.packetizer_handle = handle;
         if !*self.muted.read() {
-            self.stream.play()?;
+            self.stream
+                .play()
+                .map_err(|x| Error::OtherWithContext(x.to_string()))?;
         }
         Ok(())
     }
 
-    fn init_mp4_logger(&mut self) -> Result<()> {
+    fn init_mp4_logger(&mut self) -> Result<(), Error> {
         let mp4_logger = mp4_logger::get_audio_logger(&self.own_id)?;
         self.mp4_logger.write().replace(mp4_logger);
         Ok(())
     }
 
-    fn remove_mp4_logger(&mut self) -> Result<()> {
+    fn remove_mp4_logger(&mut self) -> Result<(), Error> {
         self.mp4_logger.write().take();
         Ok(())
     }
@@ -138,7 +145,7 @@ fn create_source_track(
     event_ch: broadcast::Sender<BlinkEventKind>,
     mp4_writer: Arc<warp::sync::RwLock<Option<Box<dyn Mp4LoggerInstance>>>>,
     muted: Arc<warp::sync::RwLock<bool>>,
-) -> Result<(cpal::Stream, JoinHandle<()>)> {
+) -> Result<(cpal::Stream, JoinHandle<()>), Error> {
     let config = cpal::StreamConfig {
         channels: source_config.channels(),
         sample_rate: SampleRate(source_config.sample_rate()),

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -148,6 +148,8 @@ pub enum BlinkEventKind {
     AudioOutputDeviceNoLongerAvailable,
     #[display(fmt = "AudioInputDeviceNoLongerAvailable")]
     AudioInputDeviceNoLongerAvailable,
+    #[display(fmt = "AudioStreamError")]
+    AudioStreamError,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -264,11 +264,7 @@ impl TryFrom<&str> for MimeType {
             MIME_TYPE_G722 => MimeType::G722,
             MIME_TYPE_PCMU => MimeType::PCMU,
             MIME_TYPE_PCMA => MimeType::PCMA,
-            _ => {
-                return Err(Error::InvalidMimeType {
-                    mime_type: value.into(),
-                })
-            }
+            _ => return Err(Error::InvalidMimeType(value.into())),
         };
         Ok(mime_type)
     }

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -215,13 +215,17 @@ pub enum Error {
     InvalidDataType,
 
     //Blink Errors
-    #[error("Invalid MIME type: {mime_type}")]
-    InvalidMimeType { mime_type: String },
+    #[error("Invalid MIME type: {_0}")]
+    InvalidMimeType(String),
     #[error("Device not found")]
     AudioDeviceNotFound,
     // indicates a problem enumerating audio I/O devices
     #[error("AudioHostError: {_0}")]
     AudioHostError(String),
+    #[error("MicrophoneMissing")]
+    MicrophoneMissing,
+    #[error("SpeakerMissing")]
+    SpeakerMissing,
     #[error("CallNotInProgress")]
     CallNotInProgress,
     #[error("BlinkNotInitialized")]

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -215,21 +215,23 @@ pub enum Error {
     InvalidDataType,
 
     //Blink Errors
-    #[error("Invalid MIME type: {_0}")]
-    InvalidMimeType(String),
     #[error("Device not found")]
     AudioDeviceNotFound,
     // indicates a problem enumerating audio I/O devices
     #[error("AudioHostError: {_0}")]
     AudioHostError(String),
+    #[error("BlinkNotInitialized")]
+    BlinkNotInitialized,
+    #[error("CallNotInProgress")]
+    CallNotInProgress,
+    #[error("Invalid MIME type: {_0}")]
+    InvalidMimeType(String),
+    #[error("InvalidAudioConfig")]
+    InvalidAudioConfig,
     #[error("MicrophoneMissing")]
     MicrophoneMissing,
     #[error("SpeakerMissing")]
     SpeakerMissing,
-    #[error("CallNotInProgress")]
-    CallNotInProgress,
-    #[error("BlinkNotInitialized")]
-    BlinkNotInitialized,
 
     //Misc
     #[error("Length for '{context}' is invalid. Current length: {current}. Minimum Length: {minimum:?}, Maximum: {maximum:?}")]

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -215,8 +215,10 @@ pub enum Error {
     InvalidDataType,
 
     //Blink Errors
-    #[error("Device not found")]
+    #[error("Audio device not found")]
     AudioDeviceNotFound,
+    #[error("AudioDeviceDisconnected")]
+    AudioDeviceDisconnected,
     // indicates a problem enumerating audio I/O devices
     #[error("AudioHostError: {_0}")]
     AudioHostError(String),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
This PR adds new errors to `warp::error:Error`, which are used when blink attempts to build an audio stream for an input or output device. These new error codes will help the UI inform the user why they weren't able to initiate/join a call. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
