### PR TITLE
fix: Await for export after signaling

### DIFF
--- a/warp/src/constellation/directory.rs
+++ b/warp/src/constellation/directory.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::result_large_err)]
 use super::file::File;
+use super::guard::SignalGuard;
 use super::item::{FormatType, Item};
 use crate::error::Error;
 use crate::sync::{Arc, RwLock};
@@ -596,11 +597,17 @@ impl Directory {
     }
 
     fn signal(&self) {
-        let Some(signal) = self.signal.read().clone() else {
+        let Some(signal) = self.signal_guard() else {
             return;
         };
+        drop(signal)
+    }
 
-        let _ = signal.unbounded_send(());
+    /// Produce a guard that is used to signal change after it has been dropped
+    /// This would return `None` if `rebuild_paths` used or `set_signal` is used until the write has
+    /// been finished, unless a signal has not been set at all
+    pub fn signal_guard(&self) -> Option<SignalGuard> {
+        self.signal.try_read().map(|signal| SignalGuard { signal })
     }
 }
 

--- a/warp/src/constellation/file.rs
+++ b/warp/src/constellation/file.rs
@@ -10,6 +10,7 @@ use std::io::{Read, Seek};
 use uuid::Uuid;
 use warp_derive::FFIFree;
 
+use super::guard::SignalGuard;
 use super::item::FormatType;
 
 /// `FileType` describes all supported file types.
@@ -314,11 +315,17 @@ impl File {
     }
 
     fn signal(&self) {
-        let Some(signal) = self.signal.read().clone() else {
+        let Some(signal) = self.signal_guard() else {
             return;
         };
+        drop(signal)
+    }
 
-        let _ = signal.unbounded_send(());
+    /// Produce a guard that is used to signal change after it has been dropped
+    /// This would return `None` if `rebuild_paths` used or `set_signal` is used until the write has
+    /// been finished, unless a signal has not been set at all
+    pub fn signal_guard(&self) -> Option<SignalGuard> {
+        self.signal.try_read().map(|signal| SignalGuard { signal })
     }
 }
 

--- a/warp/src/constellation/guard.rs
+++ b/warp/src/constellation/guard.rs
@@ -1,0 +1,17 @@
+pub struct SignalGuard<'a> {
+    pub(crate) signal: parking_lot::lock_api::RwLockReadGuard<
+        'a,
+        parking_lot::RawRwLock,
+        Option<futures::channel::mpsc::UnboundedSender<()>>,
+    >,
+}
+
+impl<'a> Drop for SignalGuard<'a> {
+    fn drop(&mut self) {
+        let Some(signal) = self.signal.as_ref() else {
+            return;
+        };
+
+        _ = signal.unbounded_send(());
+    }
+}

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -2,6 +2,7 @@
 pub mod directory;
 pub mod file;
 pub mod item;
+pub mod guard;
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Creates a guard that would send a signal after it is dropped and await for the export to complete, notifying the task.
- Reduce repeated signal/export calls by holding the guard internally and export at completion of the stream or task

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- When signaling, it does not properly wait for signaling to begin while holding a lock, which cause the stream or future to complete instead of awaiting. This may cause some task not to wait on the export and if the application shuts down, it may only have the bare minimum in the index and not the additional like thumbnail or may not have completed the export at all for the index, which may cause some inconsistency when executing constellation functions and reviewing the data in the index. Generally, in normal applications, it would not shut down right after, however if we do not await for the task to notify when the export is complete, it may not have the correct results if it does shut down right after. This PR fixes that by dropping the guard and wait to be notify that an export has been complete before yielding the stream or returning the function.
- Additionally, this PR would reduce internal signaling in warp-ipfs by using a guard that holds the lock belonging to the signal. This prevents additional signals while this guard is held but would allow for the signals outside of the guard scope (eg when renaming a `File` or `Directory` directly instead via `Constellation`, etc)