### PR TITLE
chore: Dont remove blocks manually

### DIFF
--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -741,16 +741,6 @@ impl MessageDocument {
         Ok(document)
     }
 
-    // pub async fn remove(&self, ipfs: &Ipfs) -> Result<(), Error> {
-    //     let cid = self.message;
-    //     if ipfs.is_pinned(&cid).await? {
-    //         ipfs.remove_pin(&cid, false).await?;
-    //     }
-    //     ipfs.remove_block(cid).await?;
-
-    //     Ok(())
-    // }
-
     pub async fn update(
         &mut self,
         ipfs: &Ipfs,

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -316,12 +316,8 @@ impl IdentityCacheTask {
 
                 let remove_pin_and_block = async {
                     if let Some(old_cid) = old_cid {
-                        if old_cid != cid {
-                            if self.ipfs.is_pinned(&old_cid).await? {
-                                self.ipfs.remove_pin(&old_cid).recursive().await?;
-                            }
-                            // Do we want to remove the old block?
-                            self.ipfs.remove_block(old_cid, false).await?;
+                        if old_cid != cid && self.ipfs.is_pinned(&old_cid).await? {
+                            self.ipfs.remove_pin(&old_cid).recursive().await?;
                         }
                     }
                     Ok::<_, Error>(())
@@ -352,12 +348,8 @@ impl IdentityCacheTask {
                 }
 
                 if let Some(old_cid) = old_cid {
-                    if old_cid != cid {
-                        if self.ipfs.is_pinned(&old_cid).await? {
-                            self.ipfs.remove_pin(&old_cid).recursive().await?;
-                        }
-                        // Do we want to remove the old block?
-                        self.ipfs.remove_block(old_cid, false).await?;
+                    if old_cid != cid && self.ipfs.is_pinned(&old_cid).await? {
+                        self.ipfs.remove_pin(&old_cid).recursive().await?;
                     }
                 }
 
@@ -423,12 +415,8 @@ impl IdentityCacheTask {
         }
 
         if let Some(old_cid) = old_cid {
-            if cid != old_cid {
-                if self.ipfs.is_pinned(&old_cid).await? {
-                    self.ipfs.remove_pin(&old_cid).recursive().await?;
-                }
-                // Do we want to remove the old block?
-                self.ipfs.remove_block(old_cid, false).await?;
+            if cid != old_cid && self.ipfs.is_pinned(&old_cid).await? {
+                self.ipfs.remove_pin(&old_cid).recursive().await?;
             }
         }
 

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -742,7 +742,6 @@ impl RootDocumentTask {
                         tracing::warn!(cid =? old_cid, "Failed to unpin root document: {e}");
                     }
                 }
-                _ = self.ipfs.remove_block(old_cid, false).await;
             }
         }
 
@@ -811,13 +810,6 @@ impl RootDocumentTask {
         };
 
         self.set_root_document(document).await?;
-
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
-
         Ok(())
     }
 
@@ -852,13 +844,6 @@ impl RootDocumentTask {
         };
 
         self.set_root_document(document).await?;
-
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
-
         Ok(())
     }
 
@@ -913,13 +898,6 @@ impl RootDocumentTask {
         };
 
         self.set_root_document(document).await?;
-
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
-
         Ok(())
     }
 
@@ -950,12 +928,6 @@ impl RootDocumentTask {
         let old_document = document.file_index.replace(cid);
 
         self.set_root_document(document).await?;
-
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
 
         Ok(())
     }
@@ -991,12 +963,6 @@ impl RootDocumentTask {
         };
 
         self.set_root_document(document).await?;
-
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
 
         Ok(())
     }
@@ -1065,11 +1031,6 @@ impl RootDocumentTask {
 
         self.set_root_document(document).await?;
 
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
         Ok(())
     }
 
@@ -1105,11 +1066,6 @@ impl RootDocumentTask {
 
         self.set_root_document(document).await?;
 
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
         Ok(())
     }
 
@@ -1165,11 +1121,6 @@ impl RootDocumentTask {
 
         self.set_root_document(document).await?;
 
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
         Ok(())
     }
 
@@ -1204,12 +1155,6 @@ impl RootDocumentTask {
         };
 
         self.set_root_document(document).await?;
-
-        if let Some(cid) = old_document {
-            if !self.ipfs.is_pinned(&cid).await? {
-                self.ipfs.remove_block(cid, false).await?;
-            }
-        }
         Ok(())
     }
 

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -736,11 +736,9 @@ impl RootDocumentTask {
         }
 
         if let Some(old_cid) = old_cid {
-            if old_cid != root_cid {
-                if self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
-                    if let Err(e) = self.ipfs.remove_pin(&old_cid).recursive().await {
-                        tracing::warn!(cid =? old_cid, "Failed to unpin root document: {e}");
-                    }
+            if old_cid != root_cid && self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
+                if let Err(e) = self.ipfs.remove_pin(&old_cid).recursive().await {
+                    tracing::warn!(cid =? old_cid, "Failed to unpin root document: {e}");
                 }
             }
         }
