### PR TITLE
fix(raygun): Honor owner's block list when member is added to group

### DIFF
--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2445,6 +2445,10 @@ impl MessageStore {
             return Err(Error::PublicKeyIsBlocked);
         }
 
+        if conversation.restrict.contains(did_key) {
+            return Err(Error::PublicKeyIsBlocked);
+        }
+
         if conversation.recipients.contains(did_key) {
             return Err(Error::IdentityExist);
         }


### PR DESCRIPTION
**What this PR does** 📖

Honor owner's block list when member is added to group.

**Which issue(s) this PR fixes** 🔨

* Fixes #418.

**Additional comments** 🎤

I haven't managed to test this yet. I wanted to modify the `add_recipient_to_conversation` test to also test this but that one is failing (on my Mac, it's failing 100% of the time) so that (currently) won't work. This should be easy to test though with Uplink (once https://github.com/Satellite-im/Uplink/pull/1725 is in a working shape).