### PR TITLE
fix: Remove unreachable panic  

### DIFF
--- a/extensions/warp-ipfs/src/behaviour/phonebook.rs
+++ b/extensions/warp-ipfs/src/behaviour/phonebook.rs
@@ -227,7 +227,7 @@ impl NetworkBehaviour for Behaviour {
                 }
 
                 if remaining_established == 0 && self.entry.contains(&peer_id) {
-                    //In case peer disconnects due to keep-alive, we should wait before emitting an event for the client to reestablish connection
+                    // Delay emitting event in case of reconnection
                     self.backoff
                         .insert(peer_id, Delay::new(Duration::from_secs(2)));
                 }

--- a/extensions/warp-ipfs/src/behaviour/phonebook.rs
+++ b/extensions/warp-ipfs/src/behaviour/phonebook.rs
@@ -279,8 +279,7 @@ impl NetworkBehaviour for Behaviour {
 
                     let _ = response.send(Ok(()));
                 }
-                Poll::Ready(None) => unreachable!("Channels are owned"),
-                Poll::Pending => break,
+                Poll::Ready(None) | Poll::Pending => break,
             }
         }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Remove panic when channel close

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- While we could consider it a bug for the channel to close or drop, if the application closes unexpectedly, it would likely cause it to panic (although not a problem), but in this case we could just break the loop and progress further. 