@@ -781,7 +779,6 @@ impl RootDocumentTask {
 
     async fn add_request(&mut self, request: Request) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.request;
         let mut list: Vec<Request> = match document.request {
             Some(cid) => self
                 .ipfs
@@ -815,7 +812,7 @@ impl RootDocumentTask {
 
     async fn remove_request(&mut self, request: Request) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.request;
+
         let mut list: Vec<Request> = match document.request {
             Some(cid) => self
                 .ipfs
@@ -869,7 +866,7 @@ impl RootDocumentTask {
 
     async fn add_friend(&mut self, did: DID) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.friends;
+
         let mut list: Vec<DID> = match document.friends {
             Some(cid) => self
                 .ipfs
@@ -925,7 +922,7 @@ impl RootDocumentTask {
 
         let cid = self.ipfs.dag().put().serialize(index_document).await?;
 
-        let old_document = document.file_index.replace(cid);
+        document.file_index.replace(cid);
 
         self.set_root_document(document).await?;
 
@@ -934,7 +931,7 @@ impl RootDocumentTask {
 
     async fn remove_friend(&mut self, did: DID) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.friends;
+
         let mut list: Vec<DID> = match document.friends {
             Some(cid) => self
                 .ipfs
@@ -1001,7 +998,7 @@ impl RootDocumentTask {
 
     async fn block_key(&mut self, did: DID) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.blocks;
+
         let mut list: Vec<DID> = match document.blocks {
             Some(cid) => self
                 .ipfs
@@ -1036,7 +1033,7 @@ impl RootDocumentTask {
 
     async fn unblock_key(&mut self, did: DID) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.blocks;
+
         let mut list: Vec<DID> = match document.blocks {
             Some(cid) => self
                 .ipfs
@@ -1091,7 +1088,7 @@ impl RootDocumentTask {
 
     async fn add_blockby_key(&mut self, did: DID) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.block_by;
+
         let mut list: Vec<DID> = match document.block_by {
             Some(cid) => self
                 .ipfs
@@ -1126,7 +1123,7 @@ impl RootDocumentTask {
 
     async fn remove_blockby_key(&mut self, did: DID) -> Result<(), Error> {
         let mut document = self.get_root_document().await?;
-        let old_document = document.block_by;
+
         let mut list: Vec<DID> = match document.block_by {
             Some(cid) => self
                 .ipfs

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -526,7 +526,6 @@ impl FileTask {
                 self.ipfs.remove_pin(&cid).recursive().await?;
             }
 
-            self.ipfs.remove_block(cid, true).await?;
             _ = tokio::fs::remove_file(path.join(".index_id")).await;
         }
 
@@ -1086,9 +1085,6 @@ impl FileTask {
         }
 
         directory.remove_item(&item.name())?;
-
-        let blocks = ipfs.remove_block(cid, true).await.unwrap_or_default();
-        tracing::info!(blocks = blocks.len(), "blocks removed");
 
         _ = self.export().await;
 

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -2277,8 +2277,6 @@ impl IdentityStore {
         if ipfs.is_pinned(&cid).await? {
             ipfs.remove_pin(&cid).recursive().await?;
         }
-        let blocks = ipfs.remove_block(cid, true).await?;
-        tracing::info!("{} blocks removed.", blocks.len());
         Ok(())
     }
 

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1428,7 +1428,7 @@ impl ConversationTask {
             return Err(Error::InvalidConversation);
         }
 
-        let list = conversation.messages.take();
+        conversation.messages.take();
         conversation.deleted = true;
 
         self.set_document(conversation.clone()).await?;

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -1441,10 +1441,6 @@ impl ConversationTask {
             }
         }
 
-        if let Some(cid) = list {
-            let _ = self.ipfs.remove_block(cid, true).await;
-        }
-
         Ok(conversation)
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Remove logic that removes blocks manually
 
**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Removing blocks manually was more of a way to make sure that we cleanup as many blocks as so the local node isnt taking up disk resources, however doing it manually for every update can be costly especially recursively removing a dag of its unpinned blocks, but at the same time, if there are updates to the internal documents, we would want to make sure those blocks are still available when exchanging that info with another peer to pin (eg messages, images, files, etc). So instead of manually removing the blocks, we will only stick with unpinning then and let a later task cleanup those blocks when needed. Blocks removed can be cleaned up later by enabling a internal gc  (or calling gc manually) that will remove unpinned blocks, however GC should probably run during startup initialization to cleanup orphan blocks.
- This change will also ensure that shuttle can pin blocks even when the local node makes an update or change, unless they disconnect, in which case it may not continue pinning until they come back online before it times out and reconnect.  