### PR TITLE
refactor: Replace broadcast with event subscriptions 

### DIFF
--- a/extensions/warp-ipfs/src/store/event_subscription.rs
+++ b/extensions/warp-ipfs/src/store/event_subscription.rs
@@ -1,0 +1,141 @@
+use futures::{
+    channel::{
+        mpsc::{channel, Receiver, Sender},
+        oneshot,
+    },
+    stream::BoxStream,
+    SinkExt, StreamExt,
+};
+use std::task::{Poll, Waker};
+use std::{collections::VecDeque, sync::Arc};
+use warp::error::Error;
+
+#[allow(clippy::large_enum_variant)]
+enum Command<T: Clone + Send + 'static> {
+    Subscribe {
+        response: oneshot::Sender<Receiver<T>>,
+    },
+    Emit {
+        event: T,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct EventSubscription<T: Clone + Send + 'static> {
+    tx: Sender<Command<T>>,
+    task: Arc<tokio::task::JoinHandle<()>>,
+}
+
+impl<T: Clone + Send + 'static> EventSubscription<T> {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let (tx, rx) = futures::channel::mpsc::channel(0);
+
+        let mut task = EventSubscriptionTask {
+            queue: Default::default(),
+            senders: Default::default(),
+            waker: None,
+            rx,
+        };
+
+        let handle = tokio::spawn(async move {
+            task.start().await;
+        });
+
+        Self {
+            tx,
+            task: Arc::new(handle),
+        }
+    }
+
+    pub async fn subscribe<'a>(&self) -> Result<BoxStream<'a, T>, Error> {
+        let (tx, rx) = futures::channel::oneshot::channel();
+
+        let _ = self
+            .tx
+            .clone()
+            .send(Command::Subscribe { response: tx })
+            .await;
+
+        Ok(rx.await.map_err(anyhow::Error::from)?.boxed())
+    }
+
+    pub async fn emit(&self, event: T) {
+        let _ = self.tx.clone().send(Command::Emit { event }).await;
+    }
+}
+
+impl<T: Clone + Send + 'static> Drop for EventSubscription<T> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self.task) == 1 && !self.task.is_finished() {
+            self.task.abort();
+        }
+    }
+}
+
+pub struct EventSubscriptionTask<T: Clone + Send + 'static> {
+    senders: Vec<Sender<T>>,
+    queue: VecDeque<T>,
+    rx: Receiver<Command<T>>,
+    waker: Option<Waker>,
+}
+
+impl<T: Clone + Send + 'static> EventSubscriptionTask<T> {
+    pub async fn start(&mut self) {
+        loop {
+            tokio::select! {
+                _ = futures::future::poll_fn(|cx|  -> Poll<T>{
+                    if let Some(event) = self.queue.pop_front() {
+                        let mut count = 0;
+                        self.senders.retain_mut(|sender| {
+                            if sender.is_closed() {
+                                return false;
+                            }
+
+                            match sender.poll_ready(cx) {
+                                Ready(Ok(_)) => {
+                                    _ = sender.start_send(event.clone());
+                                    count += 1;
+                                }
+                                Ready(Err(e)) => {
+                                    if e.is_disconnected() {
+                                        return false;
+                                    }
+                                }
+                                Pending => (),
+                            }
+                            true
+                        });
+
+                        if count == 0 {
+                            self.queue.push_front(event);
+                        }
+                    }
+                    self.waker = Some(cx.waker().clone());
+                    Poll::Pending
+                }) => {}
+                Some(command) = self.rx.next() => {
+                    match command {
+                        Command::Subscribe { response } => {
+                            _ = response.send(self.subscribe())
+                        },
+                        Command::Emit { event } => self.emit(event),
+                    }
+                }
+            }
+        }
+    }
+
+    fn subscribe(&mut self) -> Receiver<T> {
+        let (tx, rx) = channel(1);
+        self.senders.push(tx);
+        rx
+    }
+
+    fn emit(&mut self, event: T) {
+        self.queue.push_back(event);
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+}

--- a/extensions/warp-ipfs/src/store/event_subscription.rs
+++ b/extensions/warp-ipfs/src/store/event_subscription.rs
@@ -63,6 +63,10 @@ impl<T: Clone + Send + 'static> EventSubscription<T> {
     pub async fn emit(&self, event: T) {
         let _ = self.tx.clone().send(Command::Emit { event }).await;
     }
+
+    pub fn try_emit(&self, event: T) {
+        let _ = self.tx.clone().try_send(Command::Emit { event });
+    }
 }
 
 impl<T: Clone + Send + 'static> Drop for EventSubscription<T> {
@@ -73,7 +77,7 @@ impl<T: Clone + Send + 'static> Drop for EventSubscription<T> {
     }
 }
 
-pub struct EventSubscriptionTask<T: Clone + Send + 'static> {
+struct EventSubscriptionTask<T: Clone + Send + 'static> {
     senders: Vec<Sender<T>>,
     queue: VecDeque<T>,
     rx: Receiver<Command<T>>,

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -1,3 +1,4 @@
+pub mod event_subscription;
 pub mod conversation;
 pub mod discovery;
 pub mod document;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Replaces the broadcast system with its own broadcast using future channels.

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

- N/A
**Special notes for reviewers** 🗒️

**Additional comments** 🎤
Previously, we were using broadcast from tokio to emit an event across all subscribers, however, the broadcast does not queue previous messages and would drop messages if there is no active receiver. This created a problem around online indicators where it may not emit an event if the receiver is not being polled and as a result may cause the message to drop or be ignored and not indicating to the subscribers of the event stream about any online/offline indication. This PR changes that by storing a list of senders for a given receiver and when an event is emitted, it would not immediately emit the event to the channels but queue the event internally and push it out to all senders that are ready and active. If there is no active receivers,  no senders, or all the senders are not ready to have anything emitted on the channel, it would retain the events until it is ready
