### PR TITLE
refactor: Move FileStore logic into a separate task

### DIFF
--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -13,7 +13,6 @@ use rust_ipfs::{
     Ipfs, IpfsPath,
 };
 
-use tokio::sync::Notify;
 use tokio_util::io::ReaderStream;
 use tracing::{Instrument, Span};
 use warp::{
@@ -86,7 +85,6 @@ impl FileStore {
             config,
             signal_tx,
             signal_rx,
-            signal_guard: Arc::default(),
             rx,
         };
 
@@ -404,7 +402,6 @@ struct FileTask {
     path: Arc<RwLock<PathBuf>>,
     index_cid: Option<Cid>,
     config: config::Config,
-    signal_guard: Arc<Notify>,
     ipfs: Ipfs,
     signal_tx: futures::channel::mpsc::UnboundedSender<()>,
     signal_rx: futures::channel::mpsc::UnboundedReceiver<()>,
@@ -530,7 +527,6 @@ impl FileTask {
                     if let Err(_e) = self.export().await {
                         tracing::error!("Error exporting index: {_e}");
                     }
-                    self.signal_guard.notify_waiters();
                 }
             }
         }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -651,7 +651,6 @@ impl FileTask {
 
         let background = self.config.thumbnail_task;
 
-        let name = name.to_string();
         let constellation_tx = self.constellation_tx.clone();
 
         let progress_stream = async_stream::stream! {
@@ -963,7 +962,6 @@ impl FileTask {
             return Err(Error::FileExist);
         }
 
-        let name = name.to_string();
         let stream = stream.map(Ok::<_, std::io::Error>).boxed();
         let constellation_tx = self.constellation_tx.clone();
         let max_size = self.max_size();

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -786,7 +786,9 @@ impl FileTask {
                             file.set_thumbnail_format(extension_type.into());
                             file.set_thumbnail_reference(&path.to_string());
                         }
-                        Err(_e) => {}
+                        Err(e) => {
+                            tracing::error!(error = %e, ticket = %ticket, "Error generating thumbnail");
+                        }
                     }
                 }
             };
@@ -945,7 +947,9 @@ impl FileTask {
                     file.set_thumbnail_format(extension_type.into());
                     file.set_thumbnail_reference(&path.to_string());
                 }
