### PR TITLE
refactor: Use Error directly in Progression::ProgressFailed

### DIFF
--- a/extensions/warp-ipfs/examples/ipfs-persistent.rs
+++ b/extensions/warp-ipfs/examples/ipfs-persistent.rs
@@ -132,7 +132,7 @@ async fn main() -> anyhow::Result<()> {
                         println!(
                             "{name} failed to upload at {} MB due to: {}",
                             last_size.unwrap_or_default(),
-                            error.unwrap_or_default()
+                            error
                         );
                     }
                 }

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -600,7 +600,7 @@ async fn main() -> anyhow::Result<()> {
                                                 writeln!(stdout, "> {name} is uploaded")?;
                                             },
                                             AttachmentKind::AttachedProgress(Progression::ProgressFailed { name, error, .. }) => {
-                                                writeln!(stdout, "> {name} failed to upload: {}", error.unwrap_or_default())?;
+                                                writeln!(stdout, "> {name} failed to upload: {}", error)?;
                                             },
                                             AttachmentKind::Pending(Ok(_)) => {
                                                 writeln!(stdout, "> File sent")?;
@@ -659,7 +659,7 @@ async fn main() -> anyhow::Result<()> {
                                                 writeln!(stdout,
                                                     "{name} failed to download at {} MB due to: {}",
                                                     last_size.unwrap_or_default(),
-                                                    error.unwrap_or_default()
+                                                    error
                                                 )?;
                                             }
                                         }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -658,10 +658,11 @@ impl FileTask {
                         written, error, ..
                     } => {
                         last_written = written;
+                        let error = error.map(Error::Any).unwrap_or(Error::Other);
                         yield Progression::ProgressFailed {
                             name,
                             last_size: Some(last_written),
-                            error: error.map(|e| e.to_string()),
+                            error,
                         };
                         return;
                     }
@@ -682,7 +683,7 @@ impl FileTask {
                         yield Progression::ProgressFailed {
                             name,
                             last_size: Some(last_written),
-                            error: Some("IpfsPath not set".into()),
+                            error: Error::Other,
                         };
                         return;
                     }
@@ -708,7 +709,7 @@ impl FileTask {
                 yield Progression::ProgressFailed {
                     name,
                     last_size: Some(last_written),
-                    error: Some(e.to_string()),
+                    error: e,
                 };
                 return;
             }
@@ -757,10 +758,11 @@ impl FileTask {
                     UnixfsStatus::FailedStatus {
                         written, error, ..
                     } => {
+                        let error = error.map(Error::Any).unwrap_or(Error::Other);
                         yield Progression::ProgressFailed {
                             name: name.to_string(),
                             last_size: Some(written),
-                            error: error.map(|e| e.to_string()),
+                            error,
                         };
                         return;
                     }
@@ -967,10 +969,11 @@ impl FileTask {
                         written, error, ..
                     } => {
                         last_written = written;
+                        let error = error.map(Error::Any).unwrap_or(Error::Other);
                         yield Progression::ProgressFailed {
                             name: n,
                             last_size: Some(last_written),
-                            error: error.map(|e| e.to_string()),
+                            error,
                         };
                         return;
                     }
@@ -988,12 +991,12 @@ impl FileTask {
                     yield Progression::ProgressFailed {
                         name,
                         last_size: Some(last_written),
-                        error: Some(Error::InvalidLength {
+                        error: Error::InvalidLength {
                             context: "buffer".into(),
                             current: root.size() + last_written,
                             minimum: None,
                             maximum: Some(max_size),
-                        }).map(|e| e.to_string())
+                        }
                     };
                     return;
                 }
@@ -1006,7 +1009,7 @@ impl FileTask {
                         yield Progression::ProgressFailed {
                             name,
                             last_size: Some(last_written),
-                            error: Some("IpfsPath not set".into()),
+                            error: Error::Other,
                         };
                         return;
                     }
@@ -1023,7 +1026,7 @@ impl FileTask {
                 yield Progression::ProgressFailed {
                     name,
                     last_size: Some(last_written),
-                    error: Some(e.to_string()),
+                    error: e,
                 };
                 return;
             }

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -16,8 +16,6 @@ use dyn_clone::DynClone;
 use futures::stream::BoxStream;
 use futures::Stream;
 
-use serde::{Deserialize, Serialize};
-
 #[derive(Debug, Clone)]
 pub enum ConstellationEventKind {
     Uploaded {
@@ -50,7 +48,7 @@ impl Stream for ConstellationEventStream {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug)]
 pub enum Progression {
     CurrentProgress {
         /// name of the file
@@ -77,7 +75,7 @@ pub enum Progression {
         last_size: Option<usize>,
 
         /// error of why it failed, if any
-        error: Option<String>,
+        error: Error,
     },
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Remove Clone, Serialize and Deserialize from `Progression`
- Use `Error` instead of `Option<String>`

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
