### PR TITLE
refactor: Convert `Conversation` into a trait

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -356,7 +356,7 @@ async fn main() -> anyhow::Result<()> {
                             let list = chat.list_conversations().await?;
                             for convo in list.iter() {
                                 let mut recipients = vec![];
-                                for recipient in convo.recipients() {
+                                for recipient in convo.members() {
                                     let username = get_username(&*new_account,  recipient).await;
                                     recipients.push(username);
                                 }

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use clap::Parser;
 use comfy_table::Table;
 use futures::prelude::*;

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -14,9 +14,8 @@ use warp::{
     crypto::{cipher::Cipher, did_key::CoreSign, DIDKey, Ed25519KeyPair, KeyMaterial, DID},
     error::Error,
     raygun::{
-        Conversation, ConversationSettings, ConversationType, DirectConversationSettings,
-        GroupSettings, Message, MessageOptions, MessagePage, MessageReference, Messages,
-        MessagesType,
+        ConversationSettings, ConversationType, DirectConversationSettings, GroupSettings, Message,
+        MessageOptions, MessagePage, MessageReference, Messages, MessagesType,
     },
 };
 
@@ -624,26 +623,26 @@ impl ConversationDocument {
     }
 }
 
-impl From<ConversationDocument> for Conversation {
-    fn from(document: ConversationDocument) -> Self {
-        Conversation::from(&document)
-    }
-}
+// impl From<ConversationDocument> for Conversation {
+//     fn from(document: ConversationDocument) -> Self {
+//         Conversation::from(&document)
+//     }
+// }
 
-impl From<&ConversationDocument> for Conversation {
-    fn from(document: &ConversationDocument) -> Self {
-        let mut conversation = Conversation::default();
-        conversation.set_id(document.id);
-        conversation.set_name(document.name.clone());
-        conversation.set_creator(document.creator.clone());
-        conversation.set_conversation_type(document.conversation_type);
-        conversation.set_recipients(document.recipients());
-        conversation.set_created(document.created);
-        conversation.set_settings(document.settings);
-        conversation.set_modified(document.modified);
-        conversation
-    }
-}
+// impl From<&ConversationDocument> for Conversation {
+//     fn from(document: &ConversationDocument) -> Self {
+//         let mut conversation = Conversation::default();
+//         conversation.set_id(document.id);
+//         conversation.set_name(document.name.clone());
+//         conversation.set_creator(document.creator.clone());
+//         conversation.set_conversation_type(document.conversation_type);
+//         conversation.set_recipients(document.recipients());
+//         conversation.set_created(document.created);
+//         conversation.set_settings(document.settings);
+//         conversation.set_modified(document.modified);
+//         conversation
+//     }
+// }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageDocument {

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -623,27 +623,6 @@ impl ConversationDocument {
     }
 }
 
-// impl From<ConversationDocument> for Conversation {
-//     fn from(document: ConversationDocument) -> Self {
-//         Conversation::from(&document)
-//     }
-// }
-
-// impl From<&ConversationDocument> for Conversation {
-//     fn from(document: &ConversationDocument) -> Self {
-//         let mut conversation = Conversation::default();
-//         conversation.set_id(document.id);
-//         conversation.set_name(document.name.clone());
-//         conversation.set_creator(document.creator.clone());
-//         conversation.set_conversation_type(document.conversation_type);
-//         conversation.set_recipients(document.recipients());
-//         conversation.set_created(document.created);
-//         conversation.set_settings(document.settings);
-//         conversation.set_modified(document.modified);
-//         conversation
-//     }
-// }
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MessageDocument {
     pub id: Uuid,

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1189,20 +1189,13 @@ impl ConversationTask {
             return Err(Error::CannotCreateConversation);
         }
 
-        //TODO
-        // if let Some(conversation) = self
-        //     .list()
-        //     .await
-        //     .iter()
-        //     .find(|conversation| {
-        //         conversation.conversation_type == ConversationType::Direct
-        //             && conversation.recipients().contains(did)
-        //             && conversation.recipients().contains(&self.keypair)
-        //     })
-        //     .map(Conversation::from)
-        // {
-        //     return Err(Error::ConversationExist { conversation });
-        // }
+        if let Some(conversation) = self.list().await.iter().find(|conversation| {
+            conversation.conversation_type == ConversationType::Direct
+                && conversation.recipients().contains(did)
+                && conversation.recipients().contains(&self.keypair)
+        }) {
+            return Ok(conversation.id);
+        }
 
         //Temporary limit
         // if self.list_conversations().await.unwrap_or_default().len() >= 256 {

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -2,6 +2,7 @@ mod common;
 
 #[cfg(test)]
 mod test {
+    #![allow(deprecated)]
     use futures::{StreamExt, TryStreamExt};
     use std::time::Duration;
     use warp::{

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -46,8 +46,8 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 1);
-        assert!(conversation.recipients().contains(&did_a));
+        assert_eq!(conversation.members().len(), 1);
+        assert!(conversation.members().contains(&did_a));
 
         Ok(())
     }
@@ -186,10 +186,10 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
         Ok(())
     }
 
@@ -237,9 +237,9 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(conversation.conversation_type(), ConversationType::Group);
-        assert_eq!(conversation.recipients().len(), 2);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
+        assert_eq!(conversation.members().len(), 2);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
         let id = conversation.id();
 
         chat_a.delete(id, None).await?;
@@ -429,11 +429,11 @@ mod test {
             ConversationSettings::Group(settings),
         );
         assert_eq!(conversation.name().as_deref(), Some("test"));
-        assert_eq!(conversation.recipients().len(), 4);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 4);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -593,11 +593,11 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(settings),
         );
