### PR TITLE
chore: Cleanup & refactor Conversation types

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -357,12 +357,18 @@ async fn main() -> anyhow::Result<()> {
                             for convo in list.iter() {
                                 let mut recipients = vec![];
                                 for recipient in convo.recipients() {
-                                    let username = get_username(&*new_account,  recipient).await;
+                                    let username = get_username(&*new_account, recipient.clone()).await;
                                     recipients.push(username);
                                 }
                                 let created = convo.created();
                                 let modified = convo.modified();
-                                table.add_row(vec![convo.name().unwrap_or_default(), convo.id().to_string(), created.to_string(), modified.to_string(), recipients.join(",").to_string()]);
+                                table.add_row(vec![
+                                    convo.name().map(ToOwned::to_owned).unwrap_or_default(),
+                                    convo.id().to_string(),
+                                    created.to_string(),
+                                    modified.to_string(),
+                                    recipients.join(",").to_string(),
+                                ]);
                             }
                             writeln!(stdout, "{table}")?;
                         },

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -14,9 +14,9 @@ use warp::{
     crypto::{cipher::Cipher, did_key::CoreSign, DIDKey, Ed25519KeyPair, KeyMaterial, DID},
     error::Error,
     raygun::{
-        Conversation, ConversationSettings, ConversationType, DirectConversationSettings,
-        GroupSettings, Message, MessageOptions, MessagePage, MessageReference, Messages,
-        MessagesType,
+        Conversation, ConversationSettings, ConversationType, DirectConversation,
+        DirectConversationSettings, GroupConversation, GroupSettings, Message, MessageOptions,
+        MessagePage, MessageReference, Messages, MessagesType,
     },
 };
 
