### PR TITLE
fix: Save id prior to removing of old data

### DIFF
--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -299,7 +299,6 @@ impl IdentityCacheTask {
 
                 remove_pin_and_block.await?;
 
-
                 Ok(Some(old_document.clone()))
             }
             None => {
@@ -326,7 +325,6 @@ impl IdentityCacheTask {
                 let cid = self.ipfs.dag().put().serialize(list)?.pin(false).await?;
 
                 let old_cid = self.list.replace(cid);
-
 
                 if let Some(path) = self.path.as_ref() {
                     let cid = cid.to_string();
@@ -403,7 +401,6 @@ impl IdentityCacheTask {
         let cid = self.ipfs.dag().put().serialize(list)?.pin(false).await?;
 
         let old_cid = self.list.replace(cid);
-
 
         if let Some(path) = self.path.as_ref() {
             let cid = cid.to_string();

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -277,6 +277,13 @@ impl IdentityCacheTask {
 
                 let old_cid = self.list.replace(cid);
 
+                if let Some(path) = self.path.as_ref() {
+                    let cid = cid.to_string();
+                    if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
+                        tracing::error!("Error writing cid to file: {e}");
+                    }
+                }
+
                 let remove_pin_and_block = async {
                     if let Some(old_cid) = old_cid {
                         if old_cid != cid {
@@ -292,12 +299,6 @@ impl IdentityCacheTask {
 
                 remove_pin_and_block.await?;
 
-                if let Some(path) = self.path.as_ref() {
-                    let cid = cid.to_string();
-                    if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
-                        tracing::error!("Error writing cid to file: {e}");
-                    }
-                }
 
                 Ok(Some(old_document.clone()))
             }
@@ -326,6 +327,14 @@ impl IdentityCacheTask {
 
                 let old_cid = self.list.replace(cid);
 
+
+                if let Some(path) = self.path.as_ref() {
+                    let cid = cid.to_string();
+                    if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
+                        tracing::error!("Error writing cid to file: {e}");
+                    }
+                }
+
                 if let Some(old_cid) = old_cid {
                     if old_cid != cid {
                         if self.ipfs.is_pinned(&old_cid).await? {
@@ -333,13 +342,6 @@ impl IdentityCacheTask {
                         }
                         // Do we want to remove the old block?
                         self.ipfs.remove_block(old_cid, false).await?;
-                    }
-                }
-
-                if let Some(path) = self.path.as_ref() {
-                    let cid = cid.to_string();
-                    if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
-                        tracing::error!("Error writing cid to file: {e}");
                     }
                 }
 
@@ -402,6 +404,14 @@ impl IdentityCacheTask {
 
         let old_cid = self.list.replace(cid);
 
+
+        if let Some(path) = self.path.as_ref() {
+            let cid = cid.to_string();
+            if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
+                tracing::error!("Error writing cid to file: {e}");
+            }
+        }
+
         if let Some(old_cid) = old_cid {
             if cid != old_cid {
                 if self.ipfs.is_pinned(&old_cid).await? {
@@ -409,13 +419,6 @@ impl IdentityCacheTask {
                 }
                 // Do we want to remove the old block?
                 self.ipfs.remove_block(old_cid, false).await?;
-            }
-        }
-
-        if let Some(path) = self.path.as_ref() {
-            let cid = cid.to_string();
-            if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
-                tracing::error!("Error writing cid to file: {e}");
             }
         }
 

--- a/extensions/warp-ipfs/src/store/document/conversation.rs
+++ b/extensions/warp-ipfs/src/store/document/conversation.rs
@@ -365,16 +365,16 @@ impl ConversationTask {
 
         self.ipfs.insert_pin(&cid, true).await?;
 
-        if let Some(old_cid) = old_map_cid {
-            if old_cid != cid && self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
-                self.ipfs.remove_pin(&old_cid, true).await?;
-            }
-        }
-
         if let Some(path) = self.path.as_ref() {
             let cid = cid.to_string();
             if let Err(e) = tokio::fs::write(path.join(".message_id"), cid).await {
                 tracing::error!("Error writing to '.message_id': {e}.")
+            }
+        }
+
+        if let Some(old_cid) = old_map_cid {
+            if old_cid != cid && self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
+                self.ipfs.remove_pin(&old_cid, true).await?;
             }
         }
 

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -9,7 +9,7 @@ use warp::{
 };
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all="lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum IdentityDocumentVersion {
     #[default]
     V0,

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -556,6 +556,13 @@ impl RootDocumentTask {
 
         let old_cid = self.cid.replace(root_cid);
 
+        if let Some(path) = self.path.as_ref() {
+            let cid = root_cid.to_string();
+            if let Err(e) = tokio::fs::write(path.join(".id"), cid).await {
+                tracing::error!("Error writing to '.id': {e}.")
+            }
+        }
+
         if let Some(old_cid) = old_cid {
             if old_cid != root_cid {
                 if self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
@@ -564,13 +571,6 @@ impl RootDocumentTask {
                     }
                 }
                 _ = self.ipfs.remove_block(old_cid, false).await;
-            }
-        }
-
-        if let Some(path) = self.path.as_ref() {
-            let cid = root_cid.to_string();
-            if let Err(e) = tokio::fs::write(path.join(".id"), cid).await {
-                tracing::error!("Error writing to '.id': {e}.")
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Change logic to save data to file prior to removing old previous data. 

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- N/A

**Special notes for reviewers** 🗒️

**Additional comments** 🎤  
- When adding or altering the block store, we would unpin and remove old data prior to saving to disk, however if the application closes before the data is removed, it would then attempt to load invalid data. This was discovered as a chance when uploading multiple files while updating the index. This simple PR solves it by changing the logic to save prior to removing any old data so if the application closes prior to the completion of the old data being removed, it would not affect the new data and would load successfully while the old data can be later cleared. 