### PR TITLE
chore: Remove a redundant channel

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1375,7 +1375,7 @@ impl RayGun for WarpIpfs {
     }
 
     async fn list_conversations(&self) -> Result<Vec<Conversation>, Error> {
-        self.messaging_store()?.list_conversations().await
+        Ok(self.messaging_store()?.list_conversations().await)
     }
 
     async fn get_message_count(&self, conversation_id: Uuid) -> Result<usize, Error> {

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1471,7 +1471,7 @@ impl MessageStore {
                 let conversation_type = conversation.conversation_type;
 
                 let mut keystore = Keystore::new(conversation_id);
-                keystore.insert(&*did, &*did, warp::crypto::generate::<64>())?;
+                keystore.insert(&did, &did, warp::crypto::generate::<64>())?;
 
                 conversation.verify()?;
 


### PR DESCRIPTION
**What this PR does** 📖

Instead of sending commands through a channel and receiving the response through a oneshot channel created just for the response, just make the async calls directly.

**Special notes for reviewers** 🗒️

While this compiles just fine, many conversation tests are failing after this change. Most likely, these changes are only exposing an issue, that was not being exposed before.

Keeping it draft until I can figure out the issue.