### PR TITLE
refactor: Update Messaging Events

### DIFF
--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -43,6 +43,8 @@ shuttle = { path = "../../tools/shuttle", default-features = false }
 
 [dev-dependencies]
 derive_more.workspace = true
+strum = "0.25"
+strum_macros = "0.25"
 fdlimit = "0.3"
 rustyline-async = "0.4"
 comfy-table = "7.1"

--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -42,6 +42,7 @@ bytes.workspace = true
 shuttle = { path = "../../tools/shuttle", default-features = false }
 
 [dev-dependencies]
+derive_more.workspace = true
 fdlimit = "0.3"
 rustyline-async = "0.4"
 comfy-table = "7.1"

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -989,30 +989,61 @@ async fn message_event_handle(
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::Display)]
 enum Command {
+    #[display(fmt = "/create <did> - create conversation with another user")]
     CreateConversation(DID),
+    #[display(fmt = "/add-recipient <did> - add recipient to conversation")]
     AddRecipient(DID),
+    #[display(fmt = "/remove-recipient <did> - remove recipient from conversation")]
     RemoveRecipient(DID),
+    #[display(fmt = "/create-group <name> <did> ... - create group conversation with other users")]
     CreateGroupConversation(String, Vec<DID>),
+    #[display(
+        fmt = "/remove-conversation - delete current conversation. This will delete it on both ends"
+    )]
     RemoveConversation(Uuid),
+    #[display(fmt = "/set-conversation <id> - switch to a conversation")]
     SetConversation(Uuid),
+    #[display(fmt = "/set-conversation-name <name> - set conversation name")]
     SetConversationName(String),
+    #[display(fmt = "/list-conversations - list all active conversations")]
     ListConversations,
+    #[display(
+        fmt = "/list-references <lower-range> <upper-range> - list all messages in the conversation. This provides more info"
+    )]
     ListReferences(MessageOptions),
+    #[display(fmt = "/list <lower-range> <upper-range> - list all messages in the conversation")]
     ListMessages(MessageOptions),
+    #[display(
+        fmt = "/list-pages <lower-range> <upper-range> - list all messages in the conversation. This provides more info"
+    )]
     ListPages(MessageOptions),
+    #[display(fmt = "/remove-message <message-id> - remove message from conversation")]
     RemoveMessage(Uuid),
+    #[display(fmt = "/get-first - get first message in conversation")]
     GetFirst,
+    #[display(fmt = "/get-last - get last message in conversation")]
     GetLast,
+    #[display(fmt = "/search <keywords> - search for messages in conversation")]
     Search(String),
+    #[display(fmt = "/edit <message-id> <message> - edit message in the conversation")]
     EditMessage(Uuid, String),
+    #[display(fmt = "/attach <path> ... - attach files to conversation")]
     Attach(Vec<Location>),
+    #[display(fmt = "/download <message-id> <file> <path> - download file from conversation")]
     Download(Uuid, String, PathBuf),
+    #[display(
+        fmt = "/react <add | remove> <message-id> <emoji> - add or remove reaction to a message"
+    )]
     React(Uuid, ReactionState, String),
+    #[display(fmt = "/status <message-id> - get message status")]
     Status(Uuid),
+    #[display(fmt = "/pin <all | message-id> - pin a message in a the conversation.")]
     Pin(PinTarget),
+    #[display(fmt = "/unpin <all | message-id> - unpin a message in the conversation.")]
     Unpin(PinTarget),
+    #[display(fmt = "/count-messages - count messages in the conversation")]
     CountMessages,
 }
 
