### PR TITLE
feat: Return location for message attachments

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -623,7 +623,7 @@ async fn main() -> anyhow::Result<()> {
                                             return Err::<_, anyhow::Error>(anyhow::Error::from(e));
                                         },
                                     };
-                                    while let Some(event) = stream.next().await {
+                                    while let Some((_location, event)) = stream.next().await {
                                         match event {
                                             AttachmentKind::AttachedProgress(Progression::CurrentProgress { .. }) => {},
                                             AttachmentKind::AttachedProgress(Progression::ProgressComplete { name, .. }) => {

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -623,13 +623,13 @@ async fn main() -> anyhow::Result<()> {
                                             return Err::<_, anyhow::Error>(anyhow::Error::from(e));
                                         },
                                     };
-                                    while let Some((_location, event)) = stream.next().await {
+                                    while let Some(event) = stream.next().await {
                                         match event {
-                                            AttachmentKind::AttachedProgress(Progression::CurrentProgress { .. }) => {},
-                                            AttachmentKind::AttachedProgress(Progression::ProgressComplete { name, .. }) => {
+                                            AttachmentKind::AttachedProgress(_location, Progression::CurrentProgress { .. }) => {},
+                                            AttachmentKind::AttachedProgress(_location, Progression::ProgressComplete { name, .. }) => {
                                                 writeln!(stdout, "> {name} is uploaded")?;
                                             },
-                                            AttachmentKind::AttachedProgress(Progression::ProgressFailed { name, error, .. }) => {
+                                            AttachmentKind::AttachedProgress(_location, Progression::ProgressFailed { name, error, .. }) => {
                                                 writeln!(stdout, "> {name} failed to upload: {}", error)?;
                                             },
                                             AttachmentKind::Pending(Ok(_)) => {

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2408,7 +2408,7 @@ impl ConversationTask {
             }
 
             for await (location, (progress, file)) in streams {
-                yield (Some(location), AttachmentKind::AttachedProgress(progress));
+                yield AttachmentKind::AttachedProgress(location, progress);
                 if let Some(file) = file {
                     attachments.push(file);
                 }
@@ -2441,7 +2441,7 @@ impl ConversationTask {
                 }
             };
 
-            yield (None, AttachmentKind::Pending(final_results.await))
+            yield AttachmentKind::Pending(final_results.await)
         };
 
         Ok((message_id, stream.boxed()))

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2298,7 +2298,7 @@ impl ConversationTask {
                     Location::Constellation { path } => {
                         match constellation
                             .root_directory()
-                            .get_item_by_path(&path)
+                            .get_item_by_path(path)
                             .and_then(|item| item.get_file())
                         {
                             Ok(f) => {

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2294,7 +2294,7 @@ impl ConversationTask {
             let mut streams: SelectAll<_> = SelectAll::new();
 
             for file in files {
-                match file.clone() {
+                match &file {
                     Location::Constellation { path } => {
                         match constellation
                             .root_directory()
@@ -2309,7 +2309,7 @@ impl ConversationTask {
                             },
                             Err(e) => {
                                 let constellation_path = PathBuf::from(&path);
-                                let name = constellation_path.file_name().and_then(OsStr::to_str).map(str::to_string).unwrap_or(path);
+                                let name = constellation_path.file_name().and_then(OsStr::to_str).map(str::to_string).unwrap_or(path.to_string());
                                 let stream = async_stream::stream! {
                                     yield (file, (Progression::ProgressFailed { name, last_size: None, error: e }, None));
                                 };
@@ -2317,7 +2317,7 @@ impl ConversationTask {
                             },
                         }
                     }
-                    Location::Disk {path} => {
+                    Location::Disk { path } => {
                         let mut filename = match path.file_name() {
                             Some(file) => file.to_string_lossy().to_string(),
                             None => continue,

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -283,7 +283,7 @@ mod test {
             )
             .await?;
 
-        while let Some(event) = stream.next().await {
+        while let Some((_location, event)) = stream.next().await {
             match event {
                 AttachmentKind::AttachedProgress(Progression::CurrentProgress { .. }) => {}
                 AttachmentKind::AttachedProgress(Progression::ProgressComplete { name, total }) => {

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -285,8 +285,14 @@ mod test {
 
         while let Some(event) = stream.next().await {
             match event {
-                AttachmentKind::AttachedProgress(_location, Progression::CurrentProgress { .. }) => {}
-                AttachmentKind::AttachedProgress(_location, Progression::ProgressComplete { name, total }) => {
+                AttachmentKind::AttachedProgress(
+                    _location,
+                    Progression::CurrentProgress { .. },
+                ) => {}
+                AttachmentKind::AttachedProgress(
+                    _location,
+                    Progression::ProgressComplete { name, total },
+                ) => {
                     assert_eq!(name, "image.png");
                     assert_eq!(total, Some(PROFILE_IMAGE.len()));
                 }

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -283,14 +283,14 @@ mod test {
             )
             .await?;
 
-        while let Some((_location, event)) = stream.next().await {
+        while let Some(event) = stream.next().await {
             match event {
-                AttachmentKind::AttachedProgress(Progression::CurrentProgress { .. }) => {}
-                AttachmentKind::AttachedProgress(Progression::ProgressComplete { name, total }) => {
+                AttachmentKind::AttachedProgress(_location, Progression::CurrentProgress { .. }) => {}
+                AttachmentKind::AttachedProgress(_location, Progression::ProgressComplete { name, total }) => {
                     assert_eq!(name, "image.png");
                     assert_eq!(total, Some(PROFILE_IMAGE.len()));
                 }
-                AttachmentKind::AttachedProgress(Progression::ProgressFailed { .. }) => {
+                AttachmentKind::AttachedProgress(_location, Progression::ProgressFailed { .. }) => {
                     unreachable!("should not fail")
                 }
                 AttachmentKind::Pending(result) => {

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -107,11 +107,11 @@ pub enum MessageEvent {
 }
 
 pub enum AttachmentKind {
-    AttachedProgress(Progression),
+    AttachedProgress(Location, Progression),
     Pending(Result<(), Error>),
 }
 
-pub type AttachmentEventStream = BoxStream<'static, (Option<Location>, AttachmentKind)>;
+pub type AttachmentEventStream = BoxStream<'static, AttachmentKind>;
 
 pub type MessageEventStream = BoxStream<'static, MessageEventKind>;
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -111,7 +111,7 @@ pub enum AttachmentKind {
     Pending(Result<(), Error>),
 }
 
-pub type AttachmentEventStream = BoxStream<'static, AttachmentKind>;
+pub type AttachmentEventStream = BoxStream<'static, (Option<Location>, AttachmentKind)>;
 
 pub type MessageEventStream = BoxStream<'static, MessageEventKind>;
 


### PR DESCRIPTION
**What this PR does** 📖

Makes it so the original location is also returned when sending a message with attachments to it. 
The returned stream is now a pair of (optional) Location + Progress