@@ -34,18 +34,10 @@ pub enum ConversationVersion {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq)]
 pub struct ConversationDocument {
-    pub id: Uuid,
+    #[serde(flatten)]
+    pub conversation: Conversation,
     #[serde(default)]
     pub version: ConversationVersion,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub creator: Option<DID>,
-    pub created: DateTime<Utc>,
-    pub modified: DateTime<Utc>,
-    pub conversation_type: ConversationType,
-    pub settings: ConversationSettings,
-    pub recipients: Vec<DID>,
     pub excluded: HashMap<DID, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub restrict: Vec<DID>,
@@ -59,27 +51,27 @@ pub struct ConversationDocument {
 
 impl Hash for ConversationDocument {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state)
+        self.conversation.hash(state)
     }
 }
 
 impl PartialEq for ConversationDocument {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id
+        self.conversation.eq(&other.conversation)
     }
 }
 
 impl ConversationDocument {
     pub fn id(&self) -> Uuid {
-        self.id
+        self.conversation.id()
     }
 
     pub fn name(&self) -> Option<String> {
-        self.name.clone()
+        self.conversation.name().cloned()
     }
 
     pub fn topic(&self) -> String {
-        format!("{}/{}", self.conversation_type, self.id())
+        format!("{}/{}", self.conversation.conversation_type(), self.id())
     }
 
     pub fn event_topic(&self) -> String {
@@ -111,7 +103,8 @@ impl ConversationDocument {
             })
             .collect::<Vec<_>>();
 
-        self.recipients
+        self.conversation
+            .recipients()
             .iter()
             .filter(|recipient| !valid_keys.contains(recipient))
             .cloned()
@@ -120,46 +113,22 @@ impl ConversationDocument {
 }
 
 impl ConversationDocument {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         did: &DID,
-        name: Option<String>,
-        mut recipients: Vec<DID>,
+        mut conversation: Conversation,
         restrict: Vec<DID>,
-        id: Option<Uuid>,
-        conversation_type: ConversationType,
-        settings: ConversationSettings,
-        created: Option<DateTime<Utc>>,
-        modified: Option<DateTime<Utc>>,
-        creator: Option<DID>,
         signature: Option<String>,
     ) -> Result<Self, Error> {
-        let id = id.unwrap_or_else(Uuid::new_v4);
-
-        if !recipients.contains(did) {
-            recipients.push(did.clone());
-        }
-
-        if recipients.is_empty() {
-            return Err(Error::CannotCreateConversation);
+        if !conversation.recipients().contains(did) {
+            conversation = conversation.add_recipient(did.clone());
         }
 
         let messages = None;
         let excluded = Default::default();
 
-        let created = created.unwrap_or(Utc::now());
-        let modified = modified.unwrap_or(created);
-
         let mut document = Self {
-            id,
             version: ConversationVersion::V1,
-            name,
-            recipients,
-            creator,
-            created,
-            modified,
-            conversation_type,
-            settings,
+            conversation,
             excluded,
             messages,
             signature,
@@ -171,7 +140,7 @@ impl ConversationDocument {
             document.verify()?;
         }
 
-        if let Some(creator) = document.creator.as_ref() {
+        if let Some(creator) = document.conversation.creator() {
             if creator.eq(did) {
                 document.sign(did)?;
             }
@@ -185,7 +154,7 @@ impl ConversationDocument {
         recipients: [DID; 2],
         settings: DirectConversationSettings,
     ) -> Result<Self, Error> {
-        let conversation_id = Some(super::generate_shared_topic(
+        let conversation_id = super::generate_shared_topic(
             did,
             recipients
                 .iter()
@@ -194,21 +163,16 @@ impl ConversationDocument {
                 .first()
                 .ok_or(Error::Other)?,
             Some("direct-conversation"),
-        )?);
+        )?;
 
-        Self::new(
-            did,
-            None,
-            recipients.to_vec(),
-            vec![],
-            conversation_id,
-            ConversationType::Direct,
-            ConversationSettings::Direct(settings),
-            None,
-            None,
-            None,
-            None,
-        )
+        let [recipient1, recipient2] = recipients;
+        let conversation =
+            Conversation::Direct(DirectConversation::default().set_settings(settings))
+                .set_id(conversation_id)
+                .add_recipient(recipient1)
+                .add_recipient(recipient2);
+
+        Self::new(did, conversation, vec![], None)
     }
 
     pub fn new_group(
@@ -218,40 +182,102 @@ impl ConversationDocument {
         restrict: &[DID],
         settings: GroupSettings,
     ) -> Result<Self, Error> {
-        let conversation_id = Some(Uuid::new_v4());
-        Self::new(
-            did,
-            name,
-            recipients.to_vec(),
-            restrict.to_vec(),
-            conversation_id,
-            ConversationType::Group,
-            ConversationSettings::Group(settings),
-            None,
-            None,
-            Some(did.clone()),
-            None,
-        )
+        let conversation_id = Uuid::new_v4();
+        let conversation = Conversation::Group(GroupConversation::default().set_settings(settings))
+            .set_id(conversation_id)
+            .set_name(name)
+            .set_creator(Some(did.clone()))
+            .set_recipients(recipients.to_vec());
+
+        Self::new(did, conversation, restrict.to_vec(), None)
     }
 }
 
 impl ConversationDocument {
     pub fn sign(&mut self, did: &DID) -> Result<(), Error> {
-        if let ConversationSettings::Group(settings) = self.settings {
-            assert_eq!(self.conversation_type, ConversationType::Group);
-            let Some(creator) = self.creator.clone() else {
-                return Err(Error::PublicKeyInvalid);
-            };
-
-            if !settings.members_can_add_participants() && !creator.eq(did) {
-                return Err(Error::PublicKeyInvalid);
+        let settings = match self.conversation.settings() {
+            ConversationSettings::Group(settings) => {
+                assert_eq!(
+                    self.conversation.conversation_type(),
+                    ConversationType::Group
+                );
+                settings
             }
+            ConversationSettings::Direct(_) => return Ok(()),
+        };
+        let Some(creator) = self.conversation.creator().clone() else {
+            return Err(Error::PublicKeyInvalid);
+        };
 
-            if self.version == ConversationVersion::V0 {
-                self.version = ConversationVersion::V1;
+        if !settings.members_can_add_participants() && !creator.eq(did) {
+            return Err(Error::PublicKeyInvalid);
+        }
+
+        if self.version == ConversationVersion::V0 {
+            self.version = ConversationVersion::V1;
+        }
+
+        let construct = warp::crypto::hash::sha256_iter(
+            [
+                Some(self.id().into_bytes().to_vec()),
+                // self.name.as_deref().map(|s| s.as_bytes().to_vec()),
+                Some(creator.to_string().as_bytes().to_vec()),
+                Some(Vec::from_iter(
+                    self.restrict
+                        .iter()
+                        .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
+                )),
+                (!settings.members_can_add_participants()).then_some(Vec::from_iter(
+                    self.conversation
+                        .recipients()
+                        .iter()
+                        .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
+                )),
+            ]
+            .into_iter(),
+            None,
+        );
+
+        let signature = did.sign(&construct);
+        self.signature = Some(bs58::encode(signature).into_string());
+        Ok(())
+    }
+
+    pub fn verify(&self) -> Result<(), Error> {
+        let settings = match self.conversation.settings() {
+            ConversationSettings::Group(settings) => {
+                assert_eq!(
+                    self.conversation.conversation_type(),
+                    ConversationType::Group
+                );
+                settings
             }
+            ConversationSettings::Direct(_) => return Ok(()),
+        };
+        let Some(creator) = self.conversation.creator() else {
+            return Err(Error::PublicKeyInvalid);
+        };
 
-            let construct = warp::crypto::hash::sha256_iter(
+        let Some(signature) = &self.signature else {
+            return Err(Error::InvalidSignature);
+        };
+
+        let signature = bs58::decode(signature).into_vec()?;
+
+        let construct = match self.version {
+            ConversationVersion::V0 => [
+                self.id().into_bytes().to_vec(),
+                vec![0xdc, 0xfc],
+                creator.to_string().as_bytes().to_vec(),
+                Vec::from_iter(
+                    self.conversation
+                        .recipients()
+                        .iter()
+                        .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
+                ),
+            ]
+            .concat(),
+            ConversationVersion::V1 => warp::crypto::hash::sha256_iter(
                 [
                     Some(self.id().into_bytes().to_vec()),
                     // self.name.as_deref().map(|s| s.as_bytes().to_vec()),
@@ -262,71 +288,20 @@ impl ConversationDocument {
                             .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
                     )),
                     (!settings.members_can_add_participants()).then_some(Vec::from_iter(
-                        self.recipients
+                        self.conversation
+                            .recipients()
                             .iter()
                             .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
                     )),
                 ]
                 .into_iter(),
                 None,
-            );
+            ),
+        };
 
-            let signature = did.sign(&construct);
-            self.signature = Some(bs58::encode(signature).into_string());
-        }
-        Ok(())
-    }
-
-    pub fn verify(&self) -> Result<(), Error> {
-        if let ConversationSettings::Group(settings) = self.settings {
-            assert_eq!(self.conversation_type, ConversationType::Group);
-            let Some(creator) = &self.creator else {
-                return Err(Error::PublicKeyInvalid);
-            };
-
-            let Some(signature) = &self.signature else {
-                return Err(Error::InvalidSignature);
-            };
-
-            let signature = bs58::decode(signature).into_vec()?;
-
-            let construct = match self.version {
-                ConversationVersion::V0 => [
-                    self.id().into_bytes().to_vec(),
-                    vec![0xdc, 0xfc],
-                    creator.to_string().as_bytes().to_vec(),
-                    Vec::from_iter(
-                        self.recipients
-                            .iter()
-                            .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
-                    ),
-                ]
-                .concat(),
-                ConversationVersion::V1 => warp::crypto::hash::sha256_iter(
-                    [
-                        Some(self.id().into_bytes().to_vec()),
-                        // self.name.as_deref().map(|s| s.as_bytes().to_vec()),
-                        Some(creator.to_string().as_bytes().to_vec()),
-                        Some(Vec::from_iter(
-                            self.restrict
-                                .iter()
-                                .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
-                        )),
-                        (!settings.members_can_add_participants()).then_some(Vec::from_iter(
-                            self.recipients
-                                .iter()
-                                .flat_map(|rec| rec.to_string().as_bytes().to_vec()),
-                        )),
-                    ]
-                    .into_iter(),
-                    None,
-                ),
-            };
-
-            creator
-                .verify(&construct, &signature)
-                .map_err(|e| anyhow::anyhow!("{:?}", e))?;
-        }
+        creator
+            .verify(&construct, &signature)
+            .map_err(|e| anyhow::anyhow!("{:?}", e))?;
         Ok(())
     }
 
@@ -352,7 +327,7 @@ impl ConversationDocument {
         ipfs: &Ipfs,
         list: BTreeSet<MessageDocument>,
     ) -> Result<(), Error> {
-        self.modified = Utc::now();
+        *self.conversation.modified_mut() = Utc::now();
         let cid = ipfs.dag().put().serialize(list)?.await?;
         self.messages = Some(cid);
         Ok(())
@@ -626,22 +601,13 @@ impl ConversationDocument {
 
 impl From<ConversationDocument> for Conversation {
     fn from(document: ConversationDocument) -> Self {
-        Conversation::from(&document)
+        document.conversation
     }
 }
 
 impl From<&ConversationDocument> for Conversation {
     fn from(document: &ConversationDocument) -> Self {
-        let mut conversation = Conversation::default();
-        conversation.set_id(document.id);
-        conversation.set_name(document.name.clone());
-        conversation.set_creator(document.creator.clone());
-        conversation.set_conversation_type(document.conversation_type);
-        conversation.set_recipients(document.recipients());
-        conversation.set_created(document.created);
-        conversation.set_settings(document.settings);
-        conversation.set_modified(document.modified);
-        conversation
+        document.conversation.clone()
     }
 }
 

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -14,9 +14,9 @@ use warp::{
     crypto::{cipher::Cipher, did_key::CoreSign, DIDKey, Ed25519KeyPair, KeyMaterial, DID},
     error::Error,
     raygun::{
-        Conversation, ConversationSettings, ConversationType, DirectConversation,
-        DirectConversationSettings, GroupConversation, GroupSettings, Message, MessageOptions,
-        MessagePage, MessageReference, Messages, MessagesType,
+        Conversation, ConversationSettings, DirectConversation, DirectConversationSettings,
+        GroupConversation, GroupSettings, Message, MessageOptions, MessagePage, MessageReference,
+        Messages, MessagesType,
     },
 };
 
@@ -71,7 +71,7 @@ impl ConversationDocument {
     }
 
     pub fn topic(&self) -> String {
-        format!("{}/{}", self.conversation.conversation_type(), self.id())
+        format!("{}/{}", self.conversation, self.id())
     }
 
     pub fn event_topic(&self) -> String {
@@ -196,13 +196,7 @@ impl ConversationDocument {
 impl ConversationDocument {
     pub fn sign(&mut self, did: &DID) -> Result<(), Error> {
         let settings = match self.conversation.settings() {
-            ConversationSettings::Group(settings) => {
-                assert_eq!(
-                    self.conversation.conversation_type(),
-                    ConversationType::Group
-                );
-                settings
-            }
+            ConversationSettings::Group(settings) => settings,
             ConversationSettings::Direct(_) => return Ok(()),
         };
         let Some(creator) = self.conversation.creator().clone() else {
@@ -245,13 +239,7 @@ impl ConversationDocument {
 
     pub fn verify(&self) -> Result<(), Error> {
         let settings = match self.conversation.settings() {
-            ConversationSettings::Group(settings) => {
-                assert_eq!(
-                    self.conversation.conversation_type(),
-                    ConversationType::Group
-                );
-                settings
-            }
+            ConversationSettings::Group(settings) => settings,
             ConversationSettings::Direct(_) => return Ok(()),
         };
         let Some(creator) = self.conversation.creator() else {

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -199,7 +199,7 @@ impl ConversationDocument {
             ConversationSettings::Group(settings) => settings,
             ConversationSettings::Direct(_) => return Ok(()),
         };
-        let Some(creator) = self.conversation.creator().clone() else {
+        let Some(creator) = self.conversation.creator() else {
             return Err(Error::PublicKeyInvalid);
         };
 

--- a/extensions/warp-ipfs/src/store/document/conversation.rs
+++ b/extensions/warp-ipfs/src/store/document/conversation.rs
@@ -396,9 +396,12 @@ impl ConversationTask {
     }
 
     async fn set_document(&mut self, mut document: ConversationDocument) -> Result<(), Error> {
-        if let Some(creator) = document.creator.as_ref() {
+        if let Some(creator) = document.conversation.creator() {
             if creator.eq(&self.keypair)
-                && matches!(document.conversation_type, ConversationType::Group { .. })
+                && matches!(
+                    document.conversation.conversation_type(),
+                    ConversationType::Group,
+                )
             {
                 document.sign(&self.keypair)?;
             }

--- a/extensions/warp-ipfs/src/store/document/conversation.rs
+++ b/extensions/warp-ipfs/src/store/document/conversation.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use warp::{
     crypto::DID,
     error::Error,
-    raygun::{ConversationType, MessageEventKind},
+    raygun::{Conversation, MessageEventKind},
 };
 
 use crate::store::{conversation::ConversationDocument, keystore::Keystore};
@@ -397,11 +397,7 @@ impl ConversationTask {
 
     async fn set_document(&mut self, mut document: ConversationDocument) -> Result<(), Error> {
         if let Some(creator) = document.conversation.creator() {
-            if creator.eq(&self.keypair)
-                && matches!(
-                    document.conversation.conversation_type(),
-                    ConversationType::Group,
-                )
+            if creator.eq(&self.keypair) && matches!(document.conversation, Conversation::Group(_))
             {
                 document.sign(&self.keypair)?;
             }

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2359,7 +2359,7 @@ impl MessageStore {
             Conversation::Direct(_) => return Err(Error::InvalidConversation),
         };
 
-        let Some(creator) = doc.conversation.creator().clone() else {
+        let Some(creator) = doc.conversation.creator() else {
             return Err(Error::InvalidConversation);
         };
 
@@ -2403,7 +2403,7 @@ impl MessageStore {
             Conversation::Direct(_) => return Err(Error::InvalidConversation),
         };
 
-        let Some(creator) = doc.conversation.creator().clone() else {
+        let Some(creator) = doc.conversation.creator() else {
             return Err(Error::InvalidConversation);
         };
 
@@ -2471,7 +2471,7 @@ impl MessageStore {
             return Err(Error::InvalidConversation);
         }
 
-        let Some(creator) = doc.conversation.creator().clone() else {
+        let Some(creator) = doc.conversation.creator() else {
             return Err(Error::InvalidConversation);
         };
 
@@ -2527,7 +2527,7 @@ impl MessageStore {
             return Err(Error::InvalidConversation);
         }
 
-        let Some(creator) = doc.conversation.creator().clone() else {
+        let Some(creator) = doc.conversation.creator() else {
             return Err(Error::InvalidConversation);
         };
 
@@ -2577,7 +2577,7 @@ impl MessageStore {
             return Err(Error::InvalidConversation);
         }
 
-        let Some(creator) = doc.conversation.creator().clone() else {
+        let Some(creator) = doc.conversation.creator() else {
             return Err(Error::InvalidConversation);
         };
 

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -8,8 +8,8 @@ mod test {
         constellation::Progression,
         multipass::MultiPassEventKind,
         raygun::{
-            AttachmentKind, ConversationType, Location, MessageEvent, MessageEventKind,
-            MessageType, PinState, RayGunEventKind, ReactionState,
+            AttachmentKind, Conversation, Location, MessageEvent, MessageEventKind, MessageType,
+            PinState, RayGunEventKind, ReactionState,
         },
     };
 
@@ -56,7 +56,7 @@ mod test {
         assert_eq!(id_a, id_b);
 
         let conversation = chat_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.conversation_type(), ConversationType::Direct);
+        assert!(matches!(conversation, Conversation::Direct(_)));
         assert_eq!(conversation.recipients().len(), 2);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -985,7 +985,7 @@ mod test {
         assert_eq!(id_a, id_b);
 
         let conversation = chat_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.conversation_type(), ConversationType::Direct);
+        assert!(matches!(conversation, Conversation::Direct(_)));
         assert_eq!(conversation.recipients().len(), 2);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -96,7 +96,7 @@ mod test {
         .await?;
 
         let conversation = chat_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.name(), Some(name));
+        assert_eq!(conversation.name(), Some(&name));
 
         chat_a.update_conversation_name(id_a, "").await?;
 

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
     table.set_header(vec!["ID", "Name", "Type", "Recipients", "# of Messages"]);
     for convo in conversations {
         let recipients = account
-            .get_identity(Identifier::DIDList(convo.recipients().clone()))
+            .get_identity(Identifier::DIDList(convo.recipients().to_vec()))
             .await
             .map(|list| {
                 list.iter()

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> anyhow::Result<()> {
         table.add_row(vec![
             convo.id().to_string(),
             convo.name().map(ToOwned::to_owned).unwrap_or_default(),
-            convo.conversation_type().to_string(),
+            convo.to_string(),
             recipients.join(", "),
             count.to_string(),
         ]);

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
     table.set_header(vec!["ID", "Name", "Type", "Recipients", "# of Messages"]);
     for convo in conversations {
         let recipients = account
-            .get_identity(Identifier::DIDList(convo.recipients()))
+            .get_identity(Identifier::DIDList(convo.recipients().clone()))
             .await
             .map(|list| {
                 list.iter()
@@ -145,7 +145,7 @@ async fn main() -> anyhow::Result<()> {
 
         table.add_row(vec![
             convo.id().to_string(),
-            convo.name().unwrap_or_default(),
+            convo.name().map(ToOwned::to_owned).unwrap_or_default(),
             convo.conversation_type().to_string(),
             recipients.join(", "),
             count.to_string(),

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -344,37 +344,259 @@ pub enum ConversationType {
     Group,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
-pub struct Conversation {
-    id: Uuid,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    creator: Option<DID>,
-    created: DateTime<Utc>,
-    modified: DateTime<Utc>,
-    conversation_type: ConversationType,
-    settings: ConversationSettings,
-    recipients: Vec<DID>,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
+#[serde(rename_all = "snake_case")]
+#[repr(C)]
+pub enum Conversation {
+    #[display(fmt = "direct")]
+    Direct(DirectConversation),
+    #[display(fmt = "group")]
+    Group(GroupConversation),
 }
 
-impl core::hash::Hash for Conversation {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
+impl Conversation {
+    pub fn id(&self) -> Uuid {
+        self.common().id
+    }
+
+    pub fn name(&self) -> Option<&String> {
+        self.common().name.as_ref()
+    }
+
+    pub fn creator(&self) -> Option<&DID> {
+        self.common().creator.as_ref()
+    }
+
+    pub fn created(&self) -> DateTime<Utc> {
+        self.common().created
+    }
+
+    pub fn modified(&self) -> DateTime<Utc> {
+        self.common().modified
+    }
+
+    pub fn conversation_type(&self) -> ConversationType {
+        match self {
+            Conversation::Direct(_) => ConversationType::Direct,
+            Conversation::Group(_) => ConversationType::Group,
+        }
+    }
+
+    pub fn settings(&self) -> ConversationSettings {
+        match self {
+            Conversation::Direct(direct) => ConversationSettings::Direct(direct.settings),
+            Conversation::Group(group) => ConversationSettings::Group(group.settings),
+        }
+    }
+
+    pub fn recipients(&self) -> &Vec<DID> {
+        &self.common().recipients
+    }
+
+    fn common(&self) -> &ConversationCommon {
+        match self {
+            Conversation::Direct(direct) => &direct.common,
+            Conversation::Group(group) => &group.common,
+        }
     }
 }
 
-impl PartialEq for Conversation {
-    fn eq(&self, other: &Self) -> bool {
-        self.id.eq(&other.id)
+impl Conversation {
+    pub fn set_id(mut self, id: Uuid) -> Self {
+        self.common_mut().id = id;
+
+        self
+    }
+
+    pub fn id_mut(&mut self) -> &mut Uuid {
+        &mut self.common_mut().id
+    }
+
+    pub fn set_name(mut self, name: Option<String>) -> Self {
+        self.common_mut().name = name;
+
+        self
+    }
+
+    pub fn name_mut(&mut self) -> &mut Option<String> {
+        &mut self.common_mut().name
+    }
+
+    pub fn set_creator(mut self, creator: Option<DID>) -> Self {
+        self.common_mut().creator = creator;
+
+        self
+    }
+
+    pub fn creator_mut(&mut self) -> &mut Option<DID> {
+        &mut self.common_mut().creator
+    }
+
+    pub fn set_created(mut self, created: DateTime<Utc>) -> Self {
+        self.common_mut().created = created;
+
+        self
+    }
+
+    pub fn created_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.common_mut().created
+    }
+
+    pub fn set_modified(mut self, modified: DateTime<Utc>) -> Self {
+        self.common_mut().modified = modified;
+
+        self
+    }
+
+    pub fn modified_mut(&mut self) -> &mut DateTime<Utc> {
+        &mut self.common_mut().modified
+    }
+
+    pub fn set_recipients(mut self, recipients: Vec<DID>) -> Self {
+        self.common_mut().recipients = recipients;
+
+        self
+    }
+
+    pub fn add_recipient(mut self, recipient: DID) -> Self {
+        self.common_mut().recipients.push(recipient);
+
+        self
+    }
+
+    pub fn recipients_mut(&mut self) -> &mut Vec<DID> {
+        &mut self.common_mut().recipients
+    }
+
+    fn common_mut(&mut self) -> &mut ConversationCommon {
+        match self {
+            Conversation::Direct(direct) => &mut direct.common,
+            Conversation::Group(group) => &mut group.common,
+        }
     }
 }
 
 impl Default for Conversation {
     fn default() -> Self {
+        Self::Direct(DirectConversation::default())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
+pub struct DirectConversation {
+    #[serde(flatten)]
+    common: ConversationCommon,
+    settings: DirectConversationSettings,
+}
+
+impl DirectConversation {
+    pub fn settings(&self) -> DirectConversationSettings {
+        self.settings
+    }
+
+    pub fn set_settings(mut self, settings: DirectConversationSettings) -> Self {
+        self.settings = settings;
+
+        self
+    }
+
+    pub fn settings_mut(&mut self) -> &mut DirectConversationSettings {
+        &mut self.settings
+    }
+}
+
+impl core::hash::Hash for DirectConversation {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.common.hash(state);
+    }
+}
+
+impl PartialEq for DirectConversation {
+    fn eq(&self, other: &Self) -> bool {
+        self.common.eq(&other.common)
+    }
+}
+
+impl Default for DirectConversation {
+    fn default() -> Self {
+        let common = ConversationCommon::default();
+        let settings = DirectConversationSettings::default();
+        Self { common, settings }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
+pub struct GroupConversation {
+    #[serde(flatten)]
+    common: ConversationCommon,
+    settings: GroupSettings,
+}
+
+impl GroupConversation {
+    pub fn settings(&self) -> GroupSettings {
+        self.settings
+    }
+
+    pub fn set_settings(mut self, settings: GroupSettings) -> Self {
+        self.settings = settings;
+
+        self
+    }
+
+    pub fn settings_mut(&mut self) -> &mut GroupSettings {
+        &mut self.settings
+    }
+}
+
+impl core::hash::Hash for GroupConversation {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.common.hash(state);
+    }
+}
+
+impl PartialEq for GroupConversation {
+    fn eq(&self, other: &Self) -> bool {
+        self.common.eq(&other.common)
+    }
+}
+
+impl Default for GroupConversation {
+    fn default() -> Self {
+        let common = ConversationCommon::default();
+        let settings = GroupSettings::default();
+        Self { common, settings }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
+struct ConversationCommon {
+    id: Uuid,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    creator: Option<DID>,
+    created: DateTime<Utc>,
+    modified: DateTime<Utc>,
+    recipients: Vec<DID>,
+}
+
+impl core::hash::Hash for ConversationCommon {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl PartialEq for ConversationCommon {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.eq(&other.id)
+    }
+}
+
+impl Default for ConversationCommon {
+    fn default() -> Self {
         let id = Uuid::new_v4();
         let name = None;
         let creator = None;
-        let conversation_type = ConversationType::Direct;
         let recipients = Vec::new();
         let timestamp = Utc::now();
         Self {
@@ -383,78 +605,8 @@ impl Default for Conversation {
             creator,
             created: timestamp,
             modified: timestamp,
-            conversation_type,
-            settings: ConversationSettings::default(),
             recipients,
         }
-    }
-}
-
-impl Conversation {
-    pub fn id(&self) -> Uuid {
-        self.id
-    }
-
-    pub fn name(&self) -> Option<String> {
-        self.name.clone()
-    }
-
-    pub fn creator(&self) -> Option<DID> {
-        self.creator.clone()
-    }
-
-    pub fn created(&self) -> DateTime<Utc> {
-        self.created
-    }
-
-    pub fn modified(&self) -> DateTime<Utc> {
-        self.modified
-    }
-
-    pub fn conversation_type(&self) -> ConversationType {
-        self.conversation_type
-    }
-
-    pub fn settings(&self) -> ConversationSettings {
-        self.settings
-    }
-
-    pub fn recipients(&self) -> Vec<DID> {
-        self.recipients.clone()
-    }
-}
-
-impl Conversation {
-    pub fn set_id(&mut self, id: Uuid) {
-        self.id = id;
-    }
-
-    pub fn set_name(&mut self, name: Option<String>) {
-        self.name = name;
-    }
-
-    pub fn set_creator(&mut self, creator: Option<DID>) {
-        self.creator = creator;
-    }
-
-    pub fn set_created(&mut self, created: DateTime<Utc>) {
-        self.created = created;
-    }
-
-    pub fn set_modified(&mut self, modified: DateTime<Utc>) {
-        self.modified = modified;
-    }
-
-    pub fn set_conversation_type(&mut self, conversation_type: ConversationType) {
-        self.conversation_type = conversation_type;
-    }
-
-    pub fn set_settings(&mut self, settings: ConversationSettings) {
-        self.settings = settings;
-    }
-
-    pub fn set_recipients(&mut self, recipients: Vec<DID>) {
-        self.recipients = recipients;
     }
 }
 
@@ -466,12 +618,6 @@ pub enum ConversationSettings {
     Direct(DirectConversationSettings),
     #[display(fmt = "group settings {{ {_0} }}")]
     Group(GroupSettings),
-}
-
-impl Default for ConversationSettings {
-    fn default() -> Self {
-        Self::Direct(DirectConversationSettings::default())
-    }
 }
 
 /// Settings for a direct conversation.

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -334,16 +334,6 @@ impl Ord for MessagePage {
     }
 }
 
-#[derive(Debug, Hash, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Display)]
-#[serde(rename_all = "lowercase")]
-#[repr(C)]
-pub enum ConversationType {
-    #[display(fmt = "direct")]
-    Direct,
-    #[display(fmt = "group")]
-    Group,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, Display)]
 #[serde(rename_all = "snake_case")]
 #[repr(C)]
@@ -373,13 +363,6 @@ impl Conversation {
 
     pub fn modified(&self) -> DateTime<Utc> {
         self.common().modified
-    }
-
-    pub fn conversation_type(&self) -> ConversationType {
-        match self {
-            Conversation::Direct(_) => ConversationType::Direct,
-            Conversation::Group(_) => ConversationType::Group,
-        }
     }
 
     pub fn settings(&self) -> ConversationSettings {

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -372,7 +372,7 @@ impl Conversation {
         }
     }
 
-    pub fn recipients(&self) -> &Vec<DID> {
+    pub fn recipients(&self) -> &[DID] {
         &self.common().recipients
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

* chore: Turn `warp::raygun::Conversation` from struct to an enum. This makes sense and eliminates the disconnect between conversation type and conversation settings.
* creates a builder-pattern API for setting `*Conversation` types.
* Replaces `warp_ipfs::store::conversation::ConversationDocument` fields that are duplicated with `warp::raygun::Conversation`, with a `conversation` field of type `warp::raygun::Conversation`.
* Remove `warp::raygun::ConversationType`.