-        assert_eq!(conversation.recipients().len(), 4);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 4);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -746,11 +746,11 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(Default::default()),
         );
-        assert_eq!(conversation.recipients().len(), 4);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 4);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -1071,11 +1071,11 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(!conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(!conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -1319,10 +1319,10 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
 
         let mut conversation_a = chat_a.get_conversation_stream(id_a).await?;
         let mut conversation_b = chat_b.get_conversation_stream(id_b).await?;
@@ -1477,10 +1477,10 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
 
         let mut conversation_a = chat_a.get_conversation_stream(id_a).await?;
         let mut conversation_b = chat_b.get_conversation_stream(id_b).await?;

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -1,6 +1,7 @@
 mod common;
 #[cfg(test)]
 mod test {
+    #![allow(deprecated)]
     use std::time::Duration;
 
     use crate::common::create_accounts_and_chat;

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
     table.set_header(vec!["ID", "Name", "Type", "Recipients", "# of Messages"]);
     for convo in conversations {
         let recipients = account
-            .get_identity(Identifier::DIDList(convo.recipients()))
+            .get_identity(Identifier::DIDList(convo.members()))
             .await
             .map(|list| {
                 list.iter()
@@ -141,7 +141,7 @@ async fn main() -> anyhow::Result<()> {
                     .collect::<Vec<_>>()
             })?;
 
-        let count = rg.get_message_count(convo.id()).await?;
+        let count = convo.get_message_count().await?;
 
         table.add_row(vec![
             convo.id().to_string(),

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -125,7 +125,7 @@ pub enum Error {
     InvalidConversation,
     #[error("Conversation already exist")]
     ConversationExist {
-        conversation: crate::raygun::Conversation,
+        conversation: Box<dyn crate::raygun::Conversation>,
     },
     #[error("Maximum conversations has been reached")]
     ConversationLimitReached,

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -973,21 +973,21 @@ pub trait RayGun:
         Err(Error::Unimplemented)
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::get_message`")]
     /// Retrieve all messages from a conversation
     async fn get_message(&self, conversation_id: Uuid, message_id: Uuid) -> Result<Message, Error> {
         let conversation = self.get_conversation(conversation_id).await?;
         conversation.get_message(message_id).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::get_message_count`")]
     /// Get a number of messages in a conversation
     async fn get_message_count(&self, conversation_id: Uuid) -> Result<usize, Error> {
         let conversation = self.get_conversation(conversation_id).await?;
         conversation.get_message_count().await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::message_status`")]
     /// Get a status of a message in a conversation
     async fn message_status(
         &self,
@@ -998,7 +998,7 @@ pub trait RayGun:
         conversation.message_status(message_id).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::get_message_references`")]
     /// Retrieve all message references from a conversation
     async fn get_message_references(
         &self,
@@ -1009,7 +1009,7 @@ pub trait RayGun:
         conversation.get_message_references(opt).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::get_message_reference`")]
     /// Retrieve a message reference from a conversation
     async fn get_message_reference(
         &self,
@@ -1020,7 +1020,7 @@ pub trait RayGun:
         conversation.get_message_reference(message_id).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::get_messages`")]
     /// Retrieve all messages from a conversation
     async fn get_messages(
         &self,
@@ -1031,14 +1031,14 @@ pub trait RayGun:
         conversation.get_messages(options).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::send`")]
     /// Sends a message to a conversation.
     async fn send(&mut self, conversation_id: Uuid, message: Vec<String>) -> Result<(), Error> {
         let mut conversation = self.get_conversation(conversation_id).await?;
         conversation.send(message).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::edit`")]
     /// Edit an existing message in a conversation.
     async fn edit(
         &mut self,
@@ -1050,7 +1050,7 @@ pub trait RayGun:
         conversation.edit(message_id, message).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::delete`")]
     /// Delete message from a conversation
     async fn delete(
         &mut self,
@@ -1061,7 +1061,7 @@ pub trait RayGun:
         conversation.delete(message_id).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::react`")]
     /// React to a message
     async fn react(
         &mut self,
@@ -1074,7 +1074,7 @@ pub trait RayGun:
         conversation.react(message_id, state, emoji).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::pin`")]
     /// Pin a message within a conversation
     async fn pin(
         &mut self,
@@ -1086,7 +1086,7 @@ pub trait RayGun:
         conversation.pin(message_id, state).await
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::reply`")]
     /// Reply to a message within a conversation
     async fn reply(
         &mut self,
@@ -1102,7 +1102,7 @@ pub trait RayGun:
         Err(Error::Unimplemented)
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::update_settings`")]
     /// Update conversation settings
     async fn update_conversation_settings(
         &mut self,
@@ -1140,7 +1140,7 @@ pub trait RayGunGroupConversation: Sync + Send {
 
 #[async_trait::async_trait]
 pub trait RayGunAttachment: Sync + Send {
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::attach`")]
     /// Send files to a conversation.
     /// If no files is provided in the array, it will throw an error
     async fn attach(
@@ -1153,7 +1153,7 @@ pub trait RayGunAttachment: Sync + Send {
         Err(Error::Unimplemented)
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::download`")]
     /// Downloads a file that been attached to a message
     /// Note: Must use the filename associated when downloading
     async fn download(
@@ -1166,7 +1166,7 @@ pub trait RayGunAttachment: Sync + Send {
         Err(Error::Unimplemented)
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::download_stream`")]
     /// Stream a file that been attached to a message
     /// Note: Must use the filename associated when downloading
     async fn download_stream(
@@ -1181,7 +1181,7 @@ pub trait RayGunAttachment: Sync + Send {
 
 #[async_trait::async_trait]
 pub trait RayGunStream: Sync + Send {
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::get_conversation_stream`")]
     /// Subscribe to an stream of events from the conversation
     async fn get_conversation_stream(&mut self, _: Uuid) -> Result<MessageEventStream, Error> {
         Err(Error::Unimplemented)
@@ -1195,13 +1195,13 @@ pub trait RayGunStream: Sync + Send {
 
 #[async_trait::async_trait]
 pub trait RayGunEvents: Sync + Send {
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::send_event`")]
     /// Send an event to a conversation
     async fn send_event(&mut self, _: Uuid, _: MessageEvent) -> Result<(), Error> {
         Err(Error::Unimplemented)
     }
 
-    #[deprecated(note = "Use `Conversation::`")]
+    #[deprecated(note = "Use `Conversation::cancel_event`")]
     /// Cancel event that was sent, if any.
     async fn cancel_event(&mut self, _: Uuid, _: MessageEvent) -> Result<(), Error> {
         Err(Error::Unimplemented)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Refactors `Conversation` into a trait object
- Deprecate current raygun messaging logic, while defaulting to `Conversation` messaging logic for compatibility.

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
Resolves #457 

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
