### PR TITLE
chore: Remove redundant stream macros

### DIFF
--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -887,7 +887,7 @@ pub enum EmbedState {
     Disable,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Hash, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[repr(C)]
 pub enum Location {
     /// Use [`Constellation`] to send a file from constellation


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Removes redundant `async_stream::stream` usage
- Replaces `SelectAll` with `StreamMap`

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- Resolves #451 

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
