### PR TITLE
refactor: Split metadata from IdentityDocument

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -737,20 +737,20 @@ impl MultiPass for WarpIpfs {
 
                 debug!("Image cid: {cid}");
 
-                if let Some(picture_cid) = identity.profile_picture {
+                if let Some(picture_cid) = identity.metadata.profile_picture {
                     if picture_cid == cid {
                         debug!("Picture is already on document. Not updating identity");
                         return Ok(());
                     }
 
-                    if let Some(banner_cid) = identity.profile_banner {
+                    if let Some(banner_cid) = identity.metadata.profile_banner {
                         if picture_cid != banner_cid {
                             old_cid = Some(picture_cid);
                         }
                     }
                 }
 
-                identity.profile_picture = Some(cid);
+                identity.metadata.profile_picture = Some(cid);
                 store.identity_update(identity).await?;
             }
             IdentityUpdate::PicturePath(path) => {
@@ -812,24 +812,24 @@ impl MultiPass for WarpIpfs {
 
                 debug!("Image cid: {cid}");
 
-                if let Some(picture_cid) = identity.profile_picture {
+                if let Some(picture_cid) = identity.metadata.profile_picture {
                     if picture_cid == cid {
                         debug!("Picture is already on document. Not updating identity");
                         return Ok(());
                     }
 
-                    if let Some(banner_cid) = identity.profile_banner {
+                    if let Some(banner_cid) = identity.metadata.profile_banner {
                         if picture_cid != banner_cid {
                             old_cid = Some(picture_cid);
                         }
                     }
                 }
 
-                identity.profile_picture = Some(cid);
+                identity.metadata.profile_picture = Some(cid);
                 store.identity_update(identity).await?;
             }
             IdentityUpdate::ClearPicture => {
-                let document = identity.profile_picture.take();
+                let document = identity.metadata.profile_picture.take();
                 if let Some(cid) = document {
                     old_cid = Some(cid);
                 }
@@ -876,20 +876,20 @@ impl MultiPass for WarpIpfs {
 
                 debug!("Image cid: {cid}");
 
-                if let Some(banner_cid) = identity.profile_banner {
+                if let Some(banner_cid) = identity.metadata.profile_banner {
                     if banner_cid == cid {
                         debug!("Banner is already on document. Not updating identity");
                         return Ok(());
                     }
 
-                    if let Some(picture_cid) = identity.profile_picture {
+                    if let Some(picture_cid) = identity.metadata.profile_picture {
                         if picture_cid != banner_cid {
                             old_cid = Some(banner_cid);
                         }
                     }
                 }
 
-                identity.profile_banner = Some(cid);
+                identity.metadata.profile_banner = Some(cid);
                 store.identity_update(identity).await?;
             }
             IdentityUpdate::BannerPath(path) => {
@@ -951,24 +951,24 @@ impl MultiPass for WarpIpfs {
 
                 debug!("Image cid: {cid}");
 
-                if let Some(banner_cid) = identity.profile_banner {
+                if let Some(banner_cid) = identity.metadata.profile_banner {
                     if banner_cid == cid {
                         debug!("Banner is already on document. Not updating identity");
                         return Ok(());
                     }
 
-                    if let Some(picture_cid) = identity.profile_picture {
+                    if let Some(picture_cid) = identity.metadata.profile_picture {
                         if picture_cid != banner_cid {
                             old_cid = Some(banner_cid);
                         }
                     }
                 }
 
-                identity.profile_banner = Some(cid);
+                identity.metadata.profile_banner = Some(cid);
                 store.identity_update(identity).await?;
             }
             IdentityUpdate::ClearBanner => {
-                let document = identity.profile_banner.take();
+                let document = identity.metadata.profile_banner.take();
                 if let Some(cid) = document {
                     old_cid = Some(cid);
                 }

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -22,11 +22,9 @@ pub struct IdentityDocument {
 
     pub did: DID,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub created: Option<DateTime<Utc>>,
+    pub created: DateTime<Utc>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub modified: Option<DateTime<Utc>>,
+    pub modified: DateTime<Utc>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
@@ -62,8 +60,8 @@ impl From<Identity> for IdentityDocument {
         let did = identity.did_key();
         let short_id = *identity.short_id();
         let status_message = identity.status_message();
-        let created = Some(identity.created());
-        let modified = Some(identity.modified());
+        let created = identity.created();
+        let modified = identity.modified();
 
         IdentityDocument {
             username,
@@ -92,8 +90,8 @@ impl From<&IdentityDocument> for Identity {
         identity.set_short_id(document.short_id);
         identity.set_status_message(document.status_message.clone());
         identity.set_username(&document.username);
-        identity.set_created(document.created.unwrap_or(Utc::now()));
-        identity.set_modified(document.modified.unwrap_or(Utc::now()));
+        identity.set_created(document.created);
+        identity.set_modified(document.modified);
         identity
     }
 }
@@ -145,11 +143,9 @@ impl IdentityDocument {
         //identification process, but will include it after it is signed
         self.metadata = Default::default();
         self.signature = None;
-        if self.created.is_none() {
-            self.created = Some(Utc::now());
-        }
-        self.modified = Some(Utc::now());
-        
+
+        self.modified = Utc::now();
+
         let bytes = serde_json::to_vec(&self)?;
         let signature = bs58::encode(did.sign(&bytes)).into_string();
         self.metadata = metadata;

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -29,7 +29,7 @@ pub struct IdentityDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
 
-    #[serde(default, flatten)]
+    #[serde(default, flatten, skip_serializing_if = "IdentityMetadata::is_empty")]
     pub metadata: IdentityMetadata,
 
     #[serde(default)]
@@ -52,6 +52,15 @@ pub struct IdentityMetadata {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<IdentityStatus>,
+}
+
+impl IdentityMetadata {
+    fn is_empty(&self) -> bool {
+        self.profile_picture.is_none()
+            || self.profile_banner.is_none()
+            || self.platform.is_none()
+            || self.status.is_none()
+    }
 }
 
 impl From<Identity> for IdentityDocument {

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -9,6 +9,7 @@ use warp::{
 };
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all="lowercase")]
 pub enum IdentityDocumentVersion {
     #[default]
     V0,
@@ -29,7 +30,6 @@ pub struct IdentityDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
 
-    #[serde(default, flatten)]
     pub metadata: IdentityMetadata,
 
     #[serde(default)]

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -196,6 +196,8 @@ impl IdentityDocument {
             }
         }
 
+        let _ = std::mem::take(&mut payload.metadata);
+
         let signature = std::mem::take(&mut payload.signature).ok_or(Error::InvalidSignature)?;
         let signature_bytes = bs58::decode(signature).into_vec()?;
         let bytes = serde_json::to_vec(&payload)?;

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -29,7 +29,7 @@ pub struct IdentityDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
 
-    #[serde(default, flatten, skip_serializing_if = "IdentityMetadata::is_empty")]
+    #[serde(default, flatten)]
     pub metadata: IdentityMetadata,
 
     #[serde(default)]
@@ -52,15 +52,6 @@ pub struct IdentityMetadata {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<IdentityStatus>,
-}
-
-impl IdentityMetadata {
-    fn is_empty(&self) -> bool {
-        self.profile_picture.is_none()
-            || self.profile_banner.is_none()
-            || self.platform.is_none()
-            || self.status.is_none()
-    }
 }
 
 impl From<Identity> for IdentityDocument {

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -524,7 +524,7 @@ impl RootDocumentTask {
         let mut root = self.get_root_document().await?;
         let mut identity = self.identity().await?;
         root.status = Some(status);
-        identity.status = Some(status);
+        identity.metadata.status = Some(status);
 
         let identity = identity.sign(&self.keypair)?;
         root.identity = self.ipfs.dag().put().serialize(identity)?.await?;

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1384,8 +1384,8 @@ impl IdentityStore {
                 .try_into()
                 .map_err(anyhow::Error::from)?,
             did: public_key.into(),
-            created: Some(time),
-            modified: Some(time),
+            created: time,
+            modified: time,
             status_message: None,
             metadata: Default::default(),
             version: Default::default(),

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -794,8 +794,7 @@ impl IdentityStore {
         ) && is_friend)
             && (!is_blocked && !is_blocked_by);
 
-        tracing::trace!("Including metadata in push: {include_meta}");
-
+        tracing::debug!(?metadata, included = include_meta);
         if include_meta {
             identity.metadata = metadata;
         }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -305,7 +305,7 @@ impl IdentityStore {
         };
 
         if let Ok(ident) = store.own_identity().await {
-            tracing::info!("Identity loaded with {}", ident.did_key());
+            tracing::info!(did = %ident.did_key(), "Identity loaded");
         }
 
         let did = store.get_keypair_did()?;
@@ -402,7 +402,7 @@ impl IdentityStore {
                                 }
                             };
 
-                            tracing::debug!("Event: {event:?}");
+                            tracing::debug!(from = %in_did, event = ?event);
 
                             if let Err(e) = store.process_message(&in_did, event).await {
                                 error!("Failed to process identity message from {in_did}: {e}");
@@ -491,14 +491,15 @@ impl IdentityStore {
             match data.version {
                 RequestResponsePayloadVersion::V0 => {
                     tracing::warn!(
-                        sender = data.sender.to_string(),
+                        sender = %data.sender,
                         "Request received from a old implementation. Unable to verify signature."
                     );
                 }
                 _ => {
                     tracing::warn!(
-                        sender = data.sender.to_string(),
-                        "Unable to verify signature {e}. Ignoreing request"
+                        sender = %data.sender,
+                        error = %e,
+                        "Unable to verify signature. Ignoreing request"
                     );
                     return Ok(());
                 }
@@ -737,9 +738,7 @@ impl IdentityStore {
 
         let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
 
-        tracing::trace!("Payload size: {} bytes", bytes.len());
-
-        tracing::info!("Sending event to {out_did}");
+        tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
         if self
             .ipfs
@@ -750,7 +749,7 @@ impl IdentityStore {
             let timer = Instant::now();
             self.ipfs.pubsub_publish(out_did.events(), bytes).await?;
             let end = timer.elapsed();
-            tracing::info!("Event sent to {out_did}");
+            tracing::info!(to = %out_did, event = ?event, "Event sent");
             tracing::trace!("Took {}ms to send event", end.as_millis());
         }
 
@@ -811,9 +810,7 @@ impl IdentityStore {
 
         let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
 
-        tracing::trace!("Payload size: {} bytes", bytes.len());
-
-        tracing::info!("Sending event to {out_did}");
+        tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
         if self
             .ipfs
@@ -824,8 +821,8 @@ impl IdentityStore {
             let timer = Instant::now();
             self.ipfs.pubsub_publish(out_did.events(), bytes).await?;
             let end = timer.elapsed();
-            tracing::info!("Event sent to {out_did}");
-            tracing::trace!("Took {}ms to send event", end.as_millis());
+            tracing::info!(to = %out_did, event = ?event, "Event sent");
+            tracing::info!("Took {}ms to send event", end.as_millis());
         }
 
         Ok(())
@@ -873,9 +870,7 @@ impl IdentityStore {
 
         let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
 
-        tracing::trace!("Payload size: {} bytes", bytes.len());
-
-        tracing::info!("Sending event to {out_did}");
+        tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
         if self
             .ipfs
@@ -886,7 +881,7 @@ impl IdentityStore {
             let timer = Instant::now();
             self.ipfs.pubsub_publish(out_did.events(), bytes).await?;
             let end = timer.elapsed();
-            tracing::info!("Event sent to {out_did}");
+            tracing::info!(to = %out_did, event = ?event, "Event sent");
             tracing::trace!("Took {}ms to send event", end.as_millis());
         }
 
@@ -1001,7 +996,7 @@ impl IdentityStore {
                 match previous_identity {
                     Some(document) => {
                         if document.different(&identity) {
-                            tracing::info!("Updating local cache of {}", identity.did);
+                            tracing::info!(%identity.did, "Updating local cache");
 
                             let document_did = identity.did.clone();
 

--- a/extensions/warp-ipfs/tests/common.rs
+++ b/extensions/warp-ipfs/tests/common.rs
@@ -7,7 +7,7 @@ use warp::{
     tesseract::Tesseract,
 };
 use warp_ipfs::{
-    config::{Bootstrap, Discovery},
+    config::{Bootstrap, Discovery, UpdateEvents},
     WarpIpfsBuilder,
 };
 
@@ -63,6 +63,7 @@ pub async fn create_account(
     config.store_setting.share_platform = true;
     config.ipfs_setting.relay_client.relay_address = vec![];
     config.ipfs_setting.bootstrap = false;
+    config.store_setting.update_events = UpdateEvents::Enabled;
     config.bootstrap = Bootstrap::None;
 
     let (mut account, _, _) = WarpIpfsBuilder::default()
@@ -119,6 +120,7 @@ pub async fn create_account_and_chat(
         namespace: context,
         discovery_type: Default::default(),
     };
+    config.store_setting.update_events = UpdateEvents::Enabled;
     config.store_setting.share_platform = true;
     config.ipfs_setting.relay_client.relay_address = vec![];
     config.ipfs_setting.bootstrap = false;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Split metadata (specifically profile banner and image, platform and status) from `IdentityDocument`
- Introduce a version field to begin creating versions of the structures for important future changes and updates
- Remove `Option` from the timestamp fields 

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- N/A

**Special notes for reviewers** 🗒️
- This is a breaking change, which would require a new identity.

**Additional comments** 🎤
- Since the internal `IdentityDocument` is signed prior to being stored apart of the root document, or sent out to another user, we are had to include all of the metadata when signing the document. This made it harder to exclude specific metadata from the identity document without the owner updating and signing the document. With this change, however, we can allow those fields to be updated without affecting the integrity of the document itself, allowing for users to exclude the specific data on their end while retaining the data, which can allow reducing the logic when updating the cached document. This will also make it easier when it comes to #336 for external nodes to exclude data from the metadata profile without corrupting the document itself or creating additional round trips between the peer and the node for it to supply specific updates. 