### PR TITLE
refactor: Change file reference type to String

### DIFF
--- a/extensions/warp-ipfs/src/store/document/files.rs
+++ b/extensions/warp-ipfs/src/store/document/files.rs
@@ -1,3 +1,4 @@
+use std::str::FromStr;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -188,7 +189,7 @@ pub struct FileDocument {
     pub creation: DateTime<Utc>,
     pub modified: DateTime<Utc>,
     pub file_type: FileType,
-    pub reference: Option<Cid>,
+    pub reference: Option<String>,
     pub hash: Hash,
 }
 
@@ -217,7 +218,7 @@ impl FileDocument {
                 .contains(&cid)
                 .await
                 .unwrap_or_default()
-                .then_some(cid)
+                .then(|| cid.to_string())
         }
 
         if let Some(cid) = file
@@ -268,7 +269,11 @@ impl FileDocument {
             }
         }
 
-        if let Some(cid) = self.reference {
+        if let Some(cid) = self
+            .reference
+            .as_ref()
+            .and_then(|cid| Cid::from_str(cid).ok())
+        {
             let path = IpfsPath::from(cid);
             file.set_reference(&path.to_string());
         }

--- a/extensions/warp-ipfs/src/store/document/files.rs
+++ b/extensions/warp-ipfs/src/store/document/files.rs
@@ -274,6 +274,7 @@ impl FileDocument {
             .as_ref()
             .and_then(|cid| Cid::from_str(cid).ok())
         {
+            // Since the cid is valid, we will convert it to a ipfs path to store as a reference in `File::reference`
             let path = IpfsPath::from(cid);
             file.set_reference(&path.to_string());
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Change FileDocument reference type from Cid to String

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This changes will help prevent pinning underlining data when walking its graph (related to #469) 