### PR TITLE
refactor: Use a map for handling identity cache

### DIFF
--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -1,14 +1,15 @@
-use std::{collections::HashSet, path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use futures::{
     channel::{
         mpsc::{Receiver, Sender},
         oneshot::Sender as OneshotSender,
     },
-    SinkExt, StreamExt,
+    stream::{BoxStream, FuturesUnordered},
+    SinkExt, StreamExt, TryFutureExt,
 };
 use libipld::Cid;
-use rust_ipfs::Ipfs;
+use rust_ipfs::{Ipfs, IpfsPath};
 use warp::{crypto::DID, error::Error};
 
 use super::identity::IdentityDocument;
@@ -28,7 +29,7 @@ enum IdentityCacheCommand {
         response: OneshotSender<Result<(), Error>>,
     },
     List {
-        response: OneshotSender<Result<Vec<IdentityDocument>, Error>>,
+        response: OneshotSender<BoxStream<'static, IdentityDocument>>,
     },
 }
 
@@ -124,7 +125,7 @@ impl IdentityCache {
         rx.await.map_err(anyhow::Error::from)?
     }
 
-    pub async fn list(&self) -> Result<Vec<IdentityDocument>, Error> {
+    pub async fn list(&self) -> Result<BoxStream<'static, IdentityDocument>, Error> {
         let (tx, rx) = futures::channel::oneshot::channel();
 
         let _ = self
@@ -133,7 +134,7 @@ impl IdentityCache {
             .send(IdentityCacheCommand::List { response: tx })
             .await;
 
-        rx.await.map_err(anyhow::Error::from)?
+        rx.await.map_err(anyhow::Error::from).map_err(Error::from)
     }
 }
 
