### PR TITLE
chore: Push relay connection to a background task

### DIFF
--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -105,6 +105,7 @@ pub struct RelayClient {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     /// List of relays to use
     pub relay_address: Vec<Multiaddr>,
+    pub background: bool,
 }
 
 impl Default for RelayClient {
@@ -120,7 +121,8 @@ impl Default for RelayClient {
                 //NYC-1-EXP
                 "/ip4/24.199.86.91/udp/46315/quic-v1/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap(),
                 "/ip4/24.199.86.91/tcp/46315/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap()
-            ]
+            ],
+            background: true
         }
     }
 }

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -368,29 +368,43 @@ impl WarpIpfs {
         }
 
         // Use the selected relays
-        for relay_peer in relay_peers {
-            match tokio::time::timeout(Duration::from_secs(5), ipfs.enable_relay(Some(relay_peer)))
-                .await
-            {
-                Ok(Ok(_)) => {}
-                Ok(Err(e)) => {
-                    error!("Failed to use {relay_peer} as a relay: {e}");
-                    continue;
-                }
-                Err(_) => {
-                    error!("Relay connection timed out");
-                    continue;
-                }
-            };
+        let relay_connection_task = {
+            let ipfs = ipfs.clone();
+            async move {
+                for relay_peer in relay_peers {
+                    match tokio::time::timeout(
+                        Duration::from_secs(5),
+                        ipfs.enable_relay(Some(relay_peer)),
+                    )
+                    .await
+                    {
+                        Ok(Ok(_)) => {}
+                        Ok(Err(e)) => {
+                            error!("Failed to use {relay_peer} as a relay: {e}");
+                            continue;
+                        }
+                        Err(_) => {
+                            error!("Relay connection timed out");
+                            continue;
+                        }
+                    };
 
-            let list = ipfs.list_relays(true).await.unwrap_or_default();
-            for addr in list
-                .iter()
-                .filter(|(peer_id, _)| *peer_id == relay_peer)
-                .flat_map(|(_, addrs)| addrs)
-            {
-                info!("Listening on {}", addr.clone().with(Protocol::P2pCircuit));
+                    let list = ipfs.list_relays(true).await.unwrap_or_default();
+                    for addr in list
+                        .iter()
+                        .filter(|(peer_id, _)| *peer_id == relay_peer)
+                        .flat_map(|(_, addrs)| addrs)
+                    {
+                        info!("Listening on {}", addr.clone().with(Protocol::P2pCircuit));
+                    }
+                }
             }
+        };
+
+        if config.ipfs_setting.relay_client.background {
+            tokio::spawn(relay_connection_task);
+        } else {
+            relay_connection_task.await;
         }
 
         if config.ipfs_setting.dht_client


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Push relay connections to a background task to keep the flow of initialization going, while allowing disabling of spawning a task
- Added a config option to allow selecting the first, specific number or all of the relays for connections and creating a reservation

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
N/A

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
