### PR TITLE
refactor: Convert `Conversation` into a trait (partial)

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -356,7 +356,7 @@ async fn main() -> anyhow::Result<()> {
                             let list = chat.list_conversations().await?;
                             for convo in list.iter() {
                                 let mut recipients = vec![];
-                                for recipient in convo.recipients() {
+                                for recipient in convo.members() {
                                     let username = get_username(&*new_account,  recipient).await;
                                     recipients.push(username);
                                 }

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1355,7 +1355,7 @@ impl IdentityInformation for WarpIpfs {
 
 #[async_trait::async_trait]
 impl RayGun for WarpIpfs {
-    async fn create_conversation(&mut self, did_key: &DID) -> Result<Conversation, Error> {
+    async fn create_conversation(&mut self, did_key: &DID) -> Result<Box<dyn Conversation>, Error> {
         self.messaging_store()?.create_conversation(did_key).await
     }
 
@@ -1364,19 +1364,22 @@ impl RayGun for WarpIpfs {
         name: Option<String>,
         recipients: Vec<DID>,
         settings: GroupSettings,
-    ) -> Result<Conversation, Error> {
+    ) -> Result<Box<dyn Conversation>, Error> {
         self.messaging_store()?
             .create_group_conversation(name, HashSet::from_iter(recipients), settings)
             .await
     }
 
-    async fn get_conversation(&self, conversation_id: Uuid) -> Result<Conversation, Error> {
+    async fn get_conversation(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Box<dyn Conversation>, Error> {
         self.messaging_store()?
             .get_conversation(conversation_id)
             .await
     }
 
-    async fn list_conversations(&self) -> Result<Vec<Conversation>, Error> {
+    async fn list_conversations(&self) -> Result<Vec<Box<dyn Conversation>>, Error> {
         self.messaging_store()?.list_conversations().await
     }
 

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -57,6 +57,36 @@ pub struct ConversationDocument {
     pub signature: Option<String>,
 }
 
+impl Conversation for ConversationDocument {
+    fn id(&self) -> Uuid {
+        self.id
+    }
+
+    fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
+    fn created(&self) -> DateTime<Utc> {
+        self.created
+    }
+
+    fn modified(&self) -> DateTime<Utc> {
+        self.modified
+    }
+
+    fn conversation_type(&self) -> ConversationType {
+        self.conversation_type
+    }
+
+    fn settings(&self) -> ConversationSettings {
+        self.settings
+    }
+
+    fn members(&self) -> Vec<DID> {
+        self.recipients.clone()
+    }
+}
+
 impl Hash for ConversationDocument {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state)
@@ -621,27 +651,6 @@ impl ConversationDocument {
         messages.remove(&document);
         self.set_message_list(ipfs, messages).await?;
         Ok(())
-    }
-}
-
-impl From<ConversationDocument> for Conversation {
-    fn from(document: ConversationDocument) -> Self {
-        Conversation::from(&document)
-    }
-}
-
-impl From<&ConversationDocument> for Conversation {
-    fn from(document: &ConversationDocument) -> Self {
-        let mut conversation = Conversation::default();
-        conversation.set_id(document.id);
-        conversation.set_name(document.name.clone());
-        conversation.set_creator(document.creator.clone());
-        conversation.set_conversation_type(document.conversation_type);
-        conversation.set_recipients(document.recipients());
-        conversation.set_created(document.created);
-        conversation.set_settings(document.settings);
-        conversation.set_modified(document.modified);
-        conversation
     }
 }
 

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -57,9 +57,9 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(conversation.conversation_type(), ConversationType::Direct);
-        assert_eq!(conversation.recipients().len(), 2);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
+        assert_eq!(conversation.members().len(), 2);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
         Ok(())
     }
 
@@ -105,9 +105,9 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(conversation.conversation_type(), ConversationType::Direct);
-        assert_eq!(conversation.recipients().len(), 2);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
+        assert_eq!(conversation.members().len(), 2);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
         let id = conversation.id();
 
         chat_a.delete(id, None).await?;
@@ -1061,9 +1061,9 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(conversation.conversation_type(), ConversationType::Direct);
-        assert_eq!(conversation.recipients().len(), 2);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
+        assert_eq!(conversation.members().len(), 2);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
 
         _account_a.block(&did_b).await?;
 

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -46,8 +46,8 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 1);
-        assert!(conversation.recipients().contains(&did_a));
+        assert_eq!(conversation.members().len(), 1);
+        assert!(conversation.members().contains(&did_a));
 
         Ok(())
     }
@@ -186,10 +186,10 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
         Ok(())
     }
 
@@ -237,9 +237,9 @@ mod test {
 
         let conversation = chat_a.get_conversation(id_a).await?;
         assert_eq!(conversation.conversation_type(), ConversationType::Group);
-        assert_eq!(conversation.recipients().len(), 2);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
+        assert_eq!(conversation.members().len(), 2);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
         let id = conversation.id();
 
         chat_a.delete(id, None).await?;
@@ -429,11 +429,11 @@ mod test {
             ConversationSettings::Group(settings),
         );
         assert_eq!(conversation.name().as_deref(), Some("test"));
-        assert_eq!(conversation.recipients().len(), 4);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 4);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -593,11 +593,11 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(settings),
         );
-        assert_eq!(conversation.recipients().len(), 4);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 4);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -746,11 +746,11 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(Default::default()),
         );
-        assert_eq!(conversation.recipients().len(), 4);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 4);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -1071,11 +1071,11 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(!conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
-        assert!(conversation.recipients().contains(&did_d));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(!conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
+        assert!(conversation.members().contains(&did_d));
         Ok(())
     }
 
@@ -1319,10 +1319,10 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
 
         let mut conversation_a = chat_a.get_conversation_stream(id_a).await?;
         let mut conversation_b = chat_b.get_conversation_stream(id_b).await?;
@@ -1477,10 +1477,10 @@ mod test {
             conversation.settings(),
             ConversationSettings::Group(GroupSettings::default()),
         );
-        assert_eq!(conversation.recipients().len(), 3);
-        assert!(conversation.recipients().contains(&did_a));
-        assert!(conversation.recipients().contains(&did_b));
-        assert!(conversation.recipients().contains(&did_c));
+        assert_eq!(conversation.members().len(), 3);
+        assert!(conversation.members().contains(&did_a));
+        assert!(conversation.members().contains(&did_b));
+        assert!(conversation.members().contains(&did_c));
 
         let mut conversation_a = chat_a.get_conversation_stream(id_a).await?;
         let mut conversation_b = chat_b.get_conversation_stream(id_b).await?;

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -133,7 +133,7 @@ async fn main() -> anyhow::Result<()> {
     table.set_header(vec!["ID", "Name", "Type", "Recipients", "# of Messages"]);
     for convo in conversations {
         let recipients = account
-            .get_identity(Identifier::DIDList(convo.recipients()))
+            .get_identity(Identifier::DIDList(convo.members()))
             .await
             .map(|list| {
                 list.iter()

--- a/warp/src/error.rs
+++ b/warp/src/error.rs
@@ -125,7 +125,7 @@ pub enum Error {
     InvalidConversation,
     #[error("Conversation already exist")]
     ConversationExist {
-        conversation: crate::raygun::Conversation,
+        conversation: Box<dyn crate::raygun::Conversation>,
     },
     #[error("Maximum conversations has been reached")]
     ConversationLimitReached,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Convert `Conversation` into a trait object

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- Relates to #457 

**Special notes for reviewers** 🗒️
- This PR, much like #458, is conceptual and still TBD for #457

**Additional comments** 🎤
- Unlike #458, this PR only supports having `Conversation` as the trait object while retaining the rest of the messaging logic, besides the breaking change between `Conversation::recipients` and `Conversation::members`
- This object attempts to remain as a getter functionality while attempting to avoid async calls, however similar to #458, we may eventually need to cache the resolved data of the `ConversationDocument` and map that out to this trait object if we wish to maintain the same flow without introducing async functions into the mix.
- Unlike #458, this PR only implements `Conversation`. It does not store its internal data inside of a lock, which means when when the conversation has an updated (eg adding/removing members, update to conversation name, etc), it would need to grab a new object by calling `RayGun::get_conversation` with the updated information
