### PR TITLE
feat: Add group convo setting for "all members can change name"

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -320,6 +320,7 @@ async fn main() -> anyhow::Result<()> {
                         CreateGroupConversation(name, did_keys, open) => {
                             let mut settings = GroupSettings::default();
                             settings.set_members_can_add_participants(open);
+                            settings.set_members_can_change_name(open);
                             if let Err(e) = chat.create_group_conversation(
                                 Some(name.to_string()),
                                 did_keys,
@@ -369,6 +370,7 @@ async fn main() -> anyhow::Result<()> {
                             let topic = *topic.read();
                             let mut settings = GroupSettings::default();
                             settings.set_members_can_add_participants(open);
+                            settings.set_members_can_change_name(open);
                             if let Err(e) = chat.update_conversation_settings(topic, ConversationSettings::Group(settings)).await {
                                 writeln!(stdout, "Error updating group settings: {e}")?;
                                 continue

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2378,9 +2378,11 @@ impl MessageStore {
 
         let mut conversation = self.conversations.get(conversation_id).await?;
 
-        if matches!(conversation.conversation_type, ConversationType::Direct) {
-            return Err(Error::InvalidConversation);
-        }
+        let settings = match conversation.settings {
+            ConversationSettings::Group(settings) => settings,
+            ConversationSettings::Direct(_) => return Err(Error::InvalidConversation),
+        };
+        assert_eq!(conversation.conversation_type, ConversationType::Group);
 
         let Some(creator) = conversation.creator.clone() else {
             return Err(Error::InvalidConversation);
@@ -2388,7 +2390,7 @@ impl MessageStore {
 
         let own_did = &*self.did;
 
-        if creator.ne(own_did) {
+        if !settings.members_can_change_name() && creator.ne(own_did) {
             return Err(Error::PublicKeyInvalid);
         }
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -482,13 +482,16 @@ pub struct DirectConversationSettings {}
 
 #[derive(Default, Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[display(
-    fmt = "Everyone can add participants: {}",
-    "if self.members_can_add_participants {\"✅\"} else {\"❌\"}"
+    fmt = "Everyone can add participants: {}, Everyone can change name: {}",
+    "if self.members_can_add_participants {\"✅\"} else {\"❌\"}",
+    "if self.members_can_change_name {\"✅\"} else {\"❌\"}"
 )]
 #[repr(C)]
 pub struct GroupSettings {
     // Everyone can add participants, if set to `true``.
     members_can_add_participants: bool,
+    // Everyone can change the name of the group.
+    members_can_change_name: bool,
 }
 
 impl GroupSettings {
@@ -496,8 +499,16 @@ impl GroupSettings {
         self.members_can_add_participants
     }
 
+    pub fn members_can_change_name(&self) -> bool {
+        self.members_can_change_name
+    }
+
     pub fn set_members_can_add_participants(&mut self, val: bool) {
         self.members_can_add_participants = val;
+    }
+
+    pub fn set_members_can_change_name(&mut self, val: bool) {
+        self.members_can_change_name = val;
     }
 }
 


### PR DESCRIPTION
**What this PR does** 📖

We already had the needed plumbing for group settings with "allow everyone to add participants" so we just add another boolean setting for "allow everyone to change conversation name".