@@ -170,7 +171,7 @@ impl IdentityCacheTask {
     ) -> Result<Option<IdentityDocument>, Error> {
         document.verify()?;
 
-        let mut list: HashSet<IdentityDocument> = match self.list {
+        let mut list: HashMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -178,13 +179,28 @@ impl IdentityCacheTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashSet::new(),
+            None => HashMap::new(),
         };
 
-        let old_document = list
-            .iter()
-            .find(|old_doc| document.did == old_doc.did && document.short_id == old_doc.short_id)
-            .cloned();
+        let did_str = document.did.to_string();
+
+        let old_document = futures::future::ready(
+            list.get(&did_str)
+                .copied()
+                .ok_or(Error::IdentityDoesntExist),
+        )
+        .and_then(|id| {
+            let ipfs = self.ipfs.clone();
+            async move {
+                ipfs.get_dag(id)
+                    .local()
+                    .deserialized::<IdentityDocument>()
+                    .await
+                    .map_err(Error::from)
+            }
+        })
+        .await
+        .ok();
 
         match old_document {
             Some(old_document) => {
@@ -192,11 +208,29 @@ impl IdentityCacheTask {
                     return Ok(None);
                 }
 
-                list.replace(document);
+                let cid = self
+                    .ipfs
+                    .dag()
+                    .put()
+                    .serialize(document.clone())?
+                    .pin(false)
+                    .await?;
+
+                let old_cid = list.insert(did_str, cid);
+
+                if let Some(old_cid) = old_cid {
+                    if old_cid != cid {
+                        if self.ipfs.is_pinned(&old_cid).await? {
+                            self.ipfs.remove_pin(&old_cid, false).await?;
+                        }
+                        // Do we want to remove the old block?
+                        self.ipfs.remove_block(old_cid, false).await?;
+                    }
+                }
 
                 let cid = self.ipfs.dag().put().serialize(list)?.pin(false).await?;
 
-                let old_cid = self.list.take();
+                let old_cid = self.list.replace(cid);
 
                 let remove_pin_and_block = async {
                     if let Some(old_cid) = old_cid {
@@ -220,14 +254,42 @@ impl IdentityCacheTask {
                     }
                 }
 
-                self.list = Some(cid);
-
                 Ok(Some(old_document.clone()))
             }
             None => {
-                list.insert(document);
+                let cid = self
+                    .ipfs
+                    .dag()
+                    .put()
+                    .serialize(document.clone())?
+                    .pin(false)
+                    .await?;
+
+                let old_cid = list.insert(did_str, cid);
+
+                if let Some(old_cid) = old_cid {
+                    if old_cid != cid {
+                        if self.ipfs.is_pinned(&old_cid).await? {
+                            self.ipfs.remove_pin(&old_cid, false).await?;
+                        }
+                        // Do we want to remove the old block?
+                        self.ipfs.remove_block(old_cid, false).await?;
+                    }
+                }
 
                 let cid = self.ipfs.dag().put().serialize(list)?.pin(false).await?;
+
+                let old_cid = self.list.replace(cid);
+
+                if let Some(old_cid) = old_cid {
+                    if old_cid != cid {
+                        if self.ipfs.is_pinned(&old_cid).await? {
+                            self.ipfs.remove_pin(&old_cid, false).await?;
+                        }
+                        // Do we want to remove the old block?
+                        self.ipfs.remove_block(old_cid, false).await?;
+                    }
+                }
 
                 if let Some(path) = self.path.as_ref() {
                     let cid = cid.to_string();
@@ -236,36 +298,36 @@ impl IdentityCacheTask {
                     }
                 }
 
-                self.list = Some(cid);
-
                 Ok(None)
             }
         }
     }
 
     async fn get(&self, did: DID) -> Result<IdentityDocument, Error> {
-        let list: HashSet<IdentityDocument> = match self.list {
-            Some(cid) => self
-                .ipfs
-                .get_dag(cid)
-                .local()
-                .deserialized()
-                .await
-                .unwrap_or_default(),
-            None => HashSet::new(),
+        let cid = match self.list {
+            Some(cid) => cid,
+            None => return Err(Error::IdentityDoesntExist),
         };
 
-        let document = list
-            .iter()
-            .find(|document| document.did == did)
-            .cloned()
-            .ok_or(Error::IdentityDoesntExist)?;
+        let path = IpfsPath::from(cid).sub_path(&did.to_string())?;
 
-        Ok(document)
+        let id = self
+            .ipfs
+            .get_dag(path)
+            .local()
+            .deserialized::<IdentityDocument>()
+            .await
+            .map_err(|_| Error::IdentityDoesntExist)?;
+
+        debug_assert_eq!(id.did, did);
+
+        id.verify()?;
+
+        Ok(id)
     }
 
     async fn remove(&mut self, did: DID) -> Result<(), Error> {
-        let mut list: HashSet<IdentityDocument> = match self.list {
+        let mut list: HashMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -278,21 +340,22 @@ impl IdentityCacheTask {
             }
         };
 
-        let old_document = list.iter().find(|document| document.did == did).cloned();
+        let old_document = match list.remove(&did.to_string()) {
+            Some(cid) => cid,
+            None => return Err(Error::IdentityDoesntExist),
+        };
 
-        if old_document.is_none() {
-            return Err(Error::IdentityDoesntExist);
+        if self.ipfs.is_pinned(&old_document).await.unwrap_or_default() {
+            self.ipfs.remove_pin(&old_document, false).await?;
         }
 
-        let document = old_document.expect("Exist");
-
-        if !list.remove(&document) {
-            return Err(Error::IdentityDoesntExist);
+        if let Err(e) = self.ipfs.remove_block(old_document, false).await {
+            tracing::warn!(cid = %old_document, id = %did, "Unable to remove block: {e}");
         }
 
         let cid = self.ipfs.dag().put().serialize(list)?.pin(false).await?;
 
-        let old_cid = self.list.take();
+        let old_cid = self.list.replace(cid);
 
         if let Some(old_cid) = old_cid {
             if cid != old_cid {
@@ -311,13 +374,11 @@ impl IdentityCacheTask {
             }
         }
 
-        self.list = Some(cid);
-
         Ok(())
     }
 
-    async fn list(&self) -> Result<Vec<IdentityDocument>, Error> {
-        let list: HashSet<IdentityDocument> = match self.list {
+    async fn list(&self) -> BoxStream<'static, IdentityDocument> {
+        let list: HashMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -325,9 +386,22 @@ impl IdentityCacheTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashSet::new(),
+            None => HashMap::new(),
         };
 
-        Ok(Vec::from_iter(list))
+        let ipfs = self.ipfs.clone();
+
+        FuturesUnordered::from_iter(list.values().copied().map(|cid| {
+            let ipfs = ipfs.clone();
+            async move {
+                ipfs.get_dag(cid)
+                    .local()
+                    .deserialized::<IdentityDocument>()
+                    .await
+            }
+        }))
+        .filter_map(|id_result| async move { id_result.ok() })
+        .filter(|id| futures::future::ready(id.verify().is_ok()))
+        .boxed()
     }
 }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -7,11 +7,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 
-use futures::{
-    channel::oneshot,
-    stream::{FuturesUnordered, SelectAll},
-    StreamExt,
-};
+use futures::{channel::oneshot, stream::SelectAll, StreamExt};
 use ipfs::{Ipfs, Keypair};
 use libipld::Cid;
 use rust_ipfs as ipfs;
@@ -1436,8 +1432,6 @@ impl IdentityStore {
             .map(|identity| identity.did_key())
             .map_err(|_| Error::OtherWithContext("Identity store may not be initialized".into()))?;
 
-        let mut preidentity = vec![];
-
         let idents_docs = match &lookup {
             //Note: If this returns more than one identity, then its likely due to frontend cache not clearing out.
             //TODO: Maybe move cache into the backend to serve as a secondary cache
@@ -1557,12 +1551,10 @@ impl IdentityStore {
             }
         };
 
-        let mut list = idents_docs
+        let list = idents_docs
             .iter()
             .filter_map(|doc| doc.resolve().ok())
             .collect::<Vec<_>>();
-
-        list.extend(preidentity);
 
         Ok(list)
     }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -7,13 +7,17 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 
-use futures::{channel::oneshot, StreamExt};
+use futures::{
+    channel::oneshot,
+    stream::{FuturesUnordered, SelectAll},
+    StreamExt,
+};
 use ipfs::{Ipfs, Keypair};
 use libipld::Cid;
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     path::PathBuf,
     time::{Duration, Instant},
 };
@@ -1450,15 +1454,14 @@ impl IdentityStore {
                 self.identity_cache
                     .list()
                     .await?
-                    .iter()
-                    .filter(|ident| ident.did == *pubkey)
-                    .cloned()
+                    .filter(|ident| {
+                        let ident = ident.clone();
+                        async move { ident.did == *pubkey }
+                    })
                     .collect::<Vec<_>>()
+                    .await
             }
             LookupBy::DidKeys(list) => {
-                let mut items = HashSet::new();
-                let cache = self.identity_cache.list().await?;
-
                 for pubkey in list {
                     if !pubkey.eq(&own_did) && !self.discovery.contains(pubkey).await {
                         if let Err(e) = self.discovery.insert(pubkey).await {
@@ -1467,23 +1470,23 @@ impl IdentityStore {
                     }
                 }
 
-                for pubkey in list {
-                    if own_did.eq(pubkey) {
-                        let own_identity = match self.own_identity().await {
-                            Ok(id) => id,
-                            Err(_) => continue,
-                        };
-                        if !preidentity.contains(&own_identity) {
-                            preidentity.push(own_identity);
-                        }
-                        continue;
-                    }
+                let mut prestream = SelectAll::new();
 
-                    if let Some(cache) = cache.iter().find(|cache| cache.did.eq(pubkey)) {
-                        items.insert(cache.clone());
+                if list.contains(&own_did) {
+                    if let Ok(own_identity) = self.own_identity_document().await {
+                        prestream.push(futures::stream::iter(vec![own_identity]));
                     }
                 }
-                Vec::from_iter(items)
+
+                let cache = self.identity_cache.list().await?;
+                cache
+                    .filter(|id| {
+                        let id = id.clone();
+                        async move { list.contains(&id.did) }
+                    })
+                    .chain(prestream.boxed())
+                    .collect::<Vec<_>>()
+                    .await
             }
             LookupBy::Username(username) if username.contains('#') => {
                 let cache = self.identity_cache.list().await?;
@@ -1491,30 +1494,38 @@ impl IdentityStore {
 
                 if split_data.len() != 2 {
                     cache
-                        .iter()
                         .filter(|ident| {
-                            ident
-                                .username
-                                .to_lowercase()
-                                .contains(&username.to_lowercase())
+                            let ident = ident.clone();
+                            async move {
+                                ident
+                                    .username
+                                    .to_lowercase()
+                                    .contains(&username.to_lowercase())
+                            }
                         })
-                        .cloned()
                         .collect::<Vec<_>>()
+                        .await
                 } else {
                     match (
                         split_data.first().map(|s| s.to_lowercase()),
                         split_data.last().map(|s| s.to_lowercase()),
                     ) {
-                        (Some(name), Some(code)) => cache
-                            .iter()
-                            .filter(|ident| {
-                                ident.username.to_lowercase().eq(&name)
-                                    && String::from_utf8_lossy(&ident.short_id)
-                                        .to_lowercase()
-                                        .eq(&code)
-                            })
-                            .cloned()
-                            .collect::<Vec<_>>(),
+                        (Some(name), Some(code)) => {
+                            cache
+                                .filter(|ident| {
+                                    let ident = ident.clone();
+                                    let name = name.clone();
+                                    let code = code.clone();
+                                    async move {
+                                        ident.username.to_lowercase().eq(&name)
+                                            && String::from_utf8_lossy(&ident.short_id)
+                                                .to_lowercase()
+                                                .eq(&code)
+                                    }
+                                })
+                                .collect::<Vec<_>>()
+                                .await
+                        }
                         _ => vec![],
                     }
                 }
@@ -1524,19 +1535,26 @@ impl IdentityStore {
                 self.identity_cache
                     .list()
                     .await?
-                    .iter()
-                    .filter(|ident| ident.username.to_lowercase().contains(&username))
-                    .cloned()
+                    .filter(|ident| {
+                        let ident = ident.clone();
+                        let username = username.clone();
+                        async move { ident.username.to_lowercase().contains(&username) }
+                    })
                     .collect::<Vec<_>>()
+                    .await
             }
-            LookupBy::ShortId(id) => self
-                .identity_cache
-                .list()
-                .await?
-                .iter()
-                .filter(|ident| String::from_utf8_lossy(&ident.short_id).eq(id))
-                .cloned()
-                .collect::<Vec<_>>(),
+            LookupBy::ShortId(id) => {
+                self.identity_cache
+                    .list()
+                    .await?
+                    .filter(|ident| {
+                        let ident = ident.clone();
+                        let id = id.clone();
+                        async move { String::from_utf8_lossy(&ident.short_id).eq(&id) }
+                    })
+                    .collect::<Vec<_>>()
+                    .await
+            }
         };
 
         let mut list = idents_docs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Utilize a map for identity cache instead of a set
- Have `IdentityCache::list` return a stream 

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
