### PR TITLE
chore: Set serde default for group settings

### DIFF
--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -489,8 +489,10 @@ pub struct DirectConversationSettings {}
 #[repr(C)]
 pub struct GroupSettings {
     // Everyone can add participants, if set to `true``.
+    #[serde(default)]
     members_can_add_participants: bool,
     // Everyone can change the name of the group.
+    #[serde(default)]
     members_can_change_name: bool,
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use serde default attr on group chat settings

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This will cause the fields to use the default values when the fields do not exist when deserializing   
- This will change in the future to be done internally