-                Err(_e) => {}
+                Err(e) => {
+                    tracing::error!(error = %e, ticket = %ticket, "Error generating thumbnail");
+                }
             }
 
             current_directory.add_item(file)?;

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -1,9 +1,11 @@
-use std::{collections::VecDeque, ffi::OsStr, path::PathBuf, sync::Arc, task::Poll};
+use std::{collections::VecDeque, ffi::OsStr, path::PathBuf, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use futures::{
-    stream::{self, BoxStream},
-    StreamExt,
+    channel::{mpsc, oneshot},
+    future::{self, BoxFuture},
+    stream::{self, BoxStream, FuturesUnordered},
+    FutureExt, SinkExt, StreamExt,
 };
 use libipld::Cid;
 use rust_ipfs::{
@@ -13,7 +15,7 @@ use rust_ipfs::{
 
 use tokio::sync::Notify;
 use tokio_util::io::ReaderStream;
-use tracing::Span;
+use tracing::{Instrument, Span};
 use warp::{
     constellation::{
         directory::Directory, ConstellationEventKind, ConstellationProgressStream, Progression,
@@ -32,26 +34,11 @@ use crate::{
 use super::{ecdh_decrypt, ecdh_encrypt, event_subscription::EventSubscription, get_keypair_did};
 
 #[derive(Clone)]
-#[allow(dead_code)]
 pub struct FileStore {
     index: Directory,
     path: Arc<RwLock<PathBuf>>,
-    modified: DateTime<Utc>,
-    index_cid: Arc<RwLock<Option<Cid>>>,
-    thumbnail_store: ThumbnailGenerator,
-
-    location_path: Option<PathBuf>,
-
-    ipfs: Ipfs,
-    constellation_tx: EventSubscription<ConstellationEventKind>,
-
-    signal: futures::channel::mpsc::UnboundedSender<()>,
-
     config: config::Config,
-
-    span: Span,
-
-    signal_guard: Arc<Notify>,
+    tx: mpsc::Sender<FileTaskCommand>,
 }
 
 impl FileStore {
@@ -84,73 +71,478 @@ impl FileStore {
         let config = config.clone();
 
         let index = Directory::new("root");
-        let path = Arc::default();
-        let modified = Utc::now();
-        let index_cid = Arc::new(RwLock::new(index_cid));
         let thumbnail_store = ThumbnailGenerator::new(ipfs.clone());
 
-        let location_path = config.path.clone();
+        let (tx, rx) = futures::channel::mpsc::channel(1);
+        let (signal_tx, signal_rx) = futures::channel::mpsc::unbounded();
 
-        let (tx, mut rx) = futures::channel::mpsc::unbounded();
-
-        let mut store = FileStore {
+        let mut task = FileTask {
             index,
-            path,
-            modified,
+            path: Arc::default(),
             index_cid,
             thumbnail_store,
-            location_path,
             ipfs,
             constellation_tx,
             config,
-            signal: tx,
+            signal_tx,
+            signal_rx,
             signal_guard: Arc::default(),
-            span,
+            rx,
         };
 
-        if let Err(e) = store.import().await {
+        if let Err(e) = task.import().await {
             tracing::error!("Error importing index: {e}");
         }
 
-        let signal = Some(store.signal.clone());
-        store.index.rebuild_paths(&signal);
+        let mut index = task.index.clone();
+        let path = task.path.clone();
+        let config = task.config.clone();
+        let _span = span.clone();
 
-        tokio::spawn({
-            let fs = store.clone();
-            async move {
-                let mut stream_ctx = futures::stream::poll_fn(|cx| {
-                    let mut signaled = false;
+        let signal = Some(task.signal_tx.clone());
+        index.rebuild_paths(&signal);
 
-                    while let Poll::Ready(Some(_)) = rx.poll_next_unpin(cx) {
-                        signaled = true;
-                    }
-
-                    if signaled {
-                        Poll::Ready(Some(()))
-                    } else {
-                        Poll::Pending
-                    }
-                });
-
-                while stream_ctx.next().await.is_some() {
-                    if let Err(_e) = fs.export().await {
-                        tracing::error!("Error exporting index: {_e}");
-                    }
-                    fs.signal_guard.notify_waiters();
-                }
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = task.run().instrument(_span) => {}
             }
         });
 
-        Ok(store)
+        Ok(FileStore {
+            index,
+            config,
+            path,
+            tx,
+        })
+    }
+}
+
+impl FileStore {
+    pub fn modified(&self) -> DateTime<Utc> {
+        self.index.modified()
     }
 
-    async fn import(&self) -> Result<(), Error> {
+    pub fn root_directory(&self) -> Directory {
+        self.index.clone()
+    }
+
+    /// Get the current directory that is mutable.
+    pub fn current_directory(&self) -> Result<Directory, Error> {
+        self.open_directory(&self.get_path().to_string_lossy())
+    }
+
+    /// Returns a mutable directory from the filesystem
+    pub fn open_directory(&self, path: &str) -> Result<Directory, Error> {
+        match path.trim().is_empty() {
+            true => Ok(self.root_directory()),
+            false => self
+                .root_directory()
+                .get_item_by_path(path)
+                .and_then(|item| item.get_directory()),
+        }
+    }
+
+    /// Current size of the file system
+    pub fn current_size(&self) -> usize {
+        self.root_directory().size()
+    }
+
+    pub fn max_size(&self) -> usize {
+        self.config.max_storage_size.unwrap_or(1024 * 1024 * 1024)
+    }
+
+    pub fn set_path(&mut self, path: PathBuf) {
+        *self.path.write() = path;
+    }
+
+    pub fn get_path(&self) -> PathBuf {
+        PathBuf::from(self.path.read().to_string_lossy().replace('\\', "/"))
+    }
+
+    pub async fn put(
+        &mut self,
+        name: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Result<ConstellationProgressStream, Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::Put {
+                name: name.into(),
+                path: path.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn get(
+        &self,
+        name: impl Into<String>,
+        path: impl Into<String>,
+    ) -> Result<ConstellationProgressStream, Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::Get {
+                name: name.into(),
+                path: path.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn put_buffer(
+        &mut self,
+        name: impl Into<String>,
+        buffer: impl Into<Vec<u8>>,
+    ) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::PutBuffer {
+                name: name.into(),
+                buffer: buffer.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn get_buffer(&self, name: impl Into<String>) -> Result<Vec<u8>, Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::GetBuffer {
+                name: name.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    /// Used to upload file to the filesystem with data from a stream
+    pub async fn put_stream(
+        &mut self,
+        name: impl Into<String>,
+        total_size: impl Into<Option<usize>>,
+        stream: BoxStream<'static, Vec<u8>>,
+    ) -> Result<ConstellationProgressStream, Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::PutStream {
+                name: name.into(),
+                total_size: total_size.into(),
+                stream,
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    /// Used to download data from the filesystem using a stream
+    pub async fn get_stream(
+        &self,
+        name: impl Into<String>,
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::GetStream {
+                name: name.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    /// Used to remove data from the filesystem
+    pub async fn remove(&mut self, name: impl Into<String>, recursive: bool) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::Remove {
+                name: name.into(),
+                recursive,
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn rename(
+        &mut self,
+        current: impl Into<String>,
+        new: impl Into<String>,
+    ) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::Rename {
+                current: current.into(),
+                new: new.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn create_directory(
+        &mut self,
+        name: impl Into<String>,
+        recursive: bool,
+    ) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::CreateDirectory {
+                name: name.into(),
+                recursive,
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn sync_ref(&mut self, path: impl Into<String>) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(FileTaskCommand::SyncRef {
+                path: path.into(),
+                response: tx,
+            })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+}
+
+type GetStream = BoxStream<'static, Result<Vec<u8>, Error>>;
+
+enum FileTaskCommand {
+    Put {
+        name: String,
+        path: String,
+        response: oneshot::Sender<Result<ConstellationProgressStream, Error>>,
+    },
+    PutBuffer {
+        name: String,
+        buffer: Vec<u8>,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+    PutStream {
+        name: String,
+        total_size: Option<usize>,
+        stream: BoxStream<'static, Vec<u8>>,
+        response: oneshot::Sender<Result<ConstellationProgressStream, Error>>,
+    },
+
+    Get {
+        name: String,
+        path: String,
+        response: oneshot::Sender<Result<ConstellationProgressStream, Error>>,
+    },
+    GetStream {
+        name: String,
+        response: oneshot::Sender<Result<GetStream, Error>>,
+    },
+    GetBuffer {
+        name: String,
+        response: oneshot::Sender<Result<Vec<u8>, Error>>,
+    },
+
+    Remove {
+        name: String,
+        recursive: bool,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+    Rename {
+        current: String,
+        new: String,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+    CreateDirectory {
+        name: String,
+        recursive: bool,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+    SyncRef {
+        path: String,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+}
+
+enum FutResult {
+    Put {
+        result: Result<(), Error>,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+    Get {
+        result: Result<Vec<u8>, Error>,
+        response: oneshot::Sender<Result<Vec<u8>, Error>>,
+    },
+    Sync {
+        result: Result<(), Error>,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
+}
+
+struct FileTask {
+    index: Directory,
+    path: Arc<RwLock<PathBuf>>,
+    index_cid: Option<Cid>,
+    config: config::Config,
+    signal_guard: Arc<Notify>,
+    ipfs: Ipfs,
+    signal_tx: futures::channel::mpsc::UnboundedSender<()>,
+    signal_rx: futures::channel::mpsc::UnboundedReceiver<()>,
+    thumbnail_store: ThumbnailGenerator,
+    constellation_tx: EventSubscription<ConstellationEventKind>,
+    rx: futures::channel::mpsc::Receiver<FileTaskCommand>,
+}
+
+impl FileTask {
+    async fn run(&mut self) {
+        let mut futs: FuturesUnordered<BoxFuture<'static, FutResult>> = FuturesUnordered::new();
+        futs.push(future::pending().boxed());
+        loop {
+            tokio::select! {
+                biased;
+                Some(command) = self.rx.next() => {
+                    match command {
+                        FileTaskCommand::Put {
+                            name,
+                            path,
+                            response,
+                        } => {
+                            _ = response.send(self.put(&name, &path).await);
+                        },
+                        FileTaskCommand::PutBuffer {
+                            name,
+                            buffer,
+                            response,
+                        } => {
+                            let fut = match self.put_buffer(name, buffer) {
+                                Ok(fut) => fut.then(|result| async move {
+                                    FutResult::Put { result, response }
+                                }).boxed(),
+                                Err(e) => {
+                                    _ = response.send(Err(e));
+                                    continue;
+                                }
+                            };
+
+                           futs.push(fut);
+                        },
+                        FileTaskCommand::PutStream {
+                            name,
+                            total_size,
+                            stream,
+                            response,
+                        } => {
+                            _ = response.send(self.put_stream(&name, total_size, stream).await);
+                        },
+                        FileTaskCommand::Get {
+                            name,
+                            path,
+                            response,
+                        } => {
+                            _ = response.send(self.get(&name, &path).await);
+                        },
+                        FileTaskCommand::GetStream { name, response } => {
+                            _ = response.send(self.get_stream(&name).await);
+                        },
+                        FileTaskCommand::GetBuffer { name, response } => {
+                            let fut = match self.get_buffer(name) {
+                                Ok(fut) => fut.then(|result| async move {
+                                    FutResult::Get { result, response }
+                                }).boxed(),
+                                Err(e) => {
+                                    _ = response.send(Err(e));
+                                    continue;
+                                }
+                            };
+
+                           futs.push(fut);
+                        },
+                        FileTaskCommand::Remove {
+                            name,
+                            recursive,
+                            response,
+                        } => {
+                            _ = response.send(self.remove(&name, recursive).await);
+                        },
+                        FileTaskCommand::Rename {
+                            current,
+                            new,
+                            response,
+                        } => {
+                            _ = response.send(self.rename(&current, &new).await);
+                        },
+                        FileTaskCommand::CreateDirectory {
+                            name,
+                            recursive,
+                            response,
+                        } => {
+                            _ = response.send(self.create_directory(&name, recursive).await);
+                        },
+                        FileTaskCommand::SyncRef { path, response } => {
+                            let fut = match self.sync_ref(&path) {
+                                Ok(fut) => fut.then(|result| async move {
+                                    FutResult::Sync { result, response }
+                                }).boxed(),
+                                Err(e) => {
+                                    _ = response.send(Err(e));
+                                    continue;
+                                }
+                            };
+
+                           futs.push(fut);
+                        },
+                    }
+                },
+                Some(fut) = futs.next() => {
+                    match fut {
+                        FutResult::Put { result, response } => {
+                            _ = response.send(result);
+                        },
+                        FutResult::Get { result, response } => {
+                            _ = response.send(result);
+                        },
+                        FutResult::Sync { result, response } => {
+                            _ = response.send(result);
+                        }
+                    }
+                },
+                _ = self.signal_rx.next() => {
+                    if let Err(_e) = self.export().await {
+                        tracing::error!("Error exporting index: {_e}");
+                    }
+                    self.signal_guard.notify_waiters();
+                }
+            }
+        }
+    }
+
+    pub async fn import(&self) -> Result<(), Error> {
         if self.config.path.is_none() {
             return Ok(());
         }
 
         tracing::info!("Importing index");
-        let cid = (*self.index_cid.read()).ok_or(Error::Other)?;
+        let cid = self.index_cid.ok_or(Error::Other)?;
 
         tracing::info!(cid = %cid, "Index located");
 
@@ -174,11 +566,11 @@ impl FileStore {
     }
 
     #[tracing::instrument(skip(self))]
-    async fn export(&self) -> Result<(), Error> {
+    pub async fn export(&mut self) -> Result<(), Error> {
         tracing::trace!("Exporting index");
 
         let mut index = self.index.clone();
-        let signal = Some(self.signal.clone());
+        let signal = Some(self.signal_tx.clone());
 
         index.rebuild_paths(&signal);
 
@@ -211,7 +603,7 @@ impl FileStore {
             .cid()
             .ok_or(Error::OtherWithContext("unable to get cid".into()))?;
 
-        let last_cid = self.index_cid.write().replace(*cid);
+        let last_cid = self.index_cid.replace(*cid);
 
         if let Some(path) = self.config.path.as_ref() {
             if let Err(_e) = tokio::fs::write(path.join(".index_id"), cid.to_string()).await {
@@ -236,24 +628,14 @@ impl FileStore {
         tracing::trace!(cid = %cid, "Index exported");
         Ok(())
     }
-}
-
-impl FileStore {
-    pub fn modified(&self) -> DateTime<Utc> {
-        self.modified
-    }
-
-    pub fn root_directory(&self) -> Directory {
-        self.index.clone()
-    }
 
     /// Get the current directory that is mutable.
-    pub fn current_directory(&self) -> Result<Directory, Error> {
+    fn current_directory(&self) -> Result<Directory, Error> {
         self.open_directory(&self.get_path().to_string_lossy())
     }
 
     /// Returns a mutable directory from the filesystem
-    pub fn open_directory(&self, path: &str) -> Result<Directory, Error> {
+    fn open_directory(&self, path: &str) -> Result<Directory, Error> {
         match path.trim().is_empty() {
             true => Ok(self.root_directory()),
             false => self
@@ -263,20 +645,24 @@ impl FileStore {
         }
     }
 
+    fn root_directory(&self) -> Directory {
+        self.index.clone()
+    }
+
     /// Current size of the file system
-    pub fn current_size(&self) -> usize {
+    fn current_size(&self) -> usize {
         self.root_directory().size()
     }
 
-    pub fn max_size(&self) -> usize {
+    fn max_size(&self) -> usize {
         self.config.max_storage_size.unwrap_or(1024 * 1024 * 1024)
     }
 
-    pub async fn put(
-        &mut self,
-        name: &str,
-        path: &str,
-    ) -> Result<ConstellationProgressStream, Error> {
+    fn get_path(&self) -> PathBuf {
+        PathBuf::from(self.path.read().to_string_lossy().replace('\\', "/"))
+    }
+
+    async fn put(&mut self, name: &str, path: &str) -> Result<ConstellationProgressStream, Error> {
         let (name, dest_path) = split_file_from_path(name)?;
 
         let ipfs = self.ipfs.clone();
@@ -306,7 +692,7 @@ impl FileStore {
             None => self.current_directory()?,
         };
 
-        if current_directory.get_item(name).is_ok() {
+        if current_directory.get_item(&name).is_ok() {
             return Err(Error::FileExist);
         }
 
@@ -315,15 +701,14 @@ impl FileStore {
             self.config.thumbnail_exact_format,
         );
 
-        let ticket = self
-            .thumbnail_store
-            .insert(&path, width, height, exact)
-            .await?;
+        let thumbnail_store = self.thumbnail_store.clone();
+
+        let ticket = thumbnail_store.insert(&path, width, height, exact).await?;
 
         let background = self.config.thumbnail_task;
 
         let name = name.to_string();
-        let fs = self.clone();
+        let constellation_tx = self.constellation_tx.clone();
 
         let progress_stream = async_stream::stream! {
             let _current_guard = current_directory.signal_guard();
@@ -401,8 +786,7 @@ impl FileStore {
             }
 
             let task = {
-                let fs = fs.clone();
-                let store = fs.thumbnail_store.clone();
+                let store = thumbnail_store.clone();
                 let file = file.clone();
                 async move {
                     match store.get(ticket).await {
@@ -422,15 +806,12 @@ impl FileStore {
                 tokio::spawn(task);
             }
 
-            drop(_current_guard);
-            fs.signal_guard.notified().await;
-
             yield Progression::ProgressComplete {
                 name: name.to_string(),
                 total: Some(total_written),
             };
 
-            fs.constellation_tx.emit(ConstellationEventKind::Uploaded {
+            constellation_tx.emit(ConstellationEventKind::Uploaded {
                 filename: name.to_string(),
                 size: Some(total_written)
             }).await;
@@ -439,7 +820,7 @@ impl FileStore {
         Ok(progress_stream.boxed())
     }
 
-    pub async fn get(&self, name: &str, path: &str) -> Result<ConstellationProgressStream, Error> {
+    async fn get(&self, name: &str, path: &str) -> Result<ConstellationProgressStream, Error> {
         let ipfs = self.ipfs.clone();
 
         let path = PathBuf::from(path);
@@ -492,7 +873,17 @@ impl FileStore {
         Ok(stream.boxed())
     }
 
-    pub async fn put_buffer(&mut self, name: &str, buffer: &[u8]) -> Result<(), Error> {
+    fn put_buffer(
+        &self,
+        name: String,
+        buffer: Vec<u8>,
+    ) -> Result<BoxFuture<'static, Result<(), Error>>, Error> {
+        let ipfs = self.ipfs.clone();
+        let thumbnail_store = self.thumbnail_store.clone();
+        let tx = self.constellation_tx.clone();
+        let thumbnail_size = self.config.thumbnail_size;
+        let thumbnail_format = self.config.thumbnail_exact_format;
+
         let (name, dest_path) = split_file_from_path(name)?;
 
         if self.current_size() + buffer.len() >= self.max_size() {
@@ -504,113 +895,114 @@ impl FileStore {
             });
         }
 
-        let ipfs = self.ipfs.clone();
-
         let current_directory = match dest_path {
             Some(dest) => self.root_directory().get_last_directory_from_path(&dest)?,
             None => self.current_directory()?,
         };
 
-        let _current_guard = current_directory.signal_guard();
+        Ok(async move {
+            let _current_guard = current_directory.signal_guard();
 
-        if current_directory.get_item_by_path(name).is_ok() {
-            return Err(Error::FileExist);
-        }
-
-        let ((width, height), exact) = (
-            self.config.thumbnail_size,
-            self.config.thumbnail_exact_format,
-        );
-
-        let ticket = self
-            .thumbnail_store
-            .insert_buffer(&name, buffer, width, height, exact)
-            .await;
-
-        let reader = ReaderStream::new(std::io::Cursor::new(buffer))
-            .map(|result| result.map(|x| x.into()))
-            .boxed();
-
-        let mut total_written = 0;
-        let mut returned_path = None;
-
-        let mut stream = ipfs.unixfs().add(
-            reader,
-            Some(AddOption {
-                pin: true,
-                ..Default::default()
-            }),
-        );
-
-        while let Some(status) = stream.next().await {
-            match status {
-                UnixfsStatus::CompletedStatus { path, written, .. } => {
-                    returned_path = Some(path);
-                    total_written = written;
-                }
-                UnixfsStatus::FailedStatus { error, .. } => {
-                    return Err(error.map(Error::Any).unwrap_or(Error::Other))
-                }
-                _ => {}
+            if current_directory.get_item_by_path(&name).is_ok() {
+                return Err(Error::FileExist);
             }
-        }
 
-        let ipfs_path = returned_path.ok_or_else(|| anyhow::anyhow!("Cid was never set"))?;
+            let ((width, height), exact) = (thumbnail_size, thumbnail_format);
 
-        let file = warp::constellation::file::File::new(name);
-        file.set_size(total_written);
-        file.set_reference(&format!("{ipfs_path}"));
-        file.set_file_type(to_file_type(name));
-        file.hash_mut().hash_from_slice(buffer)?;
+            let ticket = thumbnail_store
+                .insert_buffer(&name, &buffer, width, height, exact)
+                .await;
 
-        match self.thumbnail_store.get(ticket).await {
-            Ok((extension_type, path, thumbnail)) => {
-                file.set_thumbnail(&thumbnail);
-                file.set_thumbnail_format(extension_type.into());
-                file.set_thumbnail_reference(&path.to_string());
+            let reader = ReaderStream::new(std::io::Cursor::new(&buffer))
+                .map(|result| result.map(|x| x.into()))
+                .boxed();
+
+            let mut total_written = 0;
+            let mut returned_path = None;
+
+            let mut stream = ipfs.unixfs().add(
+                reader,
+                Some(AddOption {
+                    pin: true,
+                    ..Default::default()
+                }),
+            );
+
+            while let Some(status) = stream.next().await {
+                match status {
+                    UnixfsStatus::CompletedStatus { path, written, .. } => {
+                        returned_path = Some(path);
+                        total_written = written;
+                    }
+                    UnixfsStatus::FailedStatus { error, .. } => {
+                        return Err(error.map(Error::Any).unwrap_or(Error::Other))
+                    }
+                    _ => {}
+                }
             }
-            Err(_e) => {}
-        }
 
-        current_directory.add_item(file)?;
+            let ipfs_path = returned_path.ok_or_else(|| anyhow::anyhow!("Cid was never set"))?;
 
-        drop(_current_guard);
-        self.signal_guard.notified().await;
+            let file = warp::constellation::file::File::new(&name);
+            file.set_size(total_written);
+            file.set_reference(&format!("{ipfs_path}"));
+            file.set_file_type(to_file_type(&name));
+            file.hash_mut().hash_from_slice(&buffer)?;
 
-        self.constellation_tx
-            .emit(ConstellationEventKind::Uploaded {
+            match thumbnail_store.get(ticket).await {
+                Ok((extension_type, path, thumbnail)) => {
+                    file.set_thumbnail(&thumbnail);
+                    file.set_thumbnail_format(extension_type.into());
+                    file.set_thumbnail_reference(&path.to_string());
+                }
+                Err(_e) => {}
+            }
+
+            current_directory.add_item(file)?;
+
+            tx.emit(ConstellationEventKind::Uploaded {
                 filename: name.to_string(),
                 size: Some(total_written),
             })
             .await;
-        Ok(())
+            Ok(())
+        }
+        .boxed())
     }
 
-    pub async fn get_buffer(&self, name: &str) -> Result<Vec<u8>, Error> {
+    fn get_buffer(
+        &self,
+        name: impl Into<String>,
+    ) -> Result<BoxFuture<'static, Result<Vec<u8>, Error>>, Error> {
+        let name = name.into();
         let ipfs = self.ipfs.clone();
+        let current_directory = self.current_directory()?;
+        let tx = self.constellation_tx.clone();
 
-        let item = self.current_directory()?.get_item_by_path(name)?;
-        let file = item.get_file()?;
-        let reference = file.reference().ok_or(Error::Other)?; //Reference not found
+        Ok(async move {
+            let item = current_directory.get_item_by_path(&name)?;
+            let file = item.get_file()?;
+            let reference = file.reference().ok_or(Error::Other)?; //Reference not found
 
-        let buffer = ipfs
-            .cat_unixfs(reference.parse::<IpfsPath>()?, None)
-            .await
-            .map_err(anyhow::Error::new)?;
+            let buffer = ipfs
+                .cat_unixfs(reference.parse::<IpfsPath>()?, None)
+                .await
+                .map_err(anyhow::Error::new)?;
 
-        self.constellation_tx
-            .emit(ConstellationEventKind::Downloaded {
+            tx.emit(ConstellationEventKind::Downloaded {
                 filename: file.name(),
                 size: Some(file.size()),
                 location: None,
             })
             .await;
 
-        Ok(buffer)
+            Ok(buffer)
+        }
+        .boxed())
     }
 
     /// Used to upload file to the filesystem with data from a stream
-    pub async fn put_stream(
+    async fn put_stream(
         &mut self,
         name: &str,
         total_size: Option<usize>,
@@ -625,13 +1017,15 @@ impl FileStore {
             None => self.current_directory()?,
         };
 
-        if current_directory.get_item_by_path(name).is_ok() {
+        if current_directory.get_item_by_path(&name).is_ok() {
             return Err(Error::FileExist);
         }
 
-        let fs = self.clone();
         let name = name.to_string();
         let stream = stream.map(Ok::<_, std::io::Error>).boxed();
+        let constellation_tx = self.constellation_tx.clone();
+        let max_size = self.max_size();
+        let root = self.root_directory();
 
         let progress_stream = async_stream::stream! {
 
@@ -676,15 +1070,15 @@ impl FileStore {
                     }
                 }
 
-                if fs.current_size() + last_written >= fs.max_size() {
+                if root.size() + last_written >= max_size {
                     yield Progression::ProgressFailed {
                         name,
                         last_size: Some(last_written),
                         error: Some(Error::InvalidLength {
                             context: "buffer".into(),
-                            current: fs.current_size() + last_written,
+                            current: root.size() + last_written,
                             minimum: None,
-                            maximum: Some(fs.max_size()),
+                            maximum: Some(max_size),
                         }).map(|e| e.to_string())
                     };
                     return;
@@ -720,15 +1114,12 @@ impl FileStore {
                 return;
             }
 
-            drop(_current_guard);
-            fs.signal_guard.notified().await;
-
             yield Progression::ProgressComplete {
                 name: name.to_string(),
                 total: Some(total_written),
             };
 
-            fs.constellation_tx.emit(ConstellationEventKind::Uploaded {
+            constellation_tx.emit(ConstellationEventKind::Uploaded {
                 filename: name.to_string(),
                 size: Some(total_written)
             }).await;
@@ -738,7 +1129,7 @@ impl FileStore {
     }
 
     /// Used to download data from the filesystem using a stream
-    pub async fn get_stream(
+    async fn get_stream(
         &self,
         name: &str,
     ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
@@ -770,10 +1161,11 @@ impl FileStore {
     }
 
     /// Used to remove data from the filesystem
-    pub async fn remove(&mut self, name: &str, _: bool) -> Result<(), Error> {
+    async fn remove(&mut self, name: &str, _: bool) -> Result<(), Error> {
         let ipfs = self.ipfs.clone();
         //TODO: Recursively delete directory but for now only support deleting a file
         let directory = self.current_directory()?;
+        let _g = directory.signal_guard();
 
         let item = directory.get_item_by_path(name)?;
 
@@ -793,12 +1185,7 @@ impl FileStore {
             ipfs.remove_pin(&cid).recursive().await?;
         }
 
-        let _g = directory.signal_guard();
-
         directory.remove_item(&item.name())?;
-
-        drop(_g);
-        self.signal_guard.notified().await;
 
         let blocks = ipfs.remove_block(cid, true).await.unwrap_or_default();
         tracing::info!(blocks = blocks.len(), "blocks removed");
@@ -812,19 +1199,15 @@ impl FileStore {
         Ok(())
     }
 
-    pub async fn rename(&mut self, current: &str, new: &str) -> Result<(), Error> {
+    async fn rename(&mut self, current: &str, new: &str) -> Result<(), Error> {
         //Note: This will only support renaming the file or directory in the index
         let directory = self.current_directory()?;
-
+        let _g = directory.signal_guard();
         if directory.get_item_by_path(new).is_ok() {
             return Err(Error::DuplicateName);
         }
 
-        let _g = directory.signal_guard();
         directory.rename_item(current, new)?;
-
-        drop(_g);
-        self.signal_guard.notified().await;
 
         self.constellation_tx
             .emit(ConstellationEventKind::Renamed {
@@ -837,6 +1220,7 @@ impl FileStore {
 
     pub async fn create_directory(&mut self, name: &str, recursive: bool) -> Result<(), Error> {
         let directory = self.current_directory()?;
+        let _g = directory.signal_guard();
 
         //Prevent creating recursive/nested directorieis if `recursive` isnt true
         if name.contains('/') && !recursive {
@@ -846,17 +1230,17 @@ impl FileStore {
         if directory.has_item(name) || directory.get_item_by_path(name).is_ok() {
             return Err(Error::DirectoryExist);
         }
-        let _g = directory.signal_guard();
-        directory.add_directory(Directory::new(name))?;
 
-        drop(_g);
-        self.signal_guard.notified().await;
+        directory.add_directory(Directory::new(name))?;
 
         Ok(())
     }
 
-    pub async fn sync_ref(&mut self, path: &str) -> Result<(), Error> {
+    fn sync_ref(&mut self, path: &str) -> Result<BoxFuture<'static, Result<(), Error>>, Error> {
         let ipfs = self.ipfs.clone();
+        let thumbnail_store = self.thumbnail_store.clone();
+        let thumbnail_size = self.config.thumbnail_size;
+        let thumbnail_format = self.config.thumbnail_exact_format;
 
         let directory = self.current_directory()?;
         let file = directory
@@ -865,41 +1249,33 @@ impl FileStore {
 
         let reference = file.reference().ok_or(Error::FileNotFound)?;
 
-        let buffer = ipfs
-            .cat_unixfs(reference.parse::<IpfsPath>()?, None)
-            .await
-            .map_err(anyhow::Error::from)?;
+        Ok(async move {
+            let buffer = ipfs
+                .cat_unixfs(reference.parse::<IpfsPath>()?, None)
+                .await
+                .map_err(anyhow::Error::from)?;
 
-        let ((width, height), exact) = (
-            self.config.thumbnail_size,
-            self.config.thumbnail_exact_format,
-        );
+            let ((width, height), exact) = (thumbnail_size, thumbnail_format);
 
-        // Generate the thumbnail for the file
-        let id = self
-            .thumbnail_store
-            .insert_buffer(file.name(), &buffer, width, height, exact)
-            .await;
+            // Generate the thumbnail for the file
+            let id = thumbnail_store
+                .insert_buffer(file.name(), &buffer, width, height, exact)
+                .await;
 
-        if let Ok((extension_type, path, thumbnail)) = self.thumbnail_store.get(id).await {
-            file.set_thumbnail(&thumbnail);
-            file.set_thumbnail_format(extension_type.into());
-            file.set_thumbnail_reference(&path.to_string());
+            if let Ok((extension_type, path, thumbnail)) = thumbnail_store.get(id).await {
+                file.set_thumbnail(&thumbnail);
+                file.set_thumbnail_format(extension_type.into());
+                file.set_thumbnail_reference(&path.to_string());
+            }
+
+            Ok(())
         }
-
-        Ok(())
-    }
-
-    pub fn set_path(&mut self, path: PathBuf) {
-        *self.path.write() = path;
-    }
-
-    pub fn get_path(&self) -> PathBuf {
-        PathBuf::from(self.path.read().to_string_lossy().replace('\\', "/"))
+        .boxed())
     }
 }
 
-fn split_file_from_path(name: &str) -> Result<(&str, Option<String>), Error> {
+fn split_file_from_path(name: impl Into<String>) -> Result<(String, Option<String>), Error> {
+    let name = name.into();
     let mut split_path = name.split('/').collect::<VecDeque<_>>();
     if split_path.is_empty() {
         return Err(Error::InvalidLength {
@@ -922,5 +1298,5 @@ fn split_file_from_path(name: &str) -> Result<(&str, Option<String>), Error> {
         });
     }
     let dest_path = (!split_path.is_empty()).then(|| split_path.join("/"));
-    Ok((name, dest_path))
+    Ok((name.to_string(), dest_path))
 }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -99,7 +99,6 @@ impl FileStore {
         let mut index = task.index.clone();
         let path = task.path.clone();
         let config = task.config.clone();
-        let span = span.clone();
 
         let signal = Some(task.signal_tx.clone());
         index.rebuild_paths(&signal);

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -771,11 +771,6 @@ impl FileTask {
             file.set_reference(&format!("{ipfs_path}"));
             file.set_file_type(to_file_type(&name));
 
-            if let Ok(Err(_e)) = tokio::task::spawn_blocking({
-                let f = file.clone();
-                move || f.hash_mut().hash_from_file(&path)
-            }).await {}
-
             if let Err(e) = current_directory.add_item(file.clone()) {
                 yield Progression::ProgressFailed {
                     name,
@@ -947,7 +942,6 @@ impl FileTask {
             file.set_size(total_written);
             file.set_reference(&format!("{ipfs_path}"));
             file.set_file_type(to_file_type(&name));
-            file.hash_mut().hash_from_slice(&buffer)?;
 
             match thumbnail_store.get(ticket).await {
                 Ok((extension_type, path, thumbnail)) => {
@@ -1104,7 +1098,7 @@ impl FileTask {
             file.set_size(total_written);
             file.set_reference(&format!("{ipfs_path}"));
             file.set_file_type(to_file_type(&name));
-            // file.hash_mut().hash_from_slice(buffer)?;
+
             if let Err(e) = current_directory.add_item(file) {
                 yield Progression::ProgressFailed {
                     name,

--- a/extensions/warp-ipfs/tests/files.rs
+++ b/extensions/warp-ipfs/tests/files.rs
@@ -120,6 +120,23 @@ mod test {
     }
 
     #[tokio::test]
+    async fn rename_file_in_directory() -> anyhow::Result<()> {
+        let (_, mut fs, _, _) = create_account(None, None, None).await?;
+        let root_directory = fs.root_directory();
+        fs.create_directory("/my/storage", true).await?;
+
+        fs.put_buffer("/my/storage/image.png", PROFILE_IMAGE)
+            .await?;
+
+        fs.rename("/my/storage/image.png", "item.png").await?;
+
+        assert!(root_directory
+            .get_item_by_path("/my/storage/item.png")
+            .is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn remove_file() -> anyhow::Result<()> {
         let (_, mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Moves FileStore logic into a separate task
- Change internal logic for `put_buffer`, `get_buffer`, and `sync_ref` to send a future via oneshot.
- Remove hashing due to it taking longer for the stream to complete when dealing with larger files.

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- Resolves #435 

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Hashing will be readded later where it will hash a file or data concurrent to the process of storing the data in the local node
  - This will be similar to how we generate thumbnails in a blocking thread and yield to the task when fetching it later.
  - Even with this change, hashing large data may still take awhile under other conditions like debug profile, etc.