### PR TITLE
fix(blink): initialize CallData with own id

### DIFF
--- a/extensions/warp-blink-wrtc/src/blink_impl/blink_controller.rs
+++ b/extensions/warp-blink-wrtc/src/blink_impl/blink_controller.rs
@@ -477,7 +477,7 @@ async fn run(args: Args, mut cmd_rx: UnboundedReceiver<Cmd>, notify: Arc<Notify>
                             host_media::controller::mute_self().await;
                             let call_id = data.info.call_id();
                             data.state.set_self_muted(true);
-                            let own_state = data.state.participants_joined.get(own_id).cloned().unwrap_or_default();
+                            let own_state = data.get_participant_state(&own_id).unwrap_or_default();
                             let topic = ipfs_routes::call_signal_route(&call_id);
                             let signal = CallSignal::Announce { participant_state: own_state };
                             if let Err(e) =
@@ -492,7 +492,7 @@ async fn run(args: Args, mut cmd_rx: UnboundedReceiver<Cmd>, notify: Arc<Notify>
                             host_media::controller::unmute_self().await;
                             let call_id = data.info.call_id();
                             data.state.set_self_muted(false);
-                            let own_state = data.state.participants_joined.get(own_id).cloned().unwrap_or_default();
+                            let own_state = data.get_participant_state(&own_id).unwrap_or_default();
                             let topic = ipfs_routes::call_signal_route(&call_id);
                             let signal = CallSignal::Announce { participant_state: own_state };
                             if let Err(e) =
@@ -507,7 +507,7 @@ async fn run(args: Args, mut cmd_rx: UnboundedReceiver<Cmd>, notify: Arc<Notify>
                             let call_id = data.info.call_id();
                             host_media::controller::deafen().await;
                             data.state.set_deafened(own_id, true);
-                            let own_state = data.state.participants_joined.get(own_id).cloned().unwrap_or_default();
+                            let own_state = data.get_participant_state(&own_id).unwrap_or_default();
                             let topic = ipfs_routes::call_signal_route(&call_id);
                             let signal = CallSignal::Announce { participant_state: own_state };
                             if let Err(e) =
@@ -522,7 +522,7 @@ async fn run(args: Args, mut cmd_rx: UnboundedReceiver<Cmd>, notify: Arc<Notify>
                             let call_id = data.info.call_id();
                             host_media::controller::undeafen().await;
                             data.state.set_deafened(own_id, false);
-                            let own_state = data.state.participants_joined.get(own_id).cloned().unwrap_or_default();
+                            let own_state = data.get_participant_state(&own_id).unwrap_or_default();
                             let topic = ipfs_routes::call_signal_route(&call_id);
                             let signal = CallSignal::Announce { participant_state: own_state };
                             if let Err(e) =
@@ -555,7 +555,7 @@ async fn run(args: Args, mut cmd_rx: UnboundedReceiver<Cmd>, notify: Arc<Notify>
                             {
                                 Ok(_) => {
                                     data.state.set_self_recording(true);
-                                    let own_state = data.state.participants_joined.get(own_id).cloned().unwrap_or_default();
+                                    let own_state = data.get_participant_state(&own_id).unwrap_or_default();
                                     let topic = ipfs_routes::call_signal_route(&info.call_id());
                                     let signal = CallSignal::Announce { participant_state: own_state };
                                     if let Err(e) =
@@ -577,7 +577,7 @@ async fn run(args: Args, mut cmd_rx: UnboundedReceiver<Cmd>, notify: Arc<Notify>
                         if let Some(data) = call_data_map.get_active_mut() {
                             host_media::controller::pause_recording().await;
                             data.state.set_self_recording(false);
-                            let own_state = data.state.participants_joined.get(own_id).cloned().unwrap_or_default();
+                            let own_state = data.get_participant_state(&own_id).unwrap_or_default();
                             let topic = ipfs_routes::call_signal_route(&data.info.call_id());
                             let signal = CallSignal::Announce { participant_state: own_state };
                             if let Err(e) =

--- a/warp/src/blink/call_state.rs
+++ b/warp/src/blink/call_state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::crypto::DID;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct CallState {
     pub own_id: DID,
     pub participants_joined: HashMap<DID, ParticipantState>,

--- a/warp/src/blink/mod.rs
+++ b/warp/src/blink/mod.rs
@@ -149,7 +149,7 @@ pub enum BlinkEventKind {
     AudioStreamError,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
 pub struct CallInfo {
     call_id: Uuid,
     conversation_id: Option<Uuid>,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
Currently events are not being emitted when someone mutes/unmutes. This PR will fix that by adding `own_id` to `CallData` with `ParticipantState::default()` when a new call is added to `CallDataMap`. Without this any attempts to update the one's own `ParticipantState` will fail because the update code uses `participants_joined.get_mut()` and participants are otherwise only added in response to `CallSignal::Announce`. 

It also adds a utilty function to `CallData` to eliminate the need for higher layers of the code to use `CallData.participants_joined`. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