@@ -1044,32 +1075,8 @@ fn list_commands_and_help() -> String {
     ];
     let mut help = String::from("List of all commands:\n");
     for cmd in all_commands.iter() {
-        let cmd_help = match cmd {
-        Command::CreateConversation(_) => "/create <did> - create conversation with another user",
-        Command::AddRecipient(_) => "/add-recipient <did> - add recipient to conversation",
-        Command::RemoveRecipient(_) => "/remove-recipient <did> - remove recipient from conversation",
-        Command::CreateGroupConversation(_, _) => "/create-group <name> <did> ... - create group conversation with other users",
-        Command::RemoveConversation(_) => "/remove-conversation - delete current conversation. This will delete it on both ends",
-        Command::SetConversation(_) => "/set-conversation <id> - switch to a conversation",
-        Command::SetConversationName(_) => "/set-conversation-name <name> - set conversation name",
-        Command::ListConversations => "/list-conversations - list all active conversations",
-        Command::ListReferences(_) => "/list-references <lower-range> <upper-range> - list all messages in the conversation. This provides more info",
-        Command::ListMessages(_) => "/list <lower-range> <upper-range> - list all messages in the conversation. This provides more info",
-        Command::ListPages(_) => "/list-pages <lower-range> <upper-range> - list all messages in the conversation. This provides more info",
-        Command::RemoveMessage(_) => "/remove-message <message-id> - remove message from conversation",
-        Command::GetFirst => "/get-first - get first message in conversation",
-        Command::GetLast => "/get-last - get last message in conversation",
-        Command::Search(_) => "/search <keywords> - search for messages in conversation",
-        Command::EditMessage(_, _) => "/edit <message-id> <message> - edit message in the conversation",
-        Command::Attach(_) => "/attach <paths> - attach files to conversation",
-        Command::Download(_, _, _) => "/download <message-id> <file> <path> - download file from conversation",
-        Command::React(_, _, _) => "/react <add | remove> <message-id> <emoji> - add or remove reaction to a message",
-        Command::Status(_) => "/status <message-id> - get message status",
-        Command::Pin(_) => "/pin <all | message-id> - pin a message in a the conversation.",
-        Command::Unpin(_) => "/unpin <all | message-id> - unpin a message in the conversation.",
-        Command::CountMessages => "/count-messages - count messages in the conversation",
-    };
-        help.push_str(cmd_help);
+        help.push('\t');
+        help.push_str(cmd.to_string().as_str());
         help.push('\n');
     }
 

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -25,6 +25,7 @@ use crate::store::ecdh_encrypt;
 use super::{ecdh_decrypt, keystore::Keystore, verify_serde_sig};
 
 #[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all="lowercase")]
 pub enum ConversationVersion {
     #[default]
     V0,

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -412,13 +412,13 @@ impl ConversationDocument {
             return Ok(stream::empty().boxed());
         }
 
-        let keystore = keystore.cloned();
         let mut messages = Vec::from_iter(message_list);
 
         if option.reverse() {
             messages.reverse()
         }
 
+        let keystore = keystore.cloned();
         if option.first_message() && !messages.is_empty() {
             let message = messages
                 .first()
@@ -497,7 +497,7 @@ impl ConversationDocument {
             });
         }
 
-        let mut messages = Vec::from_iter(message_list.iter());
+        let mut messages = Vec::from_iter(message_list);
 
         if option.reverse() {
             messages.reverse()

--- a/extensions/warp-ipfs/src/store/document/conversation.rs
+++ b/extensions/warp-ipfs/src/store/document/conversation.rs
@@ -8,7 +8,7 @@ use std::{
 use futures::{
     channel::{mpsc, oneshot},
     stream::FuturesUnordered,
-    SinkExt, StreamExt,
+    SinkExt, Stream, StreamExt,
 };
 use libipld::Cid;
 use rust_ipfs::{Ipfs, IpfsPath};
@@ -224,7 +224,7 @@ impl ConversationTask {
                     let _ = response.send(self.set_document(document).await);
                 }
                 ConversationCommand::List { response } => {
-                    let _ = response.send(self.list().await);
+                    let _ = response.send(Ok(self.list().await));
                 }
                 ConversationCommand::Delete { id, response } => {
                     let _ = response.send(self.delete(id).await);
@@ -257,8 +257,18 @@ impl ConversationTask {
 
         let path = IpfsPath::from(cid).sub_path(&id.to_string())?;
 
-        let document: ConversationDocument = self.ipfs.get_dag(path).local().deserialized().await?;
+        let document: ConversationDocument =
+            match self.ipfs.get_dag(path).local().deserialized().await {
+                Ok(d) => d,
+                Err(_) => return Err(Error::InvalidConversation),
+            };
+
         document.verify()?;
+
+        if document.deleted {
+            return Err(Error::InvalidConversation);
+        }
+
         Ok(document)
     }
 
@@ -286,72 +296,79 @@ impl ConversationTask {
     }
 
     async fn delete(&mut self, id: Uuid) -> Result<ConversationDocument, Error> {
-        let cid = match self.cid {
-            Some(cid) => cid,
-            None => return Err(Error::InvalidConversation),
-        };
+        if !self.contains(id).await {
+            return Err(Error::InvalidConversation);
+        }
 
-        let mut conversation_map: BTreeMap<String, Cid> =
-            self.ipfs.get_dag(cid).local().deserialized().await?;
+        let mut conversation = self.get(id).await?;
 
-        let document_cid = match conversation_map.remove(&id.to_string()) {
-            Some(cid) => cid,
-            None => return Err(Error::InvalidConversation),
-        };
+        if conversation.deleted {
+            return Err(Error::InvalidConversation);
+        }
 
-        self.set_map(conversation_map).await?;
+        let list = conversation.messages.take();
+        conversation.deleted = true;
+
+        self.set_document(conversation.clone()).await?;
 
         if let Ok(mut ks_map) = self.root.get_conversation_keystore_map().await {
             if ks_map.remove(&id.to_string()).is_some() {
                 if let Err(e) = self.set_keystore_map(ks_map).await {
-                    warn!("Failed to remove keystore for {id}: {e}");
+                    warn!(conversation_id = %id, "Failed to remove keystore: {e}");
                 }
             }
         }
 
-        let document: ConversationDocument = self
-            .ipfs
-            .get_dag(document_cid)
-            .local()
-            .deserialized()
-            .await?;
-        Ok(document)
+        if let Some(cid) = list {
+            let _ = self.ipfs.remove_block(cid, true).await;
+        }
+
+        Ok(conversation)
     }
 
-    async fn list(&self) -> Result<Vec<ConversationDocument>, Error> {
+    async fn list(&self) -> Vec<ConversationDocument> {
+        self.list_stream().collect::<Vec<_>>().await
+    }
+
+    fn list_stream(&self) -> impl Stream<Item = ConversationDocument> + Unpin {
         let cid = match self.cid {
             Some(cid) => cid,
-            None => return Ok(Vec::new()),
+            None => return futures::stream::empty().boxed(),
         };
 
-        let conversation_map: BTreeMap<String, Cid> =
-            self.ipfs.get_dag(cid).local().deserialized().await?;
+        let ipfs = self.ipfs.clone();
 
-        let list = FuturesUnordered::from_iter(
-            conversation_map
-                .values()
-                .map(|cid| self.ipfs.get_dag(*cid).local().deserialized().into_future()),
-        )
-        .filter_map(|result: Result<ConversationDocument, _>| async move { result.ok() })
-        .collect::<Vec<_>>()
-        .await;
+        let stream = async_stream::stream! {
+            let conversation_map: BTreeMap<String, Cid> = ipfs
+                .get_dag(cid)
+                .local()
+                .deserialized()
+                .await
+                .unwrap_or_default();
 
-        Ok(list)
+            let unordered = FuturesUnordered::from_iter(
+                                conversation_map
+                                    .values()
+                                    .map(|cid| ipfs.get_dag(*cid).local().deserialized().into_future()),
+                            )
+                            .filter_map(|result: Result<ConversationDocument, _>| async move { result.ok() })
+                            .filter(|document| {
+                                let deleted = document.deleted;
+                                async move { !deleted }
+                            });
+
+            for await conversation in unordered {
+                yield conversation;
+            }
+        };
+
+        stream.boxed()
     }
 
     async fn contains(&self, id: Uuid) -> bool {
-        let cid = match self.cid {
-            Some(cid) => cid,
-            None => return false,
-        };
-
-        let conversation_map: BTreeMap<String, Cid> =
-            match self.ipfs.get_dag(cid).local().deserialized().await {
-                Ok(document) => document,
-                Err(_) => return false,
-            };
-
-        conversation_map.contains_key(&id.to_string())
+        self.list_stream()
+            .any(|conversation| async move { conversation.id() == id })
+            .await
     }
 
     async fn set_keystore_map(&mut self, map: BTreeMap<String, Cid>) -> Result<(), Error> {

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1408,7 +1408,7 @@ impl MessageStore {
                     })
                     .await;
             }
-            ConversationEvents::NewGroupConversation { conversation } => {
+            ConversationEvents::NewGroupConversation { mut conversation } => {
                 let conversation_id = conversation.id;
                 let did = &*self.did;
                 info!("New group conversation event received");
@@ -1439,6 +1439,9 @@ impl MessageStore {
                 conversation.verify()?;
 
                 let topic = conversation.topic();
+
+                //TODO: Resolve message list
+                conversation.messages = None;
 
                 self.conversations.set(conversation).await?;
 

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -816,7 +816,7 @@ impl MessageStore {
                     let result = store
                         .message_event(conversation_id, &event, direction, Default::default())
                         .await.map_err(|e| {
-                            error!(id=%conversation_id, error = %e, "Failure while processing message in conversation");
+                            error!(id=%conversation_id, error = %e, direction = ?direction, "Failure while processing message in conversation");
                             e
                         });
 

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1500,10 +1500,6 @@ impl MessageStore {
                     self.remove_recipient(conversation_id, &recipient, false)
                         .await?;
                 } else {
-                    //We do this so we can grab a permit to mutate the conversation outside of the set task
-                    //so we can exclude the recipient
-                    drop(conversation);
-
                     {
                         //Small validation context
                         let context = format!("exclude {}", recipient);

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -246,6 +246,8 @@ pub enum MessagingEvents {
 pub enum ConversationUpdateKind {
     AddParticipant { did: DID },
     RemoveParticipant { did: DID },
+    AddRestricted { did: DID },
+    RemoveRestricted { did: DID },
     ChangeName { name: Option<String> },
 }
 

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -32,6 +32,8 @@ use warp::{
     tesseract::Tesseract,
 };
 
+use self::conversation::ConversationDocument;
+
 pub trait PeerTopic: Display {
     fn inbox(&self) -> String {
         format!("/peer/{self}/inbox")
@@ -134,17 +136,13 @@ where
 #[allow(clippy::large_enum_variant)]
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase", tag = "type")]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum ConversationEvents {
     NewConversation {
         recipient: DID,
     },
     NewGroupConversation {
-        creator: DID,
-        name: Option<String>,
-        conversation_id: Uuid,
-        list: Vec<DID>,
-        signature: Option<String>,
+        conversation: ConversationDocument,
     },
     LeaveConversation {
         conversation_id: Uuid,
@@ -172,7 +170,7 @@ pub enum ConversationRequestResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[allow(clippy::type_complexity)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ConversationRequestKind {
     Key,
     Ping,
@@ -187,7 +185,7 @@ pub enum ConversationRequestKind {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[allow(clippy::large_enum_variant)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ConversationResponseKind {
     Key { key: Vec<u8> },
     Pong,
@@ -201,6 +199,7 @@ impl std::fmt::Debug for ConversationResponseKind {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[allow(clippy::large_enum_variant)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum MessagingEvents {
     New {
@@ -230,22 +229,9 @@ pub enum MessagingEvents {
         state: ReactionState,
         emoji: String,
     },
-    UpdateConversationName {
-        conversation_id: Uuid,
-        name: String,
-        signature: String,
-    },
-    AddRecipient {
-        conversation_id: Uuid,
-        recipient: DID,
-        list: Vec<DID>,
-        signature: String,
-    },
-    RemoveRecipient {
-        conversation_id: Uuid,
-        recipient: DID,
-        list: Vec<DID>,
-        signature: String,
+    UpdateConversation {
+        conversation: ConversationDocument,
+        kind: ConversationUpdateKind,
     },
     Event {
         conversation_id: Uuid,
@@ -253,6 +239,14 @@ pub enum MessagingEvents {
         event: MessageEvent,
         cancelled: bool,
     },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ConversationUpdateKind {
+    AddParticipant { did: DID },
+    RemoveParticipant { did: DID },
+    ChangeName { name: Option<String> },
 }
 
 // Note that this are temporary

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::result_large_err)]
 pub mod directory;
 pub mod file;
-pub mod item;
 pub mod guard;
+pub mod item;
 
 use std::path::{Path, PathBuf};
 

--- a/warp/src/crypto/hash.rs
+++ b/warp/src/crypto/hash.rs
@@ -28,6 +28,17 @@ pub fn sha256_hash(data: &[u8], salt: Option<&[u8]>) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
+pub fn sha256_iter(iter: impl Iterator<Item = Option<impl AsRef<[u8]>>>, salt: Option<&[u8]>) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    for data in iter.flatten() {
+        hasher.update(data);
+    }
+    if let Some(salt) = salt {
+        hasher.update(salt);
+    }
+    hasher.finalize().to_vec()
+}
+
 #[cfg(test)]
 mod test {
     use crate::crypto::hash::*;

--- a/warp/src/crypto/hash.rs
+++ b/warp/src/crypto/hash.rs
@@ -28,7 +28,10 @@ pub fn sha256_hash(data: &[u8], salt: Option<&[u8]>) -> Vec<u8> {
     hasher.finalize().to_vec()
 }
 
-pub fn sha256_iter(iter: impl Iterator<Item = Option<impl AsRef<[u8]>>>, salt: Option<&[u8]>) -> Vec<u8> {
+pub fn sha256_iter(
+    iter: impl Iterator<Item = Option<impl AsRef<[u8]>>>,
+    salt: Option<&[u8]>,
+) -> Vec<u8> {
     let mut hasher = Sha256::new();
     for data in iter.flatten() {
         hasher.update(data);

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -647,6 +647,10 @@ pub struct Message {
     /// List of the reactions for the `Message`
     reactions: Vec<Reaction>,
 
+    /// List of users public keys mentioned in this message
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    mentions: Vec<DID>,
+
     /// ID of the message being replied to
     #[serde(skip_serializing_if = "Option::is_none")]
     replied: Option<Uuid>,
@@ -677,6 +681,7 @@ impl Default for Message {
             modified: None,
             pinned: false,
             reactions: Vec::new(),
+            mentions: Vec::new(),
             replied: None,
             lines: Vec::new(),
             attachment: Vec::new(),
@@ -738,6 +743,10 @@ impl Message {
         self.reactions.clone()
     }
 
+    pub fn mentions(&self) -> &[DID] {
+        &self.mentions
+    }
+
     pub fn lines(&self) -> Vec<String> {
         self.lines.clone()
     }
@@ -790,6 +799,10 @@ impl Message {
 
     pub fn set_reactions(&mut self, reaction: Vec<Reaction>) {
         self.reactions = reaction
+    }
+
+    pub fn set_mentions(&mut self, mentions: Vec<DID>) {
+        self.mentions = mentions
     }
 
     pub fn set_lines(&mut self, val: Vec<String>) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Updates the internal messaging events.
- Update the messenger example
- Add field to `ConversationDocument` to mark conversation as deleted, preserving its record internally. 
- Add block  (or restricted) list to `ConversationDocument` for future functionality when a user is blocked/unblocked.
 
**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
