### PR TITLE
fix: Dont exclude request when receiving over mesh

### DIFF
--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -153,15 +153,13 @@ pub struct IpfsSetting {
     pub disable_quic: bool,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub enum UpdateEvents {
     #[default]
     /// Emit events for all identity updates
     Enabled,
     /// Emit events for identity updates from friends
     FriendsOnly,
-    /// Send events for all identity updates, but only emit with friends
-    EmitFriendsOnly,
     /// Disable events
     Disable,
 }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -527,7 +527,7 @@ impl IdentityStore {
                             };
 
                             //Ignore requesting images if there is a change for now.
-                            if let Err(e) = store.process_message(&from_did, event, true).await {
+                            if let Err(e) = store.process_message(&from_did, event, false).await {
                                 error!("Failed to process identity message from {from_did}: {e}");
                             }
                         }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -972,7 +972,7 @@ impl IdentityStore {
             UpdateEvents::Enabled
         ) || matches!(
             self.config.store_setting.update_events,
-            UpdateEvents::FriendsOnly | UpdateEvents::EmitFriendsOnly
+            UpdateEvents::FriendsOnly
         ) && is_friend)
             && (!is_blocked && !is_blocked_by);
 
@@ -1188,20 +1188,11 @@ impl IdentityStore {
 
                             let document_did = identity.did.clone();
 
-                            let mut emit = false;
-
-                            if matches!(
-                                self.config.store_setting.update_events,
-                                UpdateEvents::Enabled
-                            ) {
-                                emit = true;
-                            } else if matches!(
-                                self.config.store_setting.update_events,
-                                UpdateEvents::FriendsOnly | UpdateEvents::EmitFriendsOnly
-                            ) && self.is_friend(&document_did).await.unwrap_or_default()
-                            {
-                                emit = true;
-                            }
+                            let emit = self.config.store_setting.update_events
+                                == UpdateEvents::Enabled
+                                || (self.config.store_setting.update_events
+                                    == UpdateEvents::FriendsOnly
+                                    && self.is_friend(&document_did).await.unwrap_or_default());
 
                             if emit {
                                 tracing::trace!("Emitting identity update event");
@@ -1243,7 +1234,6 @@ impl IdentityStore {
                                             .expect("Cid is provided");
                                         tokio::spawn({
                                             let ipfs = self.ipfs.clone();
-                                            let emit = emit;
                                             let store = self.clone();
                                             let did = in_did.clone();
                                             async move {
@@ -1301,8 +1291,8 @@ impl IdentityStore {
                                             .await
                                         {
                                             error!(
-                                            "Error requesting profile banner from {in_did}: {e}"
-                                        );
+                                                "Error requesting profile banner from {in_did}: {e}"
+                                            );
                                         }
                                     } else {
                                         let identity_profile_banner = identity
@@ -1311,7 +1301,6 @@ impl IdentityStore {
                                             .expect("Cid is provided");
                                         tokio::spawn({
                                             let ipfs = self.ipfs.clone();
-                                            let emit = emit;
                                             let did = in_did.clone();
                                             let store = self.clone();
                                             async move {
@@ -1367,19 +1356,11 @@ impl IdentityStore {
                         }
 
                         if !exclude_images {
-                            let mut emit = false;
-                            if matches!(
-                                self.config.store_setting.update_events,
-                                UpdateEvents::Enabled
-                            ) {
-                                emit = true;
-                            } else if matches!(
-                                self.config.store_setting.update_events,
-                                UpdateEvents::FriendsOnly | UpdateEvents::EmitFriendsOnly
-                            ) && self.is_friend(&document_did).await.unwrap_or_default()
-                            {
-                                emit = true;
-                            }
+                            let emit = self.config.store_setting.update_events
+                                == UpdateEvents::Enabled
+                                || (self.config.store_setting.update_events
+                                    == UpdateEvents::FriendsOnly
+                                    && self.is_friend(&document_did).await.unwrap_or_default());
 
                             if emit {
                                 let mut picture = None;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Allow a push request for images when announced over mesh
- Removed redundant config flag

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Identities announced over the global topic were originally excluded from any request/response as the requests are generally done over peer specific topics, however with shuttle discovery option enabled, it may cause such request to be excluded, causing any image updates not to be emitted because there is no difference in what was received vs what was pushed after the connection was made between the two or more peers. This PR flip the flag so the request are not excluded while a later change will not exclude it and would attempt to fetch regardless of difference