### PR TITLE
feat(groups): Ability to allow anyone to add new members to a group

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -19,9 +19,9 @@ use warp::error::Error;
 use warp::multipass::identity::Identifier;
 use warp::multipass::MultiPass;
 use warp::raygun::{
-    AttachmentKind, Location, Message, MessageEvent, MessageEventKind, MessageEventStream,
-    MessageOptions, MessageStream, MessageType, Messages, MessagesType, PinState, RayGun,
-    ReactionState,
+    AttachmentKind, GroupSettings, Location, Message, MessageEvent, MessageEventKind,
+    MessageEventStream, MessageOptions, MessageStream, MessageType, Messages, MessagesType,
+    PinState, RayGun, ReactionState,
 };
 use warp::sync::{Arc, RwLock};
 use warp::tesseract::Tesseract;
@@ -317,7 +317,13 @@ async fn main() -> anyhow::Result<()> {
 
                         },
                         CreateGroupConversation(name, did_keys, open) => {
-                            if let Err(e) = chat.create_group_conversation(Some(name.to_string()), did_keys, open).await {
+                            let mut settings = GroupSettings::default();
+                            settings.set_members_can_add_participants(open);
+                            if let Err(e) = chat.create_group_conversation(
+                                Some(name.to_string()),
+                                did_keys,
+                                settings,
+                            ).await {
                                 writeln!(stdout, "Error creating conversation: {e}")?;
                                 continue
                             }

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -993,7 +993,9 @@ enum Command {
     AddRecipient(DID),
     #[display(fmt = "/remove-recipient <did> - remove recipient from conversation")]
     RemoveRecipient(DID),
-    #[display(fmt = "/create-group [--open] <name> <did> ... - create group conversation with other users")]
+    #[display(
+        fmt = "/create-group [--open] <name> <did> ... - create group conversation with other users"
+    )]
     CreateGroupConversation(String, Vec<DID>, bool),
     #[display(
         fmt = "/remove-conversation - delete current conversation. This will delete it on both ends"

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1363,9 +1363,10 @@ impl RayGun for WarpIpfs {
         &mut self,
         name: Option<String>,
         recipients: Vec<DID>,
+        open: bool,
     ) -> Result<Conversation, Error> {
         self.messaging_store()?
-            .create_group_conversation(name, HashSet::from_iter(recipients))
+            .create_group_conversation(name, HashSet::from_iter(recipients), open)
             .await
     }
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -43,9 +43,9 @@ use warp::constellation::{
 use warp::crypto::keypair::PhraseType;
 use warp::crypto::zeroize::Zeroizing;
 use warp::raygun::{
-    AttachmentEventStream, Conversation, EmbedState, Location, Message, MessageEvent,
-    MessageEventStream, MessageOptions, MessageReference, MessageStatus, Messages, PinState,
-    RayGun, RayGunAttachment, RayGunEventKind, RayGunEventStream, RayGunEvents,
+    AttachmentEventStream, Conversation, EmbedState, GroupSettings, Location, Message,
+    MessageEvent, MessageEventStream, MessageOptions, MessageReference, MessageStatus, Messages,
+    PinState, RayGun, RayGunAttachment, RayGunEventKind, RayGunEventStream, RayGunEvents,
     RayGunGroupConversation, RayGunStream, ReactionState,
 };
 use warp::sync::{Arc, RwLock};
@@ -1363,10 +1363,10 @@ impl RayGun for WarpIpfs {
         &mut self,
         name: Option<String>,
         recipients: Vec<DID>,
-        open: bool,
+        settings: GroupSettings,
     ) -> Result<Conversation, Error> {
         self.messaging_store()?
-            .create_group_conversation(name, HashSet::from_iter(recipients), open)
+            .create_group_conversation(name, HashSet::from_iter(recipients), settings)
             .await
     }
 

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -629,6 +629,7 @@ impl From<&ConversationDocument> for Conversation {
         conversation.set_conversation_type(document.conversation_type);
         conversation.set_recipients(document.recipients());
         conversation.set_created(document.created);
+        conversation.set_settings(document.settings);
         conversation.set_modified(document.modified);
         conversation
     }

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -248,21 +248,6 @@ impl ConversationDocument {
                 return Err(Error::PublicKeyInvalid);
             }
 
-            // <<<<<<< HEAD
-            //             let mut construct = vec![
-            //                 self.id().into_bytes().to_vec(),
-            //                 vec![0xdc, 0xfc],
-            //                 creator.to_string().as_bytes().to_vec(),
-            //             ];
-            //             if !settings.members_can_add_participants() {
-            //                 construct.push(Vec::from_iter(
-            //                     self.recipients
-            //                         .iter()
-            //                         .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
-            //                 ));
-            //             }
-            //             self.signature = Some(bs58::encode(did.sign(&construct.concat())).into_string());
-            // =======
             if self.version == ConversationVersion::V0 {
                 self.version = ConversationVersion::V1;
             }

--- a/extensions/warp-ipfs/src/store/document/conversation.rs
+++ b/extensions/warp-ipfs/src/store/document/conversation.rs
@@ -382,7 +382,7 @@ impl ConversationTask {
     async fn set_document(&mut self, mut document: ConversationDocument) -> Result<(), Error> {
         if let Some(creator) = document.creator.as_ref() {
             if creator.eq(&self.keypair)
-                && matches!(document.conversation_type, ConversationType::Group)
+                && matches!(document.conversation_type, ConversationType::Group { .. })
             {
                 document.sign(&self.keypair)?;
             }

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -28,7 +28,7 @@ use warp::{
     },
     error::Error,
     multipass::identity::IdentityStatus,
-    raygun::{Message, MessageEvent, PinState, ReactionState},
+    raygun::{GroupSettings, Message, MessageEvent, PinState, ReactionState},
     tesseract::Tesseract,
 };
 
@@ -145,7 +145,7 @@ pub enum ConversationEvents {
         conversation_id: Uuid,
         list: Vec<DID>,
         signature: Option<String>,
-        open: bool,
+        settings: GroupSettings,
     },
     LeaveConversation {
         conversation_id: Uuid,

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -28,7 +28,9 @@ use warp::{
     },
     error::Error,
     multipass::identity::IdentityStatus,
-    raygun::{GroupSettings, Message, MessageEvent, PinState, ReactionState},
+    raygun::{
+        DirectConversationSettings, GroupSettings, Message, MessageEvent, PinState, ReactionState,
+    },
     tesseract::Tesseract,
 };
 
@@ -138,6 +140,7 @@ where
 pub enum ConversationEvents {
     NewConversation {
         recipient: DID,
+        settings: DirectConversationSettings,
     },
     NewGroupConversation {
         creator: DID,

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -145,6 +145,7 @@ pub enum ConversationEvents {
         conversation_id: Uuid,
         list: Vec<DID>,
         signature: Option<String>,
+        open: bool,
     },
     LeaveConversation {
         conversation_id: Uuid,

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -7,7 +7,7 @@ mod test {
     use futures::StreamExt;
     use warp::{
         multipass::MultiPassEventKind,
-        raygun::{ConversationType, GroupSettings, MessageEventKind, RayGunEventKind},
+        raygun::{ConversationSettings, GroupSettings, MessageEventKind, RayGunEventKind},
     };
 
     #[tokio::test]
@@ -40,10 +40,8 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(
-            conversation.conversation_type(),
-            ConversationType::Group {
-                settings: GroupSettings::default()
-            }
+            conversation.settings(),
+            ConversationSettings::Group(GroupSettings::default()),
         );
         assert_eq!(conversation.recipients().len(), 1);
         assert!(conversation.recipients().contains(&did_a));
@@ -182,10 +180,8 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(
-            conversation.conversation_type(),
-            ConversationType::Group {
-                settings: GroupSettings::default()
-            }
+            conversation.settings(),
+            ConversationSettings::Group(GroupSettings::default()),
         );
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
@@ -353,8 +349,8 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(
-            conversation.conversation_type(),
-            ConversationType::Group { settings }
+            conversation.settings(),
+            ConversationSettings::Group(settings),
         );
         assert_eq!(conversation.recipients().len(), 4);
         assert!(conversation.recipients().contains(&did_a));
@@ -570,10 +566,8 @@ mod test {
         let conversation = chat_a.get_conversation(id_a).await?;
 
         assert_eq!(
-            conversation.conversation_type(),
-            ConversationType::Group {
-                settings: GroupSettings::default()
-            }
+            conversation.settings(),
+            ConversationSettings::Group(GroupSettings::default()),
         );
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
@@ -820,10 +814,8 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(
-            conversation.conversation_type(),
-            ConversationType::Group {
-                settings: GroupSettings::default()
-            }
+            conversation.settings(),
+            ConversationSettings::Group(GroupSettings::default()),
         );
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
@@ -980,10 +972,8 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(
-            conversation.conversation_type(),
-            ConversationType::Group {
-                settings: GroupSettings::default()
-            }
+            conversation.settings(),
+            ConversationSettings::Group(GroupSettings::default()),
         );
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -386,7 +386,7 @@ pub enum ConversationType {
     #[display(fmt = "direct")]
     Direct,
     #[display(fmt = "group")]
-    Group { open: bool },
+    Group { settings: GroupSettings },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, warp_derive::FFIVec, FFIFree)]
@@ -490,6 +490,31 @@ impl Conversation {
 
     pub fn set_recipients(&mut self, recipients: Vec<DID>) {
         self.recipients = recipients;
+    }
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[repr(C)]
+pub struct GroupSettings {
+    // Everyone can add participants, if set to `true``.
+    members_can_add_participants: bool,
+}
+
+impl GroupSettings {
+    pub fn members_can_add_participants(&self) -> bool {
+        self.members_can_add_participants
+    }
+
+    pub fn set_members_can_add_participants(&mut self, val: bool) {
+        self.members_can_add_participants = val;
+    }
+}
+
+impl Default for GroupSettings {
+    fn default() -> Self {
+        Self {
+            members_can_add_participants: false,
+        }
     }
 }
 
@@ -938,7 +963,7 @@ pub trait RayGun:
         &mut self,
         _: Option<String>,
         _: Vec<DID>,
-        _: bool,
+        _: GroupSettings,
     ) -> Result<Conversation, Error> {
         Err(Error::Unimplemented)
     }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -515,17 +515,11 @@ pub enum ConversationSettings {
 
 /// Settings for a direct conversation.
 // Any future direct conversation settings go here.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
+#[derive(Default, Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[repr(C)]
 pub struct DirectConversationSettings {}
 
-impl Default for DirectConversationSettings {
-    fn default() -> Self {
-        Self {}
-    }
-}
-
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
+#[derive(Default, Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[repr(C)]
 pub struct GroupSettings {
     // Everyone can add participants, if set to `true``.
@@ -539,14 +533,6 @@ impl GroupSettings {
 
     pub fn set_members_can_add_participants(&mut self, val: bool) {
         self.members_can_add_participants = val;
-    }
-}
-
-impl Default for GroupSettings {
-    fn default() -> Self {
-        Self {
-            members_can_add_participants: false,
-        }
     }
 }
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -386,7 +386,7 @@ pub enum ConversationType {
     #[display(fmt = "direct")]
     Direct,
     #[display(fmt = "group")]
-    Group,
+    Group { open: bool },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, warp_derive::FFIVec, FFIFree)]
@@ -938,6 +938,7 @@ pub trait RayGun:
         &mut self,
         _: Option<String>,
         _: Vec<DID>,
+        _: bool,
     ) -> Result<Conversation, Error> {
         Err(Error::Unimplemented)
     }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -386,7 +386,7 @@ pub enum ConversationType {
     #[display(fmt = "direct")]
     Direct,
     #[display(fmt = "group")]
-    Group { settings: GroupSettings },
+    Group,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, warp_derive::FFIVec, FFIFree)]
@@ -398,6 +398,7 @@ pub struct Conversation {
     created: DateTime<Utc>,
     modified: DateTime<Utc>,
     conversation_type: ConversationType,
+    settings: ConversationSettings,
     recipients: Vec<DID>,
 }
 
@@ -428,6 +429,7 @@ impl Default for Conversation {
             created: timestamp,
             modified: timestamp,
             conversation_type,
+            settings: ConversationSettings::Direct(DirectConversationSettings::default()),
             recipients,
         }
     }
@@ -456,6 +458,10 @@ impl Conversation {
 
     pub fn conversation_type(&self) -> ConversationType {
         self.conversation_type
+    }
+
+    pub fn settings(&self) -> ConversationSettings {
+        self.settings
     }
 
     pub fn recipients(&self) -> Vec<DID> {
@@ -488,12 +494,38 @@ impl Conversation {
         self.conversation_type = conversation_type;
     }
 
+    pub fn set_settings(&mut self, settings: ConversationSettings) {
+        self.settings = settings;
+    }
+
     pub fn set_recipients(&mut self, recipients: Vec<DID>) {
         self.recipients = recipients;
     }
 }
 
-#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Hash, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Display)]
+#[serde(rename_all = "lowercase")]
+#[repr(C)]
+pub enum ConversationSettings {
+    #[display(fmt = "direct {_0}")]
+    Direct(DirectConversationSettings),
+    #[display(fmt = "group {_0}")]
+    Group(GroupSettings),
+}
+
+/// Settings for a direct conversation.
+// Any future direct conversation settings go here.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
+#[repr(C)]
+pub struct DirectConversationSettings {}
+
+impl Default for DirectConversationSettings {
+    fn default() -> Self {
+        Self {}
+    }
+}
+
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[repr(C)]
 pub struct GroupSettings {
     // Everyone can add participants, if set to `true``.


### PR DESCRIPTION
**What this PR does** 📖

This adds ability for non-owners to add new members to a group, if owner choose so at creation time. Removal is still only allowed for owner.

The `messenger` cli's `create-group`command is also updated to set this option.

**Which issue(s) this PR fixes** 🔨

Fixes #386.