### PR TITLE
chore: Deprecate status from root document

### DIFF
--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -523,7 +523,6 @@ impl RootDocumentTask {
     async fn set_identity_status(&mut self, status: IdentityStatus) -> Result<(), Error> {
         let mut root = self.get_root_document().await?;
         let mut identity = self.identity().await?;
-        root.status = Some(status);
         identity.status = Some(status);
 
         let identity = identity.sign(&self.keypair)?;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Deprecate identity status from the root document (This disables setting it on the document until a later time when the field would be removed)
 
**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
N/A

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
