### PR TITLE
Bump rust-ipfs to 0.11.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ either = "1"
 void = "1"
 
 #ipfs dependency
-rust-ipfs = "0.11.0"
+rust-ipfs = "0.11.4"
 
 
 # Blink related crates


### PR DESCRIPTION
**What this PR does** 📖

We started using a new API in e95df602f.