### PR TITLE
chore: Remove disconnect b/w Conversation* type-specific fields

### DIFF
--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -43,7 +43,6 @@ pub struct ConversationDocument {
     pub creator: Option<DID>,
     pub created: DateTime<Utc>,
     pub modified: DateTime<Utc>,
-    pub conversation_type: ConversationType,
     pub settings: ConversationSettings,
     pub recipients: Vec<DID>,
     pub excluded: HashMap<DID, String>,
@@ -79,7 +78,7 @@ impl ConversationDocument {
     }
 
     pub fn topic(&self) -> String {
-        format!("{}/{}", self.conversation_type, self.id())
+        format!("{}/{}", self.conversation_type(), self.id())
     }
 
     pub fn event_topic(&self) -> String {
@@ -117,6 +116,13 @@ impl ConversationDocument {
             .cloned()
             .collect()
     }
+
+    pub fn conversation_type(&self) -> ConversationType {
+        match self.settings {
+            ConversationSettings::Direct(_) => ConversationType::Direct,
+            ConversationSettings::Group(_) => ConversationType::Group,
+        }
+    }
 }
 
 impl ConversationDocument {
@@ -127,7 +133,6 @@ impl ConversationDocument {
         mut recipients: Vec<DID>,
         restrict: Vec<DID>,
         id: Option<Uuid>,
-        conversation_type: ConversationType,
         settings: ConversationSettings,
         created: Option<DateTime<Utc>>,
         modified: Option<DateTime<Utc>>,
@@ -158,7 +163,6 @@ impl ConversationDocument {
             creator,
             created,
             modified,
-            conversation_type,
             settings,
             excluded,
             messages,
@@ -202,7 +206,6 @@ impl ConversationDocument {
             recipients.to_vec(),
             vec![],
             conversation_id,
-            ConversationType::Direct,
             ConversationSettings::Direct(settings),
             None,
             None,
@@ -225,7 +228,6 @@ impl ConversationDocument {
             recipients.to_vec(),
             restrict.to_vec(),
             conversation_id,
-            ConversationType::Group,
             ConversationSettings::Group(settings),
             None,
             None,
@@ -238,7 +240,7 @@ impl ConversationDocument {
 impl ConversationDocument {
     pub fn sign(&mut self, did: &DID) -> Result<(), Error> {
         if let ConversationSettings::Group(settings) = self.settings {
-            assert_eq!(self.conversation_type, ConversationType::Group);
+            assert_eq!(self.conversation_type(), ConversationType::Group);
             let Some(creator) = self.creator.clone() else {
                 return Err(Error::PublicKeyInvalid);
             };
@@ -279,7 +281,7 @@ impl ConversationDocument {
 
     pub fn verify(&self) -> Result<(), Error> {
         if let ConversationSettings::Group(settings) = self.settings {
-            assert_eq!(self.conversation_type, ConversationType::Group);
+            assert_eq!(self.conversation_type(), ConversationType::Group);
             let Some(creator) = &self.creator else {
                 return Err(Error::PublicKeyInvalid);
             };
@@ -636,7 +638,6 @@ impl From<&ConversationDocument> for Conversation {
         conversation.set_id(document.id);
         conversation.set_name(document.name.clone());
         conversation.set_creator(document.creator.clone());
-        conversation.set_conversation_type(document.conversation_type);
         conversation.set_recipients(document.recipients());
         conversation.set_created(document.created);
         conversation.set_settings(document.settings);

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -352,7 +352,6 @@ pub struct Conversation {
     creator: Option<DID>,
     created: DateTime<Utc>,
     modified: DateTime<Utc>,
-    conversation_type: ConversationType,
     settings: ConversationSettings,
     recipients: Vec<DID>,
 }
@@ -374,7 +373,6 @@ impl Default for Conversation {
         let id = Uuid::new_v4();
         let name = None;
         let creator = None;
-        let conversation_type = ConversationType::Direct;
         let recipients = Vec::new();
         let timestamp = Utc::now();
         Self {
@@ -383,7 +381,6 @@ impl Default for Conversation {
             creator,
             created: timestamp,
             modified: timestamp,
-            conversation_type,
             settings: ConversationSettings::default(),
             recipients,
         }
@@ -412,7 +409,10 @@ impl Conversation {
     }
 
     pub fn conversation_type(&self) -> ConversationType {
-        self.conversation_type
+        match self.settings {
+            ConversationSettings::Direct(_) => ConversationType::Direct,
+            ConversationSettings::Group(_) => ConversationType::Group,
+        }
     }
 
     pub fn settings(&self) -> ConversationSettings {
@@ -443,10 +443,6 @@ impl Conversation {
 
     pub fn set_modified(&mut self, modified: DateTime<Utc>) {
         self.modified = modified;
-    }
-
-    pub fn set_conversation_type(&mut self, conversation_type: ConversationType) {
-        self.conversation_type = conversation_type;
     }
 
     pub fn set_settings(&mut self, settings: ConversationSettings) {


### PR DESCRIPTION
**What this PR does** 📖

This PR remove the ConversationType fields in 2 structs and add getters that infer the type from the settings field. This way, it eliminates the disconnect between them and ensures that the type is never inconsistent with the settings.