### PR TITLE
fix: Properly delete conversation when receiving event

### DIFF
--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -99,7 +99,7 @@ impl FileStore {
         }
 
         if let Err(e) = task.import_v1().await {
-            tracing::error!("Error importing index: {e}");
+            tracing::warn!("Unable to import index: {e}");
         }
 
         let mut index = task.index.clone();

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -3673,18 +3673,7 @@ async fn process_conversation(
                 }
             };
 
-            let _document = this.delete(conversation_id).await?;
-
-            // let topic = document.topic();
-            // self.queue.write().await.remove(&sender);
-
-            // if this.ipfs.pubsub_unsubscribe(&topic).await.is_ok() {
-            //     warn!(conversation_id = %document.id(), "topic should have been unsubscribed after dropping conversation.");
-            // }
-
-            this.event
-                .emit(RayGunEventKind::ConversationDeleted { conversation_id })
-                .await;
+            this.delete_conversation(conversation_id, false).await?;
         }
     }
     Ok(())

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -64,6 +64,81 @@ mod test {
     }
 
     #[tokio::test]
+    async fn destroy_conversation() -> anyhow::Result<()> {
+        let accounts = create_accounts_and_chat(vec![
+            (None, None, Some("test::destroy_conversation".into())),
+            (None, None, Some("test::destroy_conversation".into())),
+        ])
+        .await?;
+
+        let (_account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
+        let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
+
+        let mut chat_subscribe_a = chat_a.subscribe().await?;
+        let mut chat_subscribe_b = chat_b.subscribe().await?;
+
+        chat_a.create_conversation(&did_b).await?;
+
+        let id_a = tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
+                    chat_subscribe_a.next().await
+                {
+                    break conversation_id;
+                }
+            }
+        })
+        .await?;
+
+        let id_b = tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if let Some(RayGunEventKind::ConversationCreated { conversation_id }) =
+                    chat_subscribe_b.next().await
+                {
+                    break conversation_id;
+                }
+            }
+        })
+        .await?;
+
+        assert_eq!(id_a, id_b);
+
+        let conversation = chat_a.get_conversation(id_a).await?;
+        assert_eq!(conversation.conversation_type(), ConversationType::Direct);
+        assert_eq!(conversation.recipients().len(), 2);
+        assert!(conversation.recipients().contains(&did_a));
+        assert!(conversation.recipients().contains(&did_b));
+        let id = conversation.id();
+
+        chat_a.delete(id, None).await?;
+
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if let Some(RayGunEventKind::ConversationDeleted { conversation_id }) =
+                    chat_subscribe_a.next().await
+                {
+                    assert_eq!(conversation_id, id);
+                    break;
+                }
+            }
+        })
+        .await?;
+
+        tokio::time::timeout(Duration::from_secs(60), async {
+            loop {
+                if let Some(RayGunEventKind::ConversationDeleted { conversation_id }) =
+                    chat_subscribe_b.next().await
+                {
+                    assert_eq!(conversation_id, id);
+                    break;
+                }
+            }
+        })
+        .await?;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn send_message_in_conversation() -> anyhow::Result<()> {
         let accounts = create_accounts_and_chat(vec![
             (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use the correct function to delete conversation after receiving event
- Add test for deleted conversation

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- While conversation was being deleted when receiving the event, it was not terminating the task handling the pubsub streams since that call was handled from a different function. This PR uses that function instead. 
- Test was added for reassurance 