### PR TITLE
feat(conversation): Allow owners to change conversation settings

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -43,9 +43,9 @@ use warp::constellation::{
 use warp::crypto::keypair::PhraseType;
 use warp::crypto::zeroize::Zeroizing;
 use warp::raygun::{
-    AttachmentEventStream, Conversation, EmbedState, GroupSettings, Location, Message,
-    MessageEvent, MessageEventStream, MessageOptions, MessageReference, MessageStatus, Messages,
-    PinState, RayGun, RayGunAttachment, RayGunEventKind, RayGunEventStream, RayGunEvents,
+    AttachmentEventStream, Conversation, ConversationSettings, EmbedState, GroupSettings, Location,
+    Message, MessageEvent, MessageEventStream, MessageOptions, MessageReference, MessageStatus,
+    Messages, PinState, RayGun, RayGunAttachment, RayGunEventKind, RayGunEventStream, RayGunEvents,
     RayGunGroupConversation, RayGunStream, ReactionState,
 };
 use warp::sync::{Arc, RwLock};
@@ -1504,6 +1504,16 @@ impl RayGun for WarpIpfs {
     ) -> Result<(), Error> {
         self.messaging_store()?
             .embeds(conversation_id, message_id, state)
+            .await
+    }
+
+    async fn update_conversation_settings(
+        &mut self,
+        conversation_id: Uuid,
+        settings: ConversationSettings,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .update_conversation_settings(conversation_id, settings)
             .await
     }
 }

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1330,7 +1330,6 @@ impl MessageStore {
                         //      but for now, we can leave this as a silent update since the block list would be for internal handling for now
                     }
                     ConversationUpdateKind::ChangeSettings { settings } => {
-                        conversation.settings = settings;
                         conversation.excluded = document.excluded;
                         conversation.messages = document.messages;
                         self.conversations.set(conversation).await?;

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1329,6 +1329,19 @@ impl MessageStore {
                         //TODO: Maybe add a api event to emit for when blocked users are added/removed from the document
                         //      but for now, we can leave this as a silent update since the block list would be for internal handling for now
                     }
+                    ConversationUpdateKind::ChangeSettings { settings } => {
+                        conversation.settings = settings;
+                        conversation.excluded = document.excluded;
+                        conversation.messages = document.messages;
+                        self.conversations.set(conversation).await?;
+
+                        if let Err(e) = tx.send(MessageEventKind::ConversationSettingsUpdated {
+                            conversation_id,
+                            settings,
+                        }) {
+                            error!("Error broadcasting event: {e}");
+                        }
+                    }
                 }
             }
             _ => {}
@@ -3470,6 +3483,40 @@ impl MessageStore {
         }
 
         Ok(())
+    }
+
+    pub async fn update_conversation_settings(
+        &mut self,
+        conversation_id: Uuid,
+        settings: ConversationSettings,
+    ) -> Result<(), Error> {
+        let mut conversation = self.conversations.get(conversation_id).await?;
+        let own_did = &*self.did;
+        let Some(creator) = &conversation.creator else {
+            return Err(Error::InvalidConversation);
+        };
+        if creator != own_did {
+            return Err(Error::PublicKeyInvalid);
+        }
+
+        conversation.settings = settings;
+        self.conversations.set(conversation).await?;
+
+        let conversation = self.conversations.get(conversation_id).await?;
+        let event = MessagingEvents::UpdateConversation {
+            conversation: conversation.clone(),
+            kind: ConversationUpdateKind::ChangeSettings {
+                settings: conversation.settings,
+            },
+        };
+
+        let tx = self.get_conversation_sender(conversation_id).await?;
+        let _ = tx.send(MessageEventKind::ConversationSettingsUpdated {
+            conversation_id,
+            settings: conversation.settings,
+        });
+
+        self.publish(conversation_id, None, event, true).await
     }
 
     async fn queue_event(&self, did: DID, queue: Queue) -> Result<(), Error> {

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -28,7 +28,10 @@ use warp::{
     },
     error::Error,
     multipass::identity::IdentityStatus,
-    raygun::{DirectConversationSettings, Message, MessageEvent, PinState, ReactionState},
+    raygun::{
+        ConversationSettings, DirectConversationSettings, Message, MessageEvent, PinState,
+        ReactionState,
+    },
     tesseract::Tesseract,
 };
 
@@ -250,6 +253,7 @@ pub enum ConversationUpdateKind {
     AddRestricted { did: DID },
     RemoveRestricted { did: DID },
     ChangeName { name: Option<String> },
+    ChangeSettings { settings: ConversationSettings },
 }
 
 // Note that this are temporary

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -107,6 +107,10 @@ pub enum MessageEventKind {
         did_key: DID,
         event: MessageEvent,
     },
+    ConversationSettingsUpdated {
+        conversation_id: Uuid,
+        settings: ConversationSettings,
+    },
 }
 
 #[derive(
@@ -507,9 +511,9 @@ impl Conversation {
 #[serde(rename_all = "lowercase")]
 #[repr(C)]
 pub enum ConversationSettings {
-    #[display(fmt = "direct {_0}")]
+    #[display(fmt = "direct settings {{ {_0} }}")]
     Direct(DirectConversationSettings),
-    #[display(fmt = "group {_0}")]
+    #[display(fmt = "group settings {{ {_0} }}")]
     Group(GroupSettings),
 }
 
@@ -520,6 +524,10 @@ pub enum ConversationSettings {
 pub struct DirectConversationSettings {}
 
 #[derive(Default, Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
+#[display(
+    fmt = "Everyone can add participants: {}",
+    "if self.members_can_add_participants {\"✅\"} else {\"❌\"}"
+)]
 #[repr(C)]
 pub struct GroupSettings {
     // Everyone can add participants, if set to `true``.
@@ -1056,6 +1064,13 @@ pub trait RayGun:
         conversation_id: Uuid,
         message_id: Uuid,
         state: EmbedState,
+    ) -> Result<(), Error>;
+
+    /// Update conversation settings
+    async fn update_conversation_settings(
+        &mut self,
+        conversation_id: Uuid,
+        settings: ConversationSettings,
     ) -> Result<(), Error>;
 }
 


### PR DESCRIPTION
**What this PR does** 📖

Currently, this only means changing of "members can add participants" setting of groups conversation. We only allow owners to change the settings.

This also adds an command in `messenger` example CLI app to turn a group open or closed.

**Which issue(s) this PR fixes** 🔨

* Fixes #417.