### PR TITLE
refactor: Pin root document directly instead of payload

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1186,13 +1186,7 @@ impl MultiPassImportExport for WarpIpfs {
 
                 let mut store = self.identity_store(false).await?;
 
-                let package = store.import_identity_remote(keypair.clone()).await?;
-                let decrypted_bundle = ecdh_decrypt(&keypair, None, package)?;
-                let exported_document =
-                    serde_json::from_slice::<ResolvedRootDocument>(&decrypted_bundle)?;
-
-                exported_document.verify()?;
-                return store.import_identity(exported_document).await;
+                return store.import_identity_remote_resolve().await;
             }
         }
     }

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -243,6 +243,71 @@ impl RootDocument {
         Ok(exported)
     }
 
+    #[tracing::instrument(skip(self, ipfs))]
+    pub async fn resolve2(&self, ipfs: &Ipfs) -> Result<(), Error> {
+        let document: IdentityDocument = ipfs
+            .get_dag(self.identity)
+            .deserialized()
+            .await
+            .map_err(|_| Error::IdentityInvalid)?;
+
+        document.resolve()?;
+
+        _ = futures::future::ready(self.friends.ok_or(Error::Other))
+            .and_then(|document| async move {
+                ipfs.get_dag(document)
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .map_err(Error::from)
+            })
+            .await;
+
+        _ = futures::future::ready(self.blocks.ok_or(Error::Other))
+            .and_then(|document| async move {
+                ipfs.get_dag(document)
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .map_err(Error::from)
+            })
+            .await;
+
+        _ = futures::future::ready(self.block_by.ok_or(Error::Other))
+            .and_then(|document| async move {
+                ipfs.get_dag(document)
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .map_err(Error::from)
+            })
+            .await;
+
+        _ = futures::future::ready(self.request.ok_or(Error::Other))
+            .and_then(|document| async move {
+                ipfs.get_dag(document)
+                    .await
+                    .map_err(anyhow::Error::from)
+                    .map_err(Error::from)
+            })
+            .await;
+
+        _ = futures::future::ready(self.conversations_keystore.ok_or(Error::Other))
+            .and_then(|document| async move {
+                let map: BTreeMap<String, Cid> = ipfs.get_dag(document).deserialized().await?;
+                let mut resolved_map: BTreeMap<Uuid, _> = BTreeMap::new();
+                for (k, v) in map
+                    .iter()
+                    .filter_map(|(k, v)| Uuid::from_str(k).map(|k| (k, *v)).ok())
+                {
+                    if let Ok(store) = ipfs.get_dag(v).await {
+                        resolved_map.insert(k, store);
+                    }
+                }
+                Ok(resolved_map)
+            })
+            .await;
+
+        self.verify(ipfs).await
+    }
+
     pub async fn import(ipfs: &Ipfs, data: ResolvedRootDocument) -> Result<Self, Error> {
         data.verify()?;
 

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -112,6 +112,13 @@ pub enum RootDocumentCommand {
     ExportEncrypted {
         response: oneshot::Sender<Result<Vec<u8>, Error>>,
     },
+    ExportRootCid {
+        response: oneshot::Sender<Result<Cid, Error>>,
+    },
+    SetRootCid {
+        cid: Cid,
+        response: oneshot::Sender<Result<(), Error>>,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -372,6 +379,26 @@ impl RootDocumentMap {
         rx.await.map_err(anyhow::Error::from)?
     }
 
+    pub async fn export_root_cid(&self) -> Result<Cid, Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(RootDocumentCommand::ExportRootCid { response: tx })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
+    pub async fn import_root_cid(&self, cid: Cid) -> Result<(), Error> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self
+            .tx
+            .clone()
+            .send(RootDocumentCommand::SetRootCid { cid, response: tx })
+            .await;
+        rx.await.map_err(anyhow::Error::from)?
+    }
+
     pub async fn export(&self) -> Result<ResolvedRootDocument, Error> {
         let (tx, rx) = oneshot::channel();
         let _ = self
@@ -520,6 +547,9 @@ impl RootDocumentTask {
                 RootDocumentCommand::Export { response } => {
                     let _ = response.send(self.export().await);
                 }
+                RootDocumentCommand::ExportRootCid { response } => {
+                    let _ = response.send(self.cid.ok_or(Error::IdentityDoesntExist));
+                }
                 RootDocumentCommand::ExportEncrypted { response } => {
                     let _ = response.send(self.export_bytes().await);
                 }
@@ -537,6 +567,9 @@ impl RootDocumentTask {
                 }
                 RootDocumentCommand::SetRootIndex { root, response } => {
                     let _ = response.send(self.set_root_index(root).await);
+                }
+                RootDocumentCommand::SetRootCid { cid, response } => {
+                    let _ = response.send(self.set_root_cid(cid).await);
                 }
             }
         }
@@ -626,7 +659,9 @@ impl RootDocumentTask {
         //Precautionary check
         document.verify(&self.ipfs).await?;
 
-        let root_cid = self.ipfs.dag().put().serialize(document).pin(true).await?;
+        let root_cid = self.ipfs.dag().put().serialize(document).await?;
+
+        self.ipfs.insert_pin(&root_cid).recursive().await?;
 
         let old_cid = self.cid.replace(root_cid);
 
@@ -1164,5 +1199,17 @@ impl RootDocumentTask {
 
         let bytes = serde_json::to_vec(&export)?;
         ecdh_encrypt(&self.keypair, None, bytes)
+    }
+
+    async fn set_root_cid(&mut self, cid: Cid) -> Result<(), Error> {
+        let root_document = self
+            .ipfs
+            .get_dag(cid)
+            .deserialized::<RootDocument>()
+            .await?;
+        // Step down through each field to resolve them
+        root_document.resolve2(&self.ipfs).await?;
+        self.set_root_document(root_document).await?;
+        Ok(())
     }
 }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1626,7 +1626,49 @@ impl IdentityStore {
         Ok(identity)
     }
 
-    pub async fn import_identity_remote(&mut self, did: DID) -> Result<Vec<u8>, Error> {
+    #[tracing::instrument(skip(self))]
+    pub async fn import_identity_remote_resolve(&mut self) -> Result<Identity, Error> {
+        let keypair = &*self.did_key;
+        let package = self.import_identity_remote(keypair.clone()).await?;
+
+        self.root_document.import_root_cid(package).await?;
+
+        tracing::info!("Loading friends list into phonebook");
+        if let Ok(friends) = self.friends_list().await {
+            if !friends.is_empty() {
+                let phonebook = self.phonebook();
+
+                if let Err(_e) = phonebook.add_friend_list(&friends).await {
+                    error!("Error adding friends in phonebook: {_e}");
+                }
+                _ = self.announce_identity_to_mesh().await;
+            }
+        }
+
+        match self.is_registered().await.is_ok() {
+            true => {
+                if let Err(e) = self.fetch_mailbox().await {
+                    tracing::warn!(error = %e, "Unable to fetch or process mailbox");
+                }
+            }
+            false => {
+                let id = self.own_identity_document().await.expect("Valid identity");
+                if let Err(e) = self.register(&id).await {
+                    tracing::warn!(did = %id.did, error = %e, "Unable to register identity");
+                }
+
+                if let Err(e) = self.export_root_document().await {
+                    tracing::warn!(%id.did, error = %e, "Unable to export root document after registration");
+                }
+            }
+        }
+
+        let identity = self.own_identity().await?;
+
+        Ok(identity)
+    }
+
+    pub async fn import_identity_remote(&mut self, did: DID) -> Result<Cid, Error> {
         if let DiscoveryConfig::Shuttle { addresses } = self.discovery.discovery_config() {
             for peer_id in addresses.iter().filter_map(|addr| addr.peer_id()) {
                 let (tx, rx) = futures::channel::oneshot::channel();
@@ -1701,7 +1743,7 @@ impl IdentityStore {
     }
 
     pub async fn export_root_document(&self) -> Result<(), Error> {
-        let package = self.root_document.export_bytes().await?;
+        let package = self.root_document.export_root_cid().await?;
 
         if let DiscoveryConfig::Shuttle { addresses } = self.discovery.discovery_config() {
             for peer_id in addresses.iter().filter_map(|addr| addr.peer_id()) {
@@ -1711,7 +1753,7 @@ impl IdentityStore {
                     .clone()
                     .send(shuttle::identity::client::IdentityCommand::UpdatePackage {
                         peer_id,
-                        package: package.clone(),
+                        package,
                         response: tx,
                     })
                     .await;

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1709,34 +1709,14 @@ impl IdentityStore {
 
         if let DiscoveryConfig::Shuttle { addresses } = self.discovery.discovery_config() {
             for peer_id in addresses.iter().filter_map(|addr| addr.peer_id()) {
-                let (tx, rx) = futures::channel::oneshot::channel();
                 let _ = self
                     .identity_command
                     .clone()
                     .send(shuttle::identity::client::IdentityCommand::UpdateIdentity {
                         peer_id,
                         identity: identity.clone().into(),
-                        response: tx,
                     })
                     .await;
-
-                match tokio::time::timeout(SHUTTLE_TIMEOUT, rx).await {
-                    Ok(Ok(Ok(_))) => {
-                        break;
-                    }
-                    Ok(Ok(Err(e))) => {
-                        tracing::error!("Error exporting to {peer_id}: {e}");
-                        break;
-                    }
-                    Ok(Err(Canceled)) => {
-                        tracing::error!("Channel been unexpectedly closed for {peer_id}");
-                        continue;
-                    }
-                    Err(_) => {
-                        tracing::error!("Request timeout for {peer_id}");
-                        continue;
-                    }
-                }
             }
         }
         Ok(())
@@ -1747,34 +1727,14 @@ impl IdentityStore {
 
         if let DiscoveryConfig::Shuttle { addresses } = self.discovery.discovery_config() {
             for peer_id in addresses.iter().filter_map(|addr| addr.peer_id()) {
-                let (tx, rx) = futures::channel::oneshot::channel();
                 let _ = self
                     .identity_command
                     .clone()
                     .send(shuttle::identity::client::IdentityCommand::UpdatePackage {
                         peer_id,
                         package,
-                        response: tx,
                     })
                     .await;
-
-                match tokio::time::timeout(SHUTTLE_TIMEOUT, rx).await {
-                    Ok(Ok(Ok(_))) => {
-                        break;
-                    }
-                    Ok(Ok(Err(e))) => {
-                        tracing::error!("Error exporting to {peer_id}: {e}");
-                        break;
-                    }
-                    Ok(Err(Canceled)) => {
-                        tracing::error!("Channel been unexpectedly closed for {peer_id}");
-                        continue;
-                    }
-                    Err(_) => {
-                        tracing::error!("Request timeout for {peer_id}");
-                        continue;
-                    }
-                }
             }
         }
         Ok(())
@@ -1915,7 +1875,6 @@ impl IdentityStore {
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
 
             for peer_id in addresses.iter().filter_map(|addr| addr.peer_id()) {
-                let (tx, rx) = futures::channel::oneshot::channel();
                 let _ = self
                     .identity_command
                     .clone()
@@ -1923,23 +1882,8 @@ impl IdentityStore {
                         peer_id,
                         to: did.clone(),
                         request: request.clone(),
-                        response: tx,
                     })
                     .await;
-
-                match tokio::time::timeout(SHUTTLE_TIMEOUT, rx).await {
-                    Ok(Ok(result)) => {
-                        return result;
-                    }
-                    Ok(Err(Canceled)) => {
-                        tracing::error!("Channel been unexpectedly closed for {peer_id}");
-                        continue;
-                    }
-                    Err(_) => {
-                        tracing::error!("Request timeout for {peer_id}");
-                        continue;
-                    }
-                }
             }
         }
         Ok(())

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1484,7 +1484,9 @@ impl ConversationTask {
 
         document.verify()?;
 
-        self.root.set_conversation_document(document).await
+        self.root.set_conversation_document(document).await?;
+        self.identity.export_root_document().await?;
+        Ok(())
     }
 
     pub async fn subscribe(

--- a/tools/shuttle/src/identity/client.rs
+++ b/tools/shuttle/src/identity/client.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use futures::{channel::oneshot, FutureExt, StreamExt};
+use libipld::Cid;
 use rust_ipfs::{
     libp2p::{
         core::Endpoint,
@@ -74,7 +75,7 @@ pub enum IdentityCommand {
     },
     UpdatePackage {
         peer_id: PeerId,
-        package: Vec<u8>,
+        package: Cid,
         response: futures::channel::oneshot::Sender<Result<(), warp::error::Error>>,
     },
     SendRequest {
@@ -91,7 +92,7 @@ pub enum IdentityCommand {
     Fetch {
         peer_id: PeerId,
         did: DID,
-        response: futures::channel::oneshot::Sender<Result<Vec<u8>, warp::error::Error>>,
+        response: futures::channel::oneshot::Sender<Result<Cid, warp::error::Error>>,
     },
 }
 
@@ -121,7 +122,7 @@ enum IdentityResponse {
         response: futures::channel::oneshot::Sender<Result<(), warp::error::Error>>,
     },
     Fetch {
-        response: futures::channel::oneshot::Sender<Result<Vec<u8>, warp::error::Error>>,
+        response: futures::channel::oneshot::Sender<Result<Cid, warp::error::Error>>,
     },
 }
 
@@ -550,7 +551,7 @@ impl NetworkBehaviour for Behaviour {
                         response,
                     } => {
                         tracing::info!(
-                            package_size = package.len(),
+                            package = %package,
                             "Sending package to {peer_id}"
                         );
                         let payload = payload_message_construct(

--- a/tools/shuttle/src/identity/protocol.rs
+++ b/tools/shuttle/src/identity/protocol.rs
@@ -78,6 +78,7 @@ pub enum Response {
     SynchronizedResponse(SynchronizedResponse),
     MailboxResponse(MailboxResponse),
     LookupResponse(LookupResponse),
+    Ack,
     Error(String),
 }
 

--- a/tools/shuttle/src/identity/protocol.rs
+++ b/tools/shuttle/src/identity/protocol.rs
@@ -1,3 +1,4 @@
+use libipld::Cid;
 use rust_ipfs::{libp2p::StreamProtocol, Keypair};
 use serde::{Deserialize, Serialize};
 use warp::{crypto::DID, multipass::identity::ShortId};
@@ -196,7 +197,7 @@ pub enum RegisterError {
 pub enum Synchronized {
     PeerRecord { record: Vec<u8> },
     Update { document: IdentityDocument },
-    Store { package: Vec<u8> },
+    Store { package: Cid },
     Fetch { did: DID },
 }
 
@@ -205,7 +206,7 @@ pub enum Synchronized {
 pub enum SynchronizedResponse {
     RecordStored,
     IdentityUpdated,
-    Package(Vec<u8>),
+    Package(Cid),
     Error(SynchronizedError),
 }
 

--- a/tools/shuttle/src/server.rs
+++ b/tools/shuttle/src/server.rs
@@ -227,7 +227,7 @@ impl ShuttleTask {
             //       in a future that will be queued after so many request from that peer as a way to throttle the number of
             //       active request. If that exceeds a specific limit from that peer, or proceed to continue up,
             //       we can drop all requests and temporarily disconnect that peer
-            // TODO: Implement throttling in the behaviour and queue active request after a specific number of requests.   
+            // TODO: Implement throttling in the behaviour and queue active request after a specific number of requests.
             tokio::spawn(async move {
                 match payload.message() {
                     Message::Request(req) => match req {

--- a/tools/shuttle/src/server.rs
+++ b/tools/shuttle/src/server.rs
@@ -221,18 +221,28 @@ impl ShuttleServer {
 
 impl ShuttleTask {
     async fn start(&mut self) {
-        let keypair = self.ipfs.keypair();
-
         while let Some((id, ch, payload, resp)) = self.identity_rx.next().await {
             tracing::info!(request_id = ?id, "Processing Incoming Request");
-            match payload.message() {
-                Message::Request(req) => match req {
-                    identity::protocol::Request::Register(Register::IsRegistered) => {
-                        let peer_id = payload.sender();
-                        let Ok(did) = peer_id.to_did() else {
-                            tracing::warn!(%peer_id, "Could not convert to did key");
-                            let payload = payload_message_construct(
-                                keypair,
+            let keypair = self.ipfs.keypair().clone();
+            let ipfs = self.ipfs.clone();
+            let identity_storage = self.identity_storage.clone();
+            let mut subscriptions = self.subscriptions.clone();
+            let mut precord_tx = self.precord_tx.clone();
+
+            // Note: For now, we will process each request in its own task, however in the future, we will store each request
+            //       in a future that will be queued after so many request from that peer as a way to throttle the number of
+            //       active request. If that exceeds a specific limit from that peer, or proceed to continue up,
+            //       we can drop all requests and temporarily disconnect that peer
+            // TODO: Implement throttling in the behaviour and queue active request after a specific number of requests.   
+            tokio::spawn(async move {
+                match payload.message() {
+                    Message::Request(req) => match req {
+                        identity::protocol::Request::Register(Register::IsRegistered) => {
+                            let peer_id = payload.sender();
+                            let Ok(did) = peer_id.to_did() else {
+                                tracing::warn!(%peer_id, "Could not convert to did key");
+                                let payload = payload_message_construct(
+                                &keypair,
                                 None,
                                 Response::RegisterResponse(RegisterResponse::Error(
                                     identity::protocol::RegisterError::IdentityVerificationFailed,
@@ -240,127 +250,58 @@ impl ShuttleTask {
                             )
                             .expect("Valid payload construction");
 
-                            let _ = resp.send((ch, payload));
+                                let _ = resp.send((ch, payload));
 
-                            continue;
-                        };
-
-                        if !self.identity_storage.contains(&did).await {
-                            tracing::warn!(%did, "Identity is not registered");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::RegisterResponse(RegisterResponse::Error(
-                                    identity::protocol::RegisterError::NotRegistered,
-                                )),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
-
-                        let payload = payload_message_construct(
-                            keypair,
-                            None,
-                            Response::RegisterResponse(RegisterResponse::Ok),
-                        )
-                        .expect("Valid payload construction");
-
-                        let _ = resp.send((ch, payload));
-                    }
-                    identity::protocol::Request::Register(Register::RegisterIdentity {
-                        document,
-                    }) => {
-                        tracing::info!(%document.did, "Receive register request");
-                        if self.identity_storage.contains(&document.did).await {
-                            tracing::warn!(%document.did, "Identity is already registered");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::RegisterResponse(RegisterResponse::Error(
-                                    identity::protocol::RegisterError::IdentityExist,
-                                )),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
-
-                        if document.verify().is_err() {
-                            tracing::warn!(%document.did, "Identity cannot be verified");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::RegisterResponse(RegisterResponse::Error(
-                                    identity::protocol::RegisterError::IdentityVerificationFailed,
-                                )),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-
-                            continue;
-                        }
-
-                        if let Err(e) = self.identity_storage.register(document.clone()).await {
-                            tracing::warn!(%document.did, "Unable to register identity");
-                            let res_error = match e {
-                                WarpError::IdentityExist => {
-                                    Response::RegisterResponse(RegisterResponse::Error(
-                                        identity::protocol::RegisterError::IdentityExist,
-                                    ))
-                                }
-                                _ => Response::RegisterResponse(RegisterResponse::Error(
-                                    identity::protocol::RegisterError::None,
-                                )),
+                                return;
                             };
 
-                            let payload = payload_message_construct(keypair, None, res_error)
+                            if !identity_storage.contains(&did).await {
+                                tracing::warn!(%did, "Identity is not registered");
+                                let payload = payload_message_construct(
+                                    &keypair,
+                                    None,
+                                    Response::RegisterResponse(RegisterResponse::Error(
+                                        identity::protocol::RegisterError::NotRegistered,
+                                    )),
+                                )
                                 .expect("Valid payload construction");
 
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
+                                let _ = resp.send((ch, payload));
+                                return;
+                            }
 
-                        if let Err(e) = self.subscriptions.subscribe(document.did.inbox()).await {
-                            tracing::warn!(%document.did, "Unable to subscribe to given topic: {e}. ignoring...");
-                            // Although we arent able to subscribe, we can still process the request while leaving this as a warning
-                        }
-
-                        if let Err(e) = self.subscriptions.subscribe(document.did.messaging()).await
-                        {
-                            tracing::warn!(%document.did, "Unable to subscribe to given topic: {e}. ignoring...");
-                            // Although we arent able to subscribe, we can still process the request while leaving this as a warning
-                        }
-
-                        let payload = PayloadRequest::new(keypair, None, document.clone())
+                            let payload = payload_message_construct(
+                                &keypair,
+                                None,
+                                Response::RegisterResponse(RegisterResponse::Ok),
+                            )
                             .expect("Valid payload construction");
 
-                        let bytes = serde_json::to_vec(&payload).expect("Valid serialization");
+                            let _ = resp.send((ch, payload));
+                        }
+                        identity::protocol::Request::Register(Register::RegisterIdentity {
+                            document,
+                        }) => {
+                            tracing::info!(%document.did, "Receive register request");
+                            if identity_storage.contains(&document.did).await {
+                                tracing::warn!(%document.did, "Identity is already registered");
+                                let payload = payload_message_construct(
+                                    &keypair,
+                                    None,
+                                    Response::RegisterResponse(RegisterResponse::Error(
+                                        identity::protocol::RegisterError::IdentityExist,
+                                    )),
+                                )
+                                .expect("Valid payload construction");
 
-                        _ = self
-                            .ipfs
-                            .pubsub_publish("/identity/announce/v0", bytes)
-                            .await;
+                                let _ = resp.send((ch, payload));
+                                return;
+                            }
 
-                        tracing::info!(%document.did, "identity registered");
-                        let payload = payload_message_construct(
-                            keypair,
-                            None,
-                            Response::RegisterResponse(RegisterResponse::Ok),
-                        )
-                        .expect("Valid payload construction");
-
-                        let _ = resp.send((ch, payload));
-                    }
-                    identity::protocol::Request::Mailbox(event) => {
-                        let peer_id = payload.sender();
-                        let Ok(did) = peer_id.to_did() else {
-                            tracing::warn!(%peer_id, "Could not convert to did key");
-                            let payload = payload_message_construct(
-                                keypair,
+                            if document.verify().is_err() {
+                                tracing::warn!(%document.did, "Identity cannot be verified");
+                                let payload = payload_message_construct(
+                                &keypair,
                                 None,
                                 Response::RegisterResponse(RegisterResponse::Error(
                                     identity::protocol::RegisterError::IdentityVerificationFailed,
@@ -368,75 +309,81 @@ impl ShuttleTask {
                             )
                             .expect("Valid payload construction");
 
-                            let _ = resp.send((ch, payload));
+                                let _ = resp.send((ch, payload));
 
-                            continue;
-                        };
+                                return;
+                            }
 
-                        if !self.identity_storage.contains(&did).await {
-                            tracing::warn!(%did, "Identity is not registered");
+                            if let Err(e) = identity_storage.register(document.clone()).await {
+                                tracing::warn!(%document.did, "Unable to register identity");
+                                let res_error = match e {
+                                    WarpError::IdentityExist => {
+                                        Response::RegisterResponse(RegisterResponse::Error(
+                                            identity::protocol::RegisterError::IdentityExist,
+                                        ))
+                                    }
+                                    _ => Response::RegisterResponse(RegisterResponse::Error(
+                                        identity::protocol::RegisterError::None,
+                                    )),
+                                };
+
+                                let payload = payload_message_construct(&keypair, None, res_error)
+                                    .expect("Valid payload construction");
+
+                                let _ = resp.send((ch, payload));
+                                return;
+                            }
+
+                            if let Err(e) = subscriptions.subscribe(document.did.inbox()).await {
+                                tracing::warn!(%document.did, "Unable to subscribe to given topic: {e}. ignoring...");
+                                // Although we arent able to subscribe, we can still process the request while leaving this as a warning
+                            }
+
+                            if let Err(e) = subscriptions.subscribe(document.did.messaging()).await
+                            {
+                                tracing::warn!(%document.did, "Unable to subscribe to given topic: {e}. ignoring...");
+                                // Although we arent able to subscribe, we can still process the request while leaving this as a warning
+                            }
+
+                            let payload = PayloadRequest::new(&keypair, None, document.clone())
+                                .expect("Valid payload construction");
+
+                            let bytes = serde_json::to_vec(&payload).expect("Valid serialization");
+
+                            _ = ipfs.pubsub_publish("/identity/announce/v0", bytes).await;
+
+                            tracing::info!(%document.did, "identity registered");
                             let payload = payload_message_construct(
-                                keypair,
+                                &keypair,
                                 None,
-                                Response::MailboxResponse(
-                                    identity::protocol::MailboxResponse::Error(
-                                        identity::protocol::MailboxError::IdentityNotRegistered,
-                                    ),
-                                ),
+                                Response::RegisterResponse(RegisterResponse::Ok),
                             )
                             .expect("Valid payload construction");
 
                             let _ = resp.send((ch, payload));
-
-                            continue;
                         }
-
-                        match event {
-                            identity::protocol::Mailbox::FetchAll => {
-                                let (reqs, remaining) = self
-                                    .identity_storage
-                                    .fetch_mailbox(did.clone())
-                                    .await
-                                    .unwrap_or_default();
-
-                                tracing::info!(%did, request = reqs.len(), remaining = remaining);
-
+                        identity::protocol::Request::Mailbox(event) => {
+                            let peer_id = payload.sender();
+                            let Ok(did) = peer_id.to_did() else {
+                                tracing::warn!(%peer_id, "Could not convert to did key");
                                 let payload = payload_message_construct(
-                                    keypair,
-                                    None,
-                                    Response::MailboxResponse(
-                                        identity::protocol::MailboxResponse::Receive {
-                                            list: reqs,
-                                            remaining,
-                                        },
-                                    ),
-                                )
-                                .expect("Valid payload construction");
+                                &keypair,
+                                None,
+                                Response::RegisterResponse(RegisterResponse::Error(
+                                    identity::protocol::RegisterError::IdentityVerificationFailed,
+                                )),
+                            )
+                            .expect("Valid payload construction");
 
                                 let _ = resp.send((ch, payload));
-                            }
-                            identity::protocol::Mailbox::FetchFrom { .. } => {
-                                tracing::warn!(%did, "accessed to unimplemented request");
-                                //TODO
-                                let payload = payload_message_construct(
-                                    keypair,
-                                    None,
-                                    Response::MailboxResponse(
-                                        identity::protocol::MailboxResponse::Error(
-                                            identity::protocol::MailboxError::NoRequests,
-                                        ),
-                                    ),
-                                )
-                                .expect("Valid payload construction");
 
-                                let _ = resp.send((ch, payload));
-                                continue;
-                            }
-                            identity::protocol::Mailbox::Send { did: to, request } => {
-                                if !self.identity_storage.contains(to).await {
-                                    tracing::warn!(%did, "Identity is not registered");
-                                    let payload = payload_message_construct(
-                                    keypair,
+                                return;
+                            };
+
+                            if !identity_storage.contains(&did).await {
+                                tracing::warn!(%did, "Identity is not registered");
+                                let payload = payload_message_construct(
+                                    &keypair,
                                     None,
                                     Response::MailboxResponse(
                                         identity::protocol::MailboxResponse::Error(
@@ -446,15 +393,73 @@ impl ShuttleTask {
                                 )
                                 .expect("Valid payload construction");
 
-                                    let _ = resp.send((ch, payload));
+                                let _ = resp.send((ch, payload));
 
-                                    continue;
-                                }
+                                return;
+                            }
 
-                                if request.verify().is_err() {
-                                    tracing::warn!(%did, to = %to, "request could not be vertified");
+                            match event {
+                                identity::protocol::Mailbox::FetchAll => {
+                                    let (reqs, remaining) = identity_storage
+                                        .fetch_mailbox(did.clone())
+                                        .await
+                                        .unwrap_or_default();
+
+                                    tracing::info!(%did, request = reqs.len(), remaining = remaining);
+
                                     let payload = payload_message_construct(
-                                        keypair,
+                                        &keypair,
+                                        None,
+                                        Response::MailboxResponse(
+                                            identity::protocol::MailboxResponse::Receive {
+                                                list: reqs,
+                                                remaining,
+                                            },
+                                        ),
+                                    )
+                                    .expect("Valid payload construction");
+
+                                    let _ = resp.send((ch, payload));
+                                }
+                                identity::protocol::Mailbox::FetchFrom { .. } => {
+                                    tracing::warn!(%did, "accessed to unimplemented request");
+                                    //TODO
+                                    let payload = payload_message_construct(
+                                        &keypair,
+                                        None,
+                                        Response::MailboxResponse(
+                                            identity::protocol::MailboxResponse::Error(
+                                                identity::protocol::MailboxError::NoRequests,
+                                            ),
+                                        ),
+                                    )
+                                    .expect("Valid payload construction");
+
+                                    let _ = resp.send((ch, payload));
+                                }
+                                identity::protocol::Mailbox::Send { did: to, request } => {
+                                    if !identity_storage.contains(to).await {
+                                        tracing::warn!(%did, "Identity is not registered");
+                                        let payload = payload_message_construct(
+                                    &keypair,
+                                    None,
+                                    Response::MailboxResponse(
+                                        identity::protocol::MailboxResponse::Error(
+                                            identity::protocol::MailboxError::IdentityNotRegistered,
+                                        ),
+                                    ),
+                                )
+                                .expect("Valid payload construction");
+
+                                        let _ = resp.send((ch, payload));
+
+                                        return;
+                                    }
+
+                                    if request.verify().is_err() {
+                                        tracing::warn!(%did, to = %to, "request could not be vertified");
+                                        let payload = payload_message_construct(
+                                        &keypair,
                                         None,
                                         Response::MailboxResponse(
                                             identity::protocol::MailboxResponse::Error(
@@ -464,18 +469,18 @@ impl ShuttleTask {
                                     )
                                     .expect("Valid payload construction");
 
-                                    let _ = resp.send((ch, payload));
-                                    continue;
-                                }
+                                        let _ = resp.send((ch, payload));
+                                        return;
+                                    }
 
-                                if let Err(e) =
-                                    self.identity_storage.deliver_request(to, request).await
-                                {
-                                    match e {
-                                        WarpError::InvalidSignature => {
-                                            tracing::warn!(%did, to = %to, "request could not be vertified");
-                                            let payload = payload_message_construct(
-                                            keypair,
+                                    if let Err(e) =
+                                        identity_storage.deliver_request(to, request).await
+                                    {
+                                        match e {
+                                            WarpError::InvalidSignature => {
+                                                tracing::warn!(%did, to = %to, "request could not be vertified");
+                                                let payload = payload_message_construct(
+                                            &keypair,
                                             None,
                                             Response::MailboxResponse(
                                                 identity::protocol::MailboxResponse::Error(
@@ -485,50 +490,52 @@ impl ShuttleTask {
                                         )
                                         .expect("Valid payload construction");
 
-                                            let _ = resp.send((ch, payload));
-                                        }
-                                        e => {
-                                            tracing::warn!(%did, to = %to, "could not deliver request");
-                                            let payload = payload_message_construct(
-                                                keypair,
-                                                None,
-                                                Response::MailboxResponse(
-                                                    identity::protocol::MailboxResponse::Error(
-                                                        identity::protocol::MailboxError::Other(
-                                                            e.to_string(),
+                                                let _ = resp.send((ch, payload));
+                                            }
+                                            e => {
+                                                tracing::warn!(%did, to = %to, "could not deliver request");
+                                                let payload = payload_message_construct(
+                                                    &keypair,
+                                                    None,
+                                                    Response::MailboxResponse(
+                                                        identity::protocol::MailboxResponse::Error(
+                                                            identity::protocol::MailboxError::Other(
+                                                                e.to_string(),
+                                                            ),
                                                         ),
                                                     ),
-                                                ),
-                                            )
-                                            .expect("Valid payload construction");
+                                                )
+                                                .expect("Valid payload construction");
 
-                                            let _ = resp.send((ch, payload));
+                                                let _ = resp.send((ch, payload));
+                                            }
                                         }
+                                        return;
                                     }
-                                    continue;
+
+                                    tracing::info!(%did, to = %to, "request has been stored");
+
+                                    let payload = payload_message_construct(
+                                        &keypair,
+                                        None,
+                                        Response::MailboxResponse(
+                                            identity::protocol::MailboxResponse::Sent,
+                                        ),
+                                    )
+                                    .expect("Valid payload construction");
+
+                                    let _ = resp.send((ch, payload));
                                 }
-
-                                tracing::info!(%did, to = %to, "request has been stored");
-
-                                let payload = payload_message_construct(
-                                    keypair,
-                                    None,
-                                    Response::MailboxResponse(
-                                        identity::protocol::MailboxResponse::Sent,
-                                    ),
-                                )
-                                .expect("Valid payload construction");
-
-                                let _ = resp.send((ch, payload));
                             }
                         }
-                    }
-                    identity::protocol::Request::Synchronized(Synchronized::Store { package }) => {
-                        let peer_id = payload.sender();
-                        let Ok(did) = peer_id.to_did() else {
-                            tracing::warn!(%peer_id, "Could not convert to did key");
-                            let payload = payload_message_construct(
-                                keypair,
+                        identity::protocol::Request::Synchronized(Synchronized::Store {
+                            package,
+                        }) => {
+                            let peer_id = payload.sender();
+                            let Ok(did) = peer_id.to_did() else {
+                                tracing::warn!(%peer_id, "Could not convert to did key");
+                                let payload = payload_message_construct(
+                                &keypair,
                                 None,
                                 Response::RegisterResponse(RegisterResponse::Error(
                                     identity::protocol::RegisterError::IdentityVerificationFailed,
@@ -536,153 +543,32 @@ impl ShuttleTask {
                             )
                             .expect("Valid payload construction");
 
-                            let _ = resp.send((ch, payload));
+                                let _ = resp.send((ch, payload));
 
-                            continue;
-                        };
-
-                        if !self.identity_storage.contains(&did).await {
-                            tracing::warn!(%did, "Identity is not registered");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(
-                                    identity::protocol::SynchronizedResponse::Error(
-                                        SynchronizedError::NotRegistered,
-                                    ),
-                                ),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-
-                            continue;
-                        }
-
-                        if let Err(e) = self.identity_storage.store_package(&did, *package).await {
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(
-                                    identity::protocol::SynchronizedResponse::Error(
-                                        SynchronizedError::InvalidPayload { msg: e.to_string() },
-                                    ),
-                                ),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
-
-                        tracing::info!(%did, %package, "package is stored");
-
-                        let payload = payload_message_construct(
-                            keypair,
-                            None,
-                            Response::SynchronizedResponse(SynchronizedResponse::IdentityUpdated),
-                        )
-                        .expect("Valid payload construction");
-
-                        let _ = resp.send((ch, payload));
-                        continue;
-                    }
-                    identity::protocol::Request::Synchronized(Synchronized::Update {
-                        document,
-                    }) => {
-                        tracing::info!(%document.did, "Receive identity update");
-                        if document.verify().is_err() {
-                            tracing::warn!(%document.did, "identity is not valid or corrupted");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(SynchronizedResponse::Error(
-                                    SynchronizedError::Invalid,
-                                )),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-
-                            continue;
-                        }
-                        let did = document.did.clone();
-
-                        if !self.identity_storage.contains(&did).await {
-                            tracing::warn!(%did, "Identity is not registered");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(SynchronizedResponse::Error(
-                                    SynchronizedError::NotRegistered,
-                                )),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-
-                            continue;
-                        }
-
-                        if let Err(e) = self.identity_storage.update(document).await {
-                            let payload = match e {
-                                WarpError::InvalidSignature => {
-                                    tracing::warn!(%did, "Identity is not registered");
-                                    payload_message_construct(
-                                        keypair,
-                                        None,
-                                        Response::SynchronizedResponse(
-                                            SynchronizedResponse::Error(SynchronizedError::Invalid),
-                                        ),
-                                    )
-                                    .expect("Valid payload construction")
-                                }
-                                _ => payload_message_construct(
-                                    keypair,
-                                    None,
-                                    Response::SynchronizedResponse(SynchronizedResponse::Error(
-                                        SynchronizedError::Invalid,
-                                    )),
-                                )
-                                .expect("Valid payload construction"),
+                                return;
                             };
 
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
-
-                        tracing::info!(%did, "Identity updated");
-
-                        tracing::info!(%did, "Announcing to mesh");
-
-                        let payload = PayloadRequest::new(keypair, None, document.clone())
-                            .expect("Valid payload construction");
-
-                        let bytes = serde_json::to_vec(&payload).expect("Valid serialization");
-
-                        _ = self
-                            .ipfs
-                            .pubsub_publish("/identity/announce/v0", bytes)
-                            .await;
-
-                        let payload = payload_message_construct(
-                            keypair,
-                            None,
-                            Response::SynchronizedResponse(SynchronizedResponse::IdentityUpdated),
-                        )
-                        .expect("Valid payload construction");
-
-                        let _ = resp.send((ch, payload));
-                        continue;
-                    }
-                    identity::protocol::Request::Synchronized(Synchronized::PeerRecord {
-                        record,
-                    }) => {
-                        let signed_envelope = match SignedEnvelope::from_protobuf_encoding(record) {
-                            Ok(signed_envelope) => signed_envelope,
-                            Err(e) => {
+                            if !identity_storage.contains(&did).await {
+                                tracing::warn!(%did, "Identity is not registered");
                                 let payload = payload_message_construct(
-                                    keypair,
+                                    &keypair,
+                                    None,
+                                    Response::SynchronizedResponse(
+                                        identity::protocol::SynchronizedResponse::Error(
+                                            SynchronizedError::NotRegistered,
+                                        ),
+                                    ),
+                                )
+                                .expect("Valid payload construction");
+
+                                let _ = resp.send((ch, payload));
+
+                                return;
+                            }
+
+                            if let Err(e) = identity_storage.store_package(&did, *package).await {
+                                let payload = payload_message_construct(
+                                    &keypair,
                                     None,
                                     Response::SynchronizedResponse(
                                         identity::protocol::SynchronizedResponse::Error(
@@ -693,271 +579,266 @@ impl ShuttleTask {
                                     ),
                                 )
                                 .expect("Valid payload construction");
-                                let _ = resp.send((ch, payload));
-                                continue;
-                            }
-                        };
 
-                        let record = match PeerRecord::from_signed_envelope(signed_envelope) {
-                            Ok(record) => record,
-                            Err(e) => {
+                                let _ = resp.send((ch, payload));
+                                return;
+                            }
+
+                            tracing::info!(%did, %package, "package is stored");
+
+                            let payload = payload_message_construct(
+                                &keypair,
+                                None,
+                                Response::SynchronizedResponse(
+                                    SynchronizedResponse::IdentityUpdated,
+                                ),
+                            )
+                            .expect("Valid payload construction");
+
+                            let _ = resp.send((ch, payload));
+                        }
+                        identity::protocol::Request::Synchronized(Synchronized::Update {
+                            document,
+                        }) => {
+                            tracing::info!(%document.did, "Receive identity update");
+                            if document.verify().is_err() {
+                                tracing::warn!(%document.did, "identity is not valid or corrupted");
                                 let payload = payload_message_construct(
-                                    keypair,
+                                    &keypair,
+                                    None,
+                                    Response::SynchronizedResponse(SynchronizedResponse::Error(
+                                        SynchronizedError::Invalid,
+                                    )),
+                                )
+                                .expect("Valid payload construction");
+
+                                let _ = resp.send((ch, payload));
+
+                                return;
+                            }
+                            let did = document.did.clone();
+
+                            if !identity_storage.contains(&did).await {
+                                tracing::warn!(%did, "Identity is not registered");
+                                let payload = payload_message_construct(
+                                    &keypair,
+                                    None,
+                                    Response::SynchronizedResponse(SynchronizedResponse::Error(
+                                        SynchronizedError::NotRegistered,
+                                    )),
+                                )
+                                .expect("Valid payload construction");
+
+                                let _ = resp.send((ch, payload));
+
+                                return;
+                            }
+
+                            if let Err(e) = identity_storage.update(document).await {
+                                let payload = match e {
+                                    WarpError::InvalidSignature => {
+                                        tracing::warn!(%did, "Identity is not registered");
+                                        payload_message_construct(
+                                            &keypair,
+                                            None,
+                                            Response::SynchronizedResponse(
+                                                SynchronizedResponse::Error(
+                                                    SynchronizedError::Invalid,
+                                                ),
+                                            ),
+                                        )
+                                        .expect("Valid payload construction")
+                                    }
+                                    _ => payload_message_construct(
+                                        &keypair,
+                                        None,
+                                        Response::SynchronizedResponse(
+                                            SynchronizedResponse::Error(SynchronizedError::Invalid),
+                                        ),
+                                    )
+                                    .expect("Valid payload construction"),
+                                };
+
+                                let _ = resp.send((ch, payload));
+                                return;
+                            }
+
+                            tracing::info!(%did, "Identity updated");
+
+                            tracing::info!(%did, "Announcing to mesh");
+
+                            let payload = PayloadRequest::new(&keypair, None, document.clone())
+                                .expect("Valid payload construction");
+
+                            let bytes = serde_json::to_vec(&payload).expect("Valid serialization");
+
+                            _ = ipfs.pubsub_publish("/identity/announce/v0", bytes).await;
+
+                            let payload = payload_message_construct(
+                                &keypair,
+                                None,
+                                Response::SynchronizedResponse(
+                                    SynchronizedResponse::IdentityUpdated,
+                                ),
+                            )
+                            .expect("Valid payload construction");
+
+                            let _ = resp.send((ch, payload));
+                        }
+                        identity::protocol::Request::Synchronized(Synchronized::PeerRecord {
+                            record,
+                        }) => {
+                            let signed_envelope =
+                                match SignedEnvelope::from_protobuf_encoding(record) {
+                                    Ok(signed_envelope) => signed_envelope,
+                                    Err(e) => {
+                                        let payload = payload_message_construct(
+                                            &keypair,
+                                            None,
+                                            Response::SynchronizedResponse(
+                                                identity::protocol::SynchronizedResponse::Error(
+                                                    SynchronizedError::InvalidPayload {
+                                                        msg: e.to_string(),
+                                                    },
+                                                ),
+                                            ),
+                                        )
+                                        .expect("Valid payload construction");
+                                        let _ = resp.send((ch, payload));
+                                        return;
+                                    }
+                                };
+
+                            let record = match PeerRecord::from_signed_envelope(signed_envelope) {
+                                Ok(record) => record,
+                                Err(e) => {
+                                    let payload = payload_message_construct(
+                                        &keypair,
+                                        None,
+                                        Response::SynchronizedResponse(
+                                            identity::protocol::SynchronizedResponse::Error(
+                                                SynchronizedError::InvalodRecord {
+                                                    msg: e.to_string(),
+                                                },
+                                            ),
+                                        ),
+                                    )
+                                    .expect("Valid payload construction");
+
+                                    let _ = resp.send((ch, payload));
+                                    return;
+                                }
+                            };
+
+                            let peer_id = record.peer_id();
+
+                            let Ok(did) = peer_id.to_did() else {
+                                tracing::warn!(%peer_id, "Could not convert to did key");
+                                let payload = payload_message_construct(
+                                    &keypair,
                                     None,
                                     Response::SynchronizedResponse(
                                         identity::protocol::SynchronizedResponse::Error(
-                                            SynchronizedError::InvalodRecord { msg: e.to_string() },
+                                            SynchronizedError::Invalid,
                                         ),
                                     ),
                                 )
                                 .expect("Valid payload construction");
 
                                 let _ = resp.send((ch, payload));
-                                continue;
-                            }
-                        };
 
-                        let peer_id = record.peer_id();
+                                return;
+                            };
 
-                        let Ok(did) = peer_id.to_did() else {
-                            tracing::warn!(%peer_id, "Could not convert to did key");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(
-                                    identity::protocol::SynchronizedResponse::Error(
-                                        SynchronizedError::Invalid,
-                                    ),
-                                ),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-
-                            continue;
-                        };
-
-                        if !self.identity_storage.contains(&did).await {
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(
-                                    identity::protocol::SynchronizedResponse::Error(
-                                        SynchronizedError::NotRegistered,
-                                    ),
-                                ),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
-
-                        _ = self.precord_tx.send(record).await;
-
-                        let payload = payload_message_construct(
-                            keypair,
-                            None,
-                            Response::SynchronizedResponse(SynchronizedResponse::RecordStored),
-                        )
-                        .expect("Valid payload construction");
-
-                        let _ = resp.send((ch, payload));
-                        continue;
-                    }
-                    identity::protocol::Request::Synchronized(Synchronized::Fetch { did }) => {
-                        tracing::info!(%did, "Fetching document");
-                        if !self.identity_storage.contains(did).await {
-                            tracing::warn!(%did, "Identity is not registered");
-                            let payload = payload_message_construct(
-                                keypair,
-                                None,
-                                Response::SynchronizedResponse(
-                                    identity::protocol::SynchronizedResponse::Error(
-                                        SynchronizedError::NotRegistered,
-                                    ),
-                                ),
-                            )
-                            .expect("Valid payload construction");
-
-                            let _ = resp.send((ch, payload));
-                            continue;
-                        }
-
-                        tracing::info!(%did, "looking for package");
-                        let event = match self.identity_storage.get_package(did).await {
-                            Ok(package) => {
-                                tracing::info!(%did, package = %package, "package found");
-                                Response::SynchronizedResponse(SynchronizedResponse::Package(
-                                    package,
-                                ))
-                            }
-                            Err(_) => {
-                                tracing::warn!(%did, "package not found");
-                                Response::SynchronizedResponse(
-                                    identity::protocol::SynchronizedResponse::Error(
-                                        SynchronizedError::DoesntExist,
+                            if !identity_storage.contains(&did).await {
+                                let payload = payload_message_construct(
+                                    &keypair,
+                                    None,
+                                    Response::SynchronizedResponse(
+                                        identity::protocol::SynchronizedResponse::Error(
+                                            SynchronizedError::NotRegistered,
+                                        ),
                                     ),
                                 )
+                                .expect("Valid payload construction");
+
+                                let _ = resp.send((ch, payload));
+                                return;
                             }
-                        };
 
-                        let payload = payload_message_construct(keypair, None, event)
+                            _ = precord_tx.send(record).await;
+
+                            let payload = payload_message_construct(
+                                &keypair,
+                                None,
+                                Response::SynchronizedResponse(SynchronizedResponse::RecordStored),
+                            )
                             .expect("Valid payload construction");
 
-                        let _ = resp.send((ch, payload));
+                            let _ = resp.send((ch, payload));
+                        }
+                        identity::protocol::Request::Synchronized(Synchronized::Fetch { did }) => {
+                            tracing::info!(%did, "Fetching document");
+                            if !identity_storage.contains(did).await {
+                                tracing::warn!(%did, "Identity is not registered");
+                                let payload = payload_message_construct(
+                                    &keypair,
+                                    None,
+                                    Response::SynchronizedResponse(
+                                        identity::protocol::SynchronizedResponse::Error(
+                                            SynchronizedError::NotRegistered,
+                                        ),
+                                    ),
+                                )
+                                .expect("Valid payload construction");
 
-                        continue;
-                    }
-                    identity::protocol::Request::Lookup(kind) => {
-                        let peer_id = payload.sender();
-                        tracing::info!(peer_id = %peer_id, lookup = ?kind);
+                                let _ = resp.send((ch, payload));
+                                return;
+                            }
 
-                        let identity = self
-                            .identity_storage
-                            .lookup(kind.clone())
-                            .await
-                            .unwrap_or_default();
+                            tracing::info!(%did, "looking for package");
+                            let event = match identity_storage.get_package(did).await {
+                                Ok(package) => {
+                                    tracing::info!(%did, package = %package, "package found");
+                                    Response::SynchronizedResponse(SynchronizedResponse::Package(
+                                        package,
+                                    ))
+                                }
+                                Err(_) => {
+                                    tracing::warn!(%did, "package not found");
+                                    Response::SynchronizedResponse(
+                                        identity::protocol::SynchronizedResponse::Error(
+                                            SynchronizedError::DoesntExist,
+                                        ),
+                                    )
+                                }
+                            };
 
-                        let event = Response::LookupResponse(LookupResponse::Ok { identity });
+                            let payload = payload_message_construct(&keypair, None, event)
+                                .expect("Valid payload construction");
 
-                        let payload = payload_message_construct(keypair, None, event)
-                            .expect("Valid payload construction");
+                            let _ = resp.send((ch, payload));
+                        }
+                        identity::protocol::Request::Lookup(kind) => {
+                            let peer_id = payload.sender();
+                            tracing::info!(peer_id = %peer_id, lookup = ?kind);
 
-                        let _ = resp.send((ch, payload));
-                    } // identity::protocol::Request::Lookup(Lookup::PublicKeys { dids }) => {
-                      //     tracing::trace!(list_size = dids.len());
+                            let identity = identity_storage
+                                .lookup(kind.clone())
+                                .await
+                                .unwrap_or_default();
 
-                      //     let list = dids
-                      //         .iter()
-                      //         .filter_map(|did| temp_registration.get(did))
-                      //         .cloned()
-                      //         .collect::<Vec<_>>();
+                            let event = Response::LookupResponse(LookupResponse::Ok { identity });
 
-                      //     tracing::info!(list_size = list.len(), "Found");
+                            let payload = payload_message_construct(&keypair, None, event)
+                                .expect("Valid payload construction");
 
-                      //     let event = match list.is_empty() {
-                      //         false => Response::LookupResponse(LookupResponse::Ok { identity: list }),
-                      //         true => Response::LookupResponse(LookupResponse::Error(
-                      //             identity::protocol::LookupError::DoesntExist,
-                      //         )),
-                      //     };
-
-                      //     let payload =
-                      //         payload_message_construct(keypair, None, event).expect("Valid payload construction");
-
-                      //     let _ = resp.send((ch, payload));
-                      // }
-
-                      // identity::protocol::Request::Lookup(Lookup::Username { username, .. })
-                      //     if username.contains('#') =>
-                      // {
-                      //     //TODO: Score against invalid username scheme
-                      //     let split_data = username.split('#').collect::<Vec<&str>>();
-
-                      //     let list = if split_data.len() != 2 {
-                      //         temp_registration
-                      //             .values()
-                      //             .filter(|document| {
-                      //                 document
-                      //                     .username
-                      //                     .to_lowercase()
-                      //                     .eq(&username.to_lowercase())
-                      //             })
-                      //             .cloned()
-                      //             .collect::<Vec<_>>()
-                      //     } else {
-                      //         match (
-                      //             split_data.first().map(|s| s.to_lowercase()),
-                      //             split_data.last().map(|s| s.to_lowercase()),
-                      //         ) {
-                      //             (Some(name), Some(code)) => temp_registration
-                      //                 .values()
-                      //                 .filter(|ident| {
-                      //                     ident.username.to_lowercase().eq(&name)
-                      //                         && String::from_utf8_lossy(&ident.short_id)
-                      //                             .to_lowercase()
-                      //                             .eq(&code)
-                      //                 })
-                      //                 .cloned()
-                      //                 .collect::<Vec<_>>(),
-                      //             _ => vec![],
-                      //         }
-                      //     };
-
-                      //     tracing::info!(list_size = list.len(), "Found identities");
-
-                      //     let event = match list.is_empty() {
-                      //         false => Response::LookupResponse(LookupResponse::Ok { identity: list }),
-                      //         true => Response::LookupResponse(LookupResponse::Error(
-                      //             identity::protocol::LookupError::DoesntExist,
-                      //         )),
-                      //     };
-
-                      //     let payload =
-                      //         payload_message_construct(keypair, None, event).expect("Valid payload construction");
-
-                      //     let _ = resp.send((ch, payload));
-                      // }
-                      // identity::protocol::Request::Lookup(Lookup::Username { username, .. }) => {
-                      //     //TODO: Score against invalid username scheme
-                      //     let list = temp_registration
-                      //         .values()
-                      //         .filter(|document| {
-                      //             document
-                      //                 .username
-                      //                 .to_lowercase()
-                      //                 .contains(&username.to_lowercase())
-                      //         })
-                      //         .cloned()
-                      //         .collect::<Vec<_>>();
-
-                      //     tracing::info!(list_size = list.len(), "Found identities");
-
-                      //     let event = match list.is_empty() {
-                      //         false => Response::LookupResponse(LookupResponse::Ok { identity: list }),
-                      //         true => Response::LookupResponse(LookupResponse::Error(
-                      //             identity::protocol::LookupError::DoesntExist,
-                      //         )),
-                      //     };
-
-                      //     let payload =
-                      //         payload_message_construct(keypair, None, event).expect("Valid payload construction");
-
-                      //     let _ = resp.send((ch, payload));
-                      // }
-                      // identity::protocol::Request::Lookup(Lookup::ShortId { short_id }) => {
-                      //     let Some(document) = temp_registration
-                      //         .values()
-                      //         .find(|document| document.short_id.eq(short_id.as_ref()))
-                      //     else {
-                      //         let payload = payload_message_construct(
-                      //             keypair,
-                      //             None,
-                      //             Response::LookupResponse(LookupResponse::Error(
-                      //                 identity::protocol::LookupError::DoesntExist,
-                      //             )),
-                      //         )
-                      //         .expect("Valid payload construction");
-
-                      //         let _ = resp.send((ch, payload));
-                      //         continue;
-                      //     };
-
-                      //     let payload = payload_message_construct(
-                      //         keypair,
-                      //         None,
-                      //         Response::LookupResponse(LookupResponse::Ok {
-                      //             identity: vec![document.clone()],
-                      //         }),
-                      //     )
-                      //     .expect("Valid payload construction");
-
-                      //     let _ = resp.send((ch, payload));
-                      // }
-                },
-                Message::Response(_) => {}
-            }
+                            let _ = resp.send((ch, payload));
+                        }
+                    },
+                    Message::Response(_) => {}
+                }
+            });
         }
     }
 }

--- a/tools/shuttle/src/server.rs
+++ b/tools/shuttle/src/server.rs
@@ -184,7 +184,7 @@ impl ShuttleServer {
 
         println!(
             "Identities Registered: {}",
-            identity.list().await?.count().await
+            identity.list().await.count().await
         );
 
         let mut subscriptions = Subscriptions::new(&ipfs, &identity);
@@ -239,12 +239,7 @@ impl ShuttleTask {
                             continue;
                         };
 
-                        if !self
-                            .identity_storage
-                            .contains(&did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if !self.identity_storage.contains(&did).await {
                             tracing::warn!(%did, "Identity is not registered");
                             let payload = payload_message_construct(
                                 keypair,
@@ -272,12 +267,7 @@ impl ShuttleTask {
                         document,
                     }) => {
                         tracing::info!(%document.did, "Receive register request");
-                        if self
-                            .identity_storage
-                            .contains(&document.did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if self.identity_storage.contains(&document.did).await {
                             tracing::warn!(%document.did, "Identity is already registered");
                             let payload = payload_message_construct(
                                 keypair,
@@ -377,12 +367,7 @@ impl ShuttleTask {
                             continue;
                         };
 
-                        if !self
-                            .identity_storage
-                            .contains(&did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if !self.identity_storage.contains(&did).await {
                             tracing::warn!(%did, "Identity is not registered");
                             let payload = payload_message_construct(
                                 keypair,
@@ -442,7 +427,7 @@ impl ShuttleTask {
                                 continue;
                             }
                             identity::protocol::Mailbox::Send { did: to, request } => {
-                                if !self.identity_storage.contains(to).await.unwrap_or_default() {
+                                if !self.identity_storage.contains(to).await {
                                     tracing::warn!(%did, "Identity is not registered");
                                     let payload = payload_message_construct(
                                     keypair,
@@ -550,12 +535,7 @@ impl ShuttleTask {
                             continue;
                         };
 
-                        if !self
-                            .identity_storage
-                            .contains(&did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if !self.identity_storage.contains(&did).await {
                             tracing::warn!(%did, "Identity is not registered");
                             let payload = payload_message_construct(
                                 keypair,
@@ -622,12 +602,7 @@ impl ShuttleTask {
                         }
                         let did = document.did.clone();
 
-                        if !self
-                            .identity_storage
-                            .contains(&did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if !self.identity_storage.contains(&did).await {
                             tracing::warn!(%did, "Identity is not registered");
                             let payload = payload_message_construct(
                                 keypair,
@@ -756,12 +731,7 @@ impl ShuttleTask {
                             continue;
                         };
 
-                        if !self
-                            .identity_storage
-                            .contains(&did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if !self.identity_storage.contains(&did).await {
                             let payload = payload_message_construct(
                                 keypair,
                                 None,
@@ -791,12 +761,7 @@ impl ShuttleTask {
                     }
                     identity::protocol::Request::Synchronized(Synchronized::Fetch { did }) => {
                         tracing::info!(%did, "Fetching document");
-                        if !self
-                            .identity_storage
-                            .contains(did)
-                            .await
-                            .unwrap_or_default()
-                        {
+                        if !self.identity_storage.contains(did).await {
                             tracing::warn!(%did, "Identity is not registered");
                             let payload = payload_message_construct(
                                 keypair,

--- a/tools/shuttle/src/server.rs
+++ b/tools/shuttle/src/server.rs
@@ -64,6 +64,12 @@ pub struct ShuttleServer {
     task: JoinHandle<()>,
 }
 
+impl Drop for ShuttleServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
 #[allow(clippy::type_complexity)]
 #[allow(dead_code)]
 struct ShuttleTask {

--- a/tools/shuttle/src/server.rs
+++ b/tools/shuttle/src/server.rs
@@ -64,12 +64,6 @@ pub struct ShuttleServer {
     task: JoinHandle<()>,
 }
 
-impl Drop for ShuttleServer {
-    fn drop(&mut self) {
-        self.task.abort();
-    }
-}
-
 #[allow(clippy::type_complexity)]
 #[allow(dead_code)]
 struct ShuttleTask {

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -96,8 +96,6 @@ impl IdentityStorage {
 
     //     rx.await.map_err(anyhow::Error::from)?
     // }
-
-
 }
 
 //Note: Maybe migrate to using a map where the public key points to the cid of the identity document instead

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -319,6 +319,7 @@ impl IdentityStorageInner {
 
     //TODO: Use a map instead with the key linked to the content pointer
     //      and resolve within a stream while matching conditions
+    //TODO: Filter stream instead
     async fn lookup(&self, kind: Lookup) -> Result<Vec<IdentityDocument>, Error> {
         let list_stream = self.list().await;
 

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
 use futures::{
     channel::{
@@ -323,7 +323,7 @@ impl IdentityStorageTask {
     async fn register(&mut self, document: IdentityDocument) -> Result<(), Error> {
         document.verify()?;
 
-        let mut list: HashMap<String, Cid> = match self.list {
+        let mut list: BTreeMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -331,7 +331,7 @@ impl IdentityStorageTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashMap::new(),
+            None => BTreeMap::new(),
         };
 
         let did_str = document.did.to_string();
@@ -370,7 +370,7 @@ impl IdentityStorageTask {
             return Err(Error::IdentityDoesntExist);
         }
 
-        let mut list: HashMap<String, Cid> = match self.packages {
+        let mut list: BTreeMap<String, Cid> = match self.packages {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -378,7 +378,7 @@ impl IdentityStorageTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashMap::new(),
+            None => BTreeMap::new(),
         };
 
         list.insert(did.to_string(), package);
@@ -404,7 +404,7 @@ impl IdentityStorageTask {
             return Err(Error::IdentityDoesntExist);
         }
 
-        let list: HashMap<String, Cid> = match self.packages {
+        let list: BTreeMap<String, Cid> = match self.packages {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -425,7 +425,7 @@ impl IdentityStorageTask {
     async fn update(&mut self, document: IdentityDocument) -> Result<(), Error> {
         document.verify()?;
 
-        let mut list: HashMap<String, Cid> = match self.list {
+        let mut list: BTreeMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -433,7 +433,7 @@ impl IdentityStorageTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashMap::new(),
+            None => BTreeMap::new(),
         };
 
         let did_str = document.did.to_string();
@@ -483,7 +483,7 @@ impl IdentityStorageTask {
     }
 
     async fn list(&self) -> BoxStream<'static, IdentityDocument> {
-        let list: HashMap<String, Cid> = match self.list {
+        let list: BTreeMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -491,7 +491,7 @@ impl IdentityStorageTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashMap::new(),
+            None => BTreeMap::new(),
         };
 
         let ipfs = self.ipfs.clone();
@@ -613,7 +613,7 @@ impl IdentityStorageTask {
 
     async fn fetch_requests(&mut self, did: DID) -> Result<(Vec<RequestPayload>, usize), Error> {
         let key_str = did.to_string();
-        let mut list: HashMap<String, Cid> = match self.mailbox {
+        let mut list: BTreeMap<String, Cid> = match self.mailbox {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -676,7 +676,7 @@ impl IdentityStorageTask {
 
         request.verify().map_err(|_| Error::InvalidSignature)?;
         let key_str = to.to_string();
-        let mut list: HashMap<String, Cid> = match self.mailbox {
+        let mut list: BTreeMap<String, Cid> = match self.mailbox {
             Some(cid) => self
                 .ipfs
                 .get_dag(cid)
@@ -684,7 +684,7 @@ impl IdentityStorageTask {
                 .deserialized()
                 .await
                 .unwrap_or_default(),
-            None => HashMap::new(),
+            None => BTreeMap::new(),
         };
 
         let mut mailbox = match list.get(&key_str) {

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -97,17 +97,7 @@ impl IdentityStorage {
     //     rx.await.map_err(anyhow::Error::from)?
     // }
 
-    // pub async fn list(&self) -> Result<Vec<IdentityDocument>, Error> {
-    //     let (tx, rx) = futures::channel::oneshot::channel();
 
-    //     let _ = self
-    //         .tx
-    //         .clone()
-    //         .send(IdentityStorageCommand::List { response: tx })
-    //         .await;
-
-    //     rx.await.map_err(anyhow::Error::from)?
-    // }
 }
 
 //Note: Maybe migrate to using a map where the public key points to the cid of the identity document instead

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -147,13 +147,7 @@ impl IdentityStorageInner {
             return Err(Error::IdentityExist);
         }
 
-        let cid = self
-            .ipfs
-            .dag()
-            .put()
-            .serialize(document.clone())
-            .pin(false)
-            .await?;
+        let cid = self.ipfs.dag().put().serialize(document).pin(false).await?;
 
         list.insert(did_str, cid);
 

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -576,19 +576,4 @@ impl IdentityStorageInner {
 
     //     Ok(())
     // }
-
-    // async fn list(&self) -> Result<Vec<IdentityDocument>, Error> {
-    //     let list: HashSet<IdentityDocument> = match self.list {
-    //         Some(cid) => self
-    //             .ipfs
-    //             .get_dag(IpfsPath::from(cid))
-    //             .local()
-    //             .deserialized()
-    //             .await
-    //             .unwrap_or_default(),
-    //         None => HashSet::new(),
-    //     };
-
-    //     Ok(Vec::from_iter(list))
-    // }
 }

--- a/tools/shuttle/src/store/identity.rs
+++ b/tools/shuttle/src/store/identity.rs
@@ -263,7 +263,7 @@ impl IdentityStorageInner {
 
         if let Some(old_cid) = old_cid {
             if old_cid != cid && self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
-                tracing::debug!(cid = %old_cid, "unpinning identity mailbox block");
+                tracing::debug!(cid = %old_cid, "unpinning identity block");
                 _ = self.ipfs.remove_pin(&old_cid).await;
             }
         }
@@ -274,7 +274,7 @@ impl IdentityStorageInner {
 
         if let Some(old_cid) = old_cid {
             if old_cid != cid && self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
-                tracing::debug!(cid = %old_cid, "unpinning identity mailbox block");
+                tracing::debug!(cid = %old_cid, "unpinning identity block");
                 _ = self.ipfs.remove_pin(&old_cid).await;
             }
         }

--- a/tools/shuttle/src/subscription_stream.rs
+++ b/tools/shuttle/src/subscription_stream.rs
@@ -29,7 +29,7 @@ impl Subscriptions {
         let identity = identity.clone();
         tokio::spawn(async move {
             {
-                let mut list = identity.list().await.expect("infallible");
+                let mut list = identity.list().await;
 
                 while let Some(id) = list.next().await {
                     _ = task.subscribe(id.did.inbox()).await;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Pins root document of identity instead of storing a payload

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Previously we would store a encrypted payload blob of the root document, however this may pose as a small problem when expanding into storing messages on the same document since the messages would need to be resolved. Same with the constellation index information. This PR simplifies it by pinning the root document directly, with specific fields containing encrypted blobs directly (eg friends list, request, blocks list), while other fields may only pin down to a specific depth in the graph. 
- Constellation index may only go down to a specific depth per document to prevent pinning the files directly since a separate protocol will handle files verification and pinning that will point back to the associated peer of said file (not apart of this PR but will be done separately).
- Blocked on #467 