### PR TITLE
chore: Internal cleanup and optimizations

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -220,7 +220,7 @@ impl WarpIpfs {
 
     pub(crate) async fn init_ipfs(&self, keypair: Keypair) -> Result<(), Error> {
         // Since some trait functions are not async (this may change in the future), we cannot hold a lock that is not async-aware
-        // through this function without suffering dead locks in the process through await points with the lock held. 
+        // through this function without suffering dead locks in the process through await points with the lock held.
         // As a result, we holds a tokio mutex lock here to allow a single call to this function on initializing
         // preventing any other calls until this lock drops, in which case may return an error if the components
         // been successfully initialized

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -144,6 +144,7 @@ impl WarpIpfsBuilder {
 
 impl WarpIpfs {
     pub async fn new(config: Config, tesseract: Tesseract) -> anyhow::Result<WarpIpfs> {
+    pub async fn new(config: Config, tesseract: Tesseract) -> Result<WarpIpfs, Error> {
         let multipass_tx = EventSubscription::new();
         let raygun_tx = EventSubscription::new();
         let constellation_tx = EventSubscription::new();

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -143,7 +143,6 @@ impl WarpIpfsBuilder {
 }
 
 impl WarpIpfs {
-    pub async fn new(config: Config, tesseract: Tesseract) -> anyhow::Result<WarpIpfs> {
     pub async fn new(config: Config, tesseract: Tesseract) -> Result<WarpIpfs, Error> {
         let multipass_tx = EventSubscription::new();
         let raygun_tx = EventSubscription::new();

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -565,11 +565,10 @@ impl WarpIpfs {
         info!("Initializing identity profile");
         let identity_store = IdentityStore::new(
             ipfs.clone(),
-            config.path.clone(),
+            &config,
             tesseract.clone(),
             self.multipass_tx.clone(),
             phonebook,
-            &config,
             discovery.clone(),
             id_sh_tx,
             span.clone(),

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -66,7 +66,7 @@ use warp::multipass::{
 use crate::config::{Bootstrap, DiscoveryType};
 use crate::store::discovery::Discovery;
 use crate::store::phonebook::PhoneBook;
-use crate::store::{ecdh_decrypt, get_keypair_did, PeerIdExt};
+use crate::store::{ecdh_decrypt, PeerIdExt};
 
 #[derive(Clone)]
 pub struct WarpIpfs {
@@ -562,11 +562,6 @@ impl WarpIpfs {
 
         let phonebook = PhoneBook::new(discovery.clone(), pb_tx);
 
-        let keypair = {
-            let keypair = ipfs.keypair();
-            Arc::new(get_keypair_did(keypair).expect("valid keypair"))
-        };
-
         info!("Initializing identity profile");
         let identity_store = IdentityStore::new(
             ipfs.clone(),
@@ -598,7 +593,6 @@ impl WarpIpfs {
             &ipfs,
             config.path.map(|path| path.join("messages")),
             discovery,
-            keypair,
             filestore.clone(),
             self.raygun_tx.clone(),
             identity_store.clone(),

--- a/extensions/warp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-ipfs/src/store/discovery.rs
@@ -44,7 +44,6 @@ impl Discovery {
 
     /// Start discovery task
     /// Note: This starting will only work across a provided namespace
-    #[allow(clippy::collapsible_if)]
     pub async fn start(&self) -> Result<(), Error> {
         match &self.config {
             DiscoveryConfig::Namespace {
@@ -77,20 +76,18 @@ impl Discovery {
                                         .await
                                         .unwrap_or_default()
                                         && cached.insert(peer_id)
+                                        && !discovery.contains(peer_id).await
                                     {
-                                        if !discovery.contains(peer_id).await {
-                                            let entry = DiscoveryEntry::new(
-                                                &discovery.ipfs,
-                                                peer_id,
-                                                discovery.config.clone(),
-                                                discovery.events.clone(),
-                                                discovery.relays.clone(),
-                                            )
-                                            .await;
-                                            if discovery.entries.write().await.insert(entry.clone())
-                                            {
-                                                entry.start().await;
-                                            }
+                                        let entry = DiscoveryEntry::new(
+                                            &discovery.ipfs,
+                                            peer_id,
+                                            discovery.config.clone(),
+                                            discovery.events.clone(),
+                                            discovery.relays.clone(),
+                                        )
+                                        .await;
+                                        if discovery.entries.write().await.insert(entry.clone()) {
+                                            entry.start().await;
                                         }
                                     }
                                 }
@@ -179,25 +176,24 @@ impl Discovery {
                                                 .await
                                                 .unwrap_or_default()
                                                 && discovery.ipfs.connect(peer_id).await.is_ok()
+                                                && !discovery.contains(peer_id).await
                                             {
-                                                if !discovery.contains(peer_id).await {
-                                                    let entry = DiscoveryEntry::new(
-                                                        &discovery.ipfs,
-                                                        peer_id,
-                                                        discovery.config.clone(),
-                                                        discovery.events.clone(),
-                                                        discovery.relays.clone(),
-                                                    )
-                                                    .await;
+                                                let entry = DiscoveryEntry::new(
+                                                    &discovery.ipfs,
+                                                    peer_id,
+                                                    discovery.config.clone(),
+                                                    discovery.events.clone(),
+                                                    discovery.relays.clone(),
+                                                )
+                                                .await;
 
-                                                    if discovery
-                                                        .entries
-                                                        .write()
-                                                        .await
-                                                        .insert(entry.clone())
-                                                    {
-                                                        entry.start().await;
-                                                    }
+                                                if discovery
+                                                    .entries
+                                                    .write()
+                                                    .await
+                                                    .insert(entry.clone())
+                                                {
+                                                    entry.start().await;
                                                 }
                                             }
                                         }

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -121,7 +121,6 @@ impl RootDocument {
     #[tracing::instrument(skip(self, ipfs))]
     pub async fn verify(&self, ipfs: &Ipfs) -> Result<(), Error> {
         let identity: IdentityDocument = ipfs
-            .dag()
             .get_dag(self.identity)
             .local()
             .deserialized()

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -17,7 +17,7 @@ pub struct IdentityCache {
 }
 
 impl IdentityCache {
-    pub async fn new(ipfs: &Ipfs, path: Option<PathBuf>) -> Self {
+    pub async fn new(ipfs: &Ipfs, path: Option<&PathBuf>) -> Self {
         let list = match path.as_ref() {
             Some(path) => tokio::fs::read(path.join(".cache_id_v0"))
                 .await
@@ -29,7 +29,7 @@ impl IdentityCache {
 
         let inner = IdentityCacheInner {
             ipfs: ipfs.clone(),
-            path,
+            path: path.cloned(),
             list,
         };
 

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -56,9 +56,9 @@ impl IdentityCache {
         inner.remove(did.clone()).await
     }
 
-    pub async fn list(&self) -> Result<BoxStream<'static, IdentityDocument>, Error> {
+    pub async fn list(&self) -> BoxStream<'static, IdentityDocument> {
         let inner = &*self.inner.read().await;
-        Ok(inner.list().await)
+        inner.list().await
     }
 }
 
@@ -373,7 +373,7 @@ mod test {
         let mut rng = rand::thread_rng();
         let cache = pregenerated_cache::<10>().await;
 
-        let list = cache.list().await?.collect::<Vec<_>>().await;
+        let list = cache.list().await.collect::<Vec<_>>().await;
 
         let random_doc = list.choose(&mut rng).expect("exist");
 

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -43,7 +43,7 @@ impl IdentityCache {
         document: &IdentityDocument,
     ) -> Result<Option<IdentityDocument>, Error> {
         let inner = &mut *self.inner.write().await;
-        inner.insert(document.clone()).await
+        inner.insert(document).await
     }
 
     pub async fn get(&self, did: &DID) -> Result<IdentityDocument, Error> {
@@ -53,7 +53,7 @@ impl IdentityCache {
 
     pub async fn remove(&self, did: &DID) -> Result<(), Error> {
         let inner = &mut *self.inner.write().await;
-        inner.remove(did.clone()).await
+        inner.remove(did).await
     }
 
     pub async fn list(&self) -> BoxStream<'static, IdentityDocument> {
@@ -72,7 +72,7 @@ struct IdentityCacheInner {
 impl IdentityCacheInner {
     async fn insert(
         &mut self,
-        document: IdentityDocument,
+        document: &IdentityDocument,
     ) -> Result<Option<IdentityDocument>, Error> {
         document.verify()?;
 
@@ -109,7 +109,7 @@ impl IdentityCacheInner {
 
         match old_document {
             Some(old_document) => {
-                if !old_document.different(&document) {
+                if !old_document.different(document) {
                     return Ok(None);
                 }
 
@@ -199,7 +199,7 @@ impl IdentityCacheInner {
         Ok(id)
     }
 
-    async fn remove(&mut self, did: DID) -> Result<(), Error> {
+    async fn remove(&mut self, did: &DID) -> Result<(), Error> {
         let mut list: HashMap<String, Cid> = match self.list {
             Some(cid) => self
                 .ipfs

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -385,7 +385,7 @@ impl RootDocumentInner {
             None => vec![],
         };
 
-        if !list.insert_item(&request) {
+        if !list.insert_item(request) {
             return Err(Error::FriendRequestExist);
         }
 
@@ -473,7 +473,7 @@ impl RootDocumentInner {
             None => vec![],
         };
 
-        if !list.insert_item(&did) {
+        if !list.insert_item(did) {
             return Err::<_, Error>(Error::FriendExist);
         }
 
@@ -605,7 +605,7 @@ impl RootDocumentInner {
             None => vec![],
         };
 
-        if !list.insert_item(&did) {
+        if !list.insert_item(did) {
             return Err::<_, Error>(Error::PublicKeyIsBlocked);
         }
 
@@ -695,7 +695,7 @@ impl RootDocumentInner {
             None => vec![],
         };
 
-        if !list.insert_item(&did) {
+        if !list.insert_item(did) {
             return Err::<_, Error>(Error::PublicKeyIsntBlocked);
         }
 

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -29,7 +29,7 @@ pub struct RootDocumentMap {
 }
 
 impl RootDocumentMap {
-    pub async fn new(ipfs: &Ipfs, keypair: Arc<DID>, path: Option<PathBuf>) -> Self {
+    pub async fn new(ipfs: &Ipfs, keypair: Arc<DID>, path: Option<&PathBuf>) -> Self {
         let cid = match path.as_ref() {
             Some(path) => tokio::fs::read(path.join(".id"))
                 .await
@@ -42,7 +42,7 @@ impl RootDocumentMap {
         let mut inner = RootDocumentInner {
             ipfs: ipfs.clone(),
             keypair,
-            path,
+            path: path.cloned(),
             cid,
         };
 

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -168,11 +168,9 @@ impl RootDocumentMap {
         inner.get_conversation_keystore_map().await
     }
 
-    pub async fn list_conversation_document(
-        &self,
-    ) -> Result<BoxStream<'static, ConversationDocument>, Error> {
+    pub async fn list_conversation_document(&self) -> BoxStream<'static, ConversationDocument> {
         let inner = &*self.inner.read().await;
-        Ok(inner.list_conversation_stream().await)
+        inner.list_conversation_stream().await
     }
 
     pub async fn get_conversation_document(&self, id: Uuid) -> Result<ConversationDocument, Error> {

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -2,14 +2,12 @@ use std::{collections::BTreeMap, future::IntoFuture, path::PathBuf, sync::Arc};
 
 use chrono::Utc;
 use futures::{
-    channel::{mpsc::Receiver, oneshot},
     stream::{BoxStream, FuturesUnordered},
-    SinkExt, StreamExt,
+    StreamExt,
 };
 use libipld::Cid;
 use rust_ipfs::{Ipfs, IpfsPath};
-use tokio::select;
-use tokio_util::sync::{CancellationToken, DropGuard};
+use tokio::sync::RwLock;
 use uuid::Uuid;
 use warp::{
     constellation::directory::Directory, crypto::DID, error::Error,
@@ -25,122 +23,9 @@ use super::{
     files::DirectoryDocument, identity::IdentityDocument, ResolvedRootDocument, RootDocument,
 };
 
-#[allow(clippy::large_enum_variant)]
-pub enum RootDocumentCommand {
-    Get {
-        response: oneshot::Sender<Result<RootDocument, Error>>,
-    },
-    Set {
-        document: RootDocument,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    Identity {
-        response: oneshot::Sender<Result<IdentityDocument, Error>>,
-    },
-    SetIdentityStatus {
-        status: IdentityStatus,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    AddFriend {
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    RemoveFriend {
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    GetFriendList {
-        response: oneshot::Sender<Result<Vec<DID>, Error>>,
-    },
-    AddRequest {
-        request: Request,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    RemoveRequest {
-        request: Request,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    GetRequestList {
-        response: oneshot::Sender<Result<Vec<Request>, Error>>,
-    },
-    GetRootIndex {
-        response: oneshot::Sender<Result<Directory, Error>>,
-    },
-    SetRootIndex {
-        root: Directory,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    AddBlock {
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    RemoveBlock {
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    GetBlockList {
-        response: oneshot::Sender<Result<Vec<DID>, Error>>,
-    },
-    IsBlocked {
-        did: DID,
-        response: oneshot::Sender<Result<bool, Error>>,
-    },
-    AddBlockBy {
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    RemoveBlockBy {
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    GetBlockByList {
-        response: oneshot::Sender<Result<Vec<DID>, Error>>,
-    },
-    IsBlockedBy {
-        did: DID,
-        response: oneshot::Sender<Result<bool, Error>>,
-    },
-    GetConversationDocument {
-        id: Uuid,
-        response: oneshot::Sender<Result<ConversationDocument, Error>>,
-    },
-    SetConversationDocument {
-        document: ConversationDocument,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    ListConversationDocument {
-        response: oneshot::Sender<Result<BoxStream<'static, ConversationDocument>, Error>>,
-    },
-    SetKeystore {
-        document: BTreeMap<String, Cid>,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    GetKeystoreMap {
-        response: oneshot::Sender<Result<BTreeMap<String, Cid>, Error>>,
-    },
-    GetKeystore {
-        id: Uuid,
-        response: oneshot::Sender<Result<Keystore, Error>>,
-    },
-    Export {
-        response: oneshot::Sender<Result<ResolvedRootDocument, Error>>,
-    },
-    ExportEncrypted {
-        response: oneshot::Sender<Result<Vec<u8>, Error>>,
-    },
-    ExportRootCid {
-        response: oneshot::Sender<Result<Cid, Error>>,
-    },
-    SetRootCid {
-        cid: Cid,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-}
-
 #[derive(Debug, Clone)]
 pub struct RootDocumentMap {
-    tx: futures::channel::mpsc::Sender<RootDocumentCommand>,
-    _task_cancellation: Arc<DropGuard>,
+    inner: Arc<RwLock<RootDocumentInner>>,
 }
 
 impl RootDocumentMap {
@@ -154,490 +39,188 @@ impl RootDocumentMap {
             None => None,
         };
 
-        let (tx, rx) = futures::channel::mpsc::channel(0);
-
-        let mut task = RootDocumentTask {
+        let mut inner = RootDocumentInner {
             ipfs: ipfs.clone(),
             keypair,
             path,
             cid,
-            rx,
         };
 
-        let token = CancellationToken::new();
-        let drop_guard = token.clone().drop_guard();
-        tokio::spawn(async move {
-            select! {
-                _ = token.cancelled() => {}
-                _ = task.run() => {}
-            }
-        });
+        inner.migrate().await;
 
         Self {
-            tx,
-            _task_cancellation: Arc::new(drop_guard),
+            inner: Arc::new(RwLock::new(inner)),
         }
     }
 
     pub async fn get(&self) -> Result<RootDocument, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::Get { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_root_document().await
     }
 
     pub async fn set(&mut self, document: RootDocument) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::Set {
-                document,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_root_document(document).await
     }
 
     pub async fn identity(&self) -> Result<IdentityDocument, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::Identity { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.identity().await
     }
 
     pub async fn set_status_indicator(&self, status: IdentityStatus) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::SetIdentityStatus {
-                status,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_identity_status(status).await
     }
 
     pub async fn add_friend(&self, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::AddFriend {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.add_friend(did.clone()).await
     }
 
     pub async fn remove_friend(&self, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::RemoveFriend {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.remove_friend(did.clone()).await
     }
 
     pub async fn add_block(&self, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::AddBlock {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.block_key(did.clone()).await
     }
 
     pub async fn remove_block(&self, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::RemoveBlock {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.unblock_key(did.clone()).await
     }
 
     pub async fn is_blocked(&self, did: &DID) -> Result<bool, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::IsBlocked {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.is_blocked(did).await
     }
 
     pub async fn add_block_by(&self, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::AddBlockBy {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.add_blockby_key(did.clone()).await
     }
 
     pub async fn remove_block_by(&self, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::RemoveBlockBy {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.remove_blockby_key(did.clone()).await
     }
 
     pub async fn add_request(&self, request: &Request) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::AddRequest {
-                request: request.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.add_request(request.clone()).await
     }
 
     pub async fn remove_request(&self, request: &Request) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::RemoveRequest {
-                request: request.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.remove_request(request.clone()).await
     }
 
     pub async fn get_friends(&self) -> Result<Vec<DID>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetFriendList { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.friend_list().await
     }
 
     pub async fn get_requests(&self) -> Result<Vec<Request>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetRequestList { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.request_list().await
     }
 
     pub async fn get_blocks(&self) -> Result<Vec<DID>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetBlockList { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.block_list().await
     }
 
     pub async fn get_block_by(&self) -> Result<Vec<DID>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetBlockByList { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.blockby_list().await
     }
 
     pub async fn is_blocked_by(&self, did: &DID) -> Result<bool, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::IsBlockedBy {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.is_blocked_by(did).await
     }
 
     pub async fn export_root_cid(&self) -> Result<Cid, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::ExportRootCid { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.cid.ok_or(Error::IdentityNotCreated)
     }
 
     pub async fn import_root_cid(&self, cid: Cid) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::SetRootCid { cid, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_root_cid(cid).await
     }
 
     pub async fn export(&self) -> Result<ResolvedRootDocument, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::Export { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.export().await
     }
 
     pub async fn export_bytes(&self) -> Result<Vec<u8>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::ExportEncrypted { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.export_bytes().await
     }
 
     pub async fn get_conversation_keystore_map(&self) -> Result<BTreeMap<String, Cid>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetKeystoreMap { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_conversation_keystore_map().await
     }
 
     pub async fn list_conversation_document(
         &self,
     ) -> Result<BoxStream<'static, ConversationDocument>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::ListConversationDocument { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        Ok(inner.list_conversation_stream().await)
     }
 
     pub async fn get_conversation_document(&self, id: Uuid) -> Result<ConversationDocument, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetConversationDocument { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_conversation_document(id).await
     }
 
     pub async fn set_conversation_document(
         &self,
         document: ConversationDocument,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::SetConversationDocument {
-                document,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_conversation_document(document).await
     }
 
     pub async fn get_conversation_keystore(&self, id: Uuid) -> Result<Keystore, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetKeystore { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_conversation_keystore(id).await
     }
 
     pub async fn set_conversation_keystore_map(
         &self,
         document: BTreeMap<String, Cid>,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::SetKeystore {
-                document,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_conversation_keystore(document).await
     }
 
     pub async fn get_directory_index(&self) -> Result<Directory, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::GetRootIndex { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_root_index().await
     }
 
     pub async fn set_directory_index(&self, root: Directory) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .tx
-            .clone()
-            .send(RootDocumentCommand::SetRootIndex { root, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_root_index(root).await
     }
 }
 
-struct RootDocumentTask {
+#[derive(Debug)]
+struct RootDocumentInner {
     keypair: Arc<DID>,
     path: Option<PathBuf>,
     ipfs: Ipfs,
     cid: Option<Cid>,
-    rx: Receiver<RootDocumentCommand>,
 }
 
-impl RootDocumentTask {
-    pub async fn run(&mut self) {
-        self.migrate().await;
-
-        while let Some(command) = self.rx.next().await {
-            match command {
-                RootDocumentCommand::Get { response } => {
-                    let _ = response.send(self.get_root_document().await);
-                }
-                RootDocumentCommand::Set { document, response } => {
-                    let _ = response.send(self.set_root_document(document).await);
-                }
-                RootDocumentCommand::Identity { response } => {
-                    let _ = response.send(self.identity().await);
-                }
-                RootDocumentCommand::AddFriend { did, response } => {
-                    let _ = response.send(self.add_friend(did).await);
-                }
-                RootDocumentCommand::RemoveFriend { did, response } => {
-                    let _ = response.send(self.remove_friend(did).await);
-                }
-                RootDocumentCommand::GetFriendList { response } => {
-                    let _ = response.send(self.friend_list().await);
-                }
-                RootDocumentCommand::AddRequest { request, response } => {
-                    let _ = response.send(self.add_request(request).await);
-                }
-                RootDocumentCommand::RemoveRequest { request, response } => {
-                    let _ = response.send(self.remove_request(request).await);
-                }
-                RootDocumentCommand::GetRequestList { response } => {
-                    let _ = response.send(self.request_list().await);
-                }
-                RootDocumentCommand::AddBlock { did, response } => {
-                    let _ = response.send(self.block_key(did).await);
-                }
-                RootDocumentCommand::RemoveBlock { did, response } => {
-                    let _ = response.send(self.unblock_key(did).await);
-                }
-                RootDocumentCommand::GetBlockList { response } => {
-                    let _ = response.send(self.block_list().await);
-                }
-                RootDocumentCommand::AddBlockBy { did, response } => {
-                    let _ = response.send(self.add_blockby_key(did).await);
-                }
-                RootDocumentCommand::RemoveBlockBy { did, response } => {
-                    let _ = response.send(self.remove_blockby_key(did).await);
-                }
-                RootDocumentCommand::GetBlockByList { response } => {
-                    let _ = response.send(self.blockby_list().await);
-                }
-                RootDocumentCommand::SetKeystore { document, response } => {
-                    let _ = response.send(self.set_conversation_keystore(document).await);
-                }
-                RootDocumentCommand::GetKeystore { id, response } => {
-                    let _ = response.send(self.get_conversation_keystore(id).await);
-                }
-                RootDocumentCommand::GetKeystoreMap { response } => {
-                    let _ = response.send(self.get_conversation_keystore_map().await);
-                }
-                RootDocumentCommand::Export { response } => {
-                    let _ = response.send(self.export().await);
-                }
-                RootDocumentCommand::ExportRootCid { response } => {
-                    let _ = response.send(self.cid.ok_or(Error::IdentityDoesntExist));
-                }
-                RootDocumentCommand::ExportEncrypted { response } => {
-                    let _ = response.send(self.export_bytes().await);
-                }
-                RootDocumentCommand::SetIdentityStatus { status, response } => {
-                    let _ = response.send(self.set_identity_status(status).await);
-                }
-                RootDocumentCommand::IsBlocked { did, response } => {
-                    _ = response.send(self.is_blocked(&did).await);
-                }
-                RootDocumentCommand::IsBlockedBy { did, response } => {
-                    _ = response.send(self.is_blocked_by(&did).await);
-                }
-                RootDocumentCommand::GetRootIndex { response } => {
-                    let _ = response.send(self.get_root_index().await);
-                }
-                RootDocumentCommand::SetRootIndex { root, response } => {
-                    let _ = response.send(self.set_root_index(root).await);
-                }
-                RootDocumentCommand::SetRootCid { cid, response } => {
-                    let _ = response.send(self.set_root_cid(cid).await);
-                }
-                RootDocumentCommand::GetConversationDocument { id, response } => {
-                    let _ = response.send(self.get_conversation_document(id).await);
-                }
-                RootDocumentCommand::SetConversationDocument { document, response } => {
-                    let _ = response.send(self.set_conversation_document(document).await);
-                }
-                RootDocumentCommand::ListConversationDocument { response } => {
-                    let _ = response.send(Ok(self.list_conversation_stream().await));
-                }
-            }
-        }
-    }
-
+impl RootDocumentInner {
     async fn migrate(&mut self) {
         let mut root = match self.get_root_document().await {
             Ok(r) => r,
@@ -689,9 +272,7 @@ impl RootDocumentTask {
 
         _ = self.set_root_document(root).await;
     }
-}
 
-impl RootDocumentTask {
     async fn get_root_document(&self) -> Result<RootDocument, Error> {
         let document: RootDocument = match self.cid {
             Some(cid) => self.ipfs.get_dag(cid).local().deserialized().await?,

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{self, Discovery as DiscoveryConfig, UpdateEvents},
-    store::{did_to_libp2p_pub, discovery::Discovery, DidExt, PeerIdExt, PeerTopic},
+    store::{did_to_libp2p_pub, discovery::Discovery, DidExt, PeerIdExt, topics::PeerTopic},
 };
 use chrono::{DateTime, Utc};
 
@@ -1143,7 +1143,6 @@ impl IdentityStore {
     }
 
     #[tracing::instrument(skip(self))]
-    #[allow(clippy::if_same_then_else)]
     async fn process_message(
         &mut self,
         in_did: &DID,

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -647,6 +647,11 @@ impl IdentityStore {
         &self.phonebook
     }
 
+    /// did key with private key embedded
+    pub(crate) fn did_key(&self) -> Arc<DID> {
+        self.did_key.clone()
+    }
+
     //TODO: Implement Errors
     #[tracing::instrument(skip(self, data, signal))]
     async fn check_request_message(

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -431,8 +431,6 @@ impl IdentityStore {
             }
         });
 
-        let did = store.get_keypair_did().expect("valid ed25519 keypair");
-
         store.discovery.start().await?;
 
         let mut discovery_rx = store.discovery.events();
@@ -467,7 +465,7 @@ impl IdentityStore {
             async move {
                 let event_stream = store
                     .ipfs
-                    .pubsub_subscribe(did.events())
+                    .pubsub_subscribe(store.did_key.events())
                     .await
                     .expect("not subscribed");
                 let identity_announce_stream = store

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::{self, Discovery as DiscoveryConfig, UpdateEvents},
-    store::{did_to_libp2p_pub, discovery::Discovery, DidExt, PeerIdExt, topics::PeerTopic},
+    store::{did_to_libp2p_pub, discovery::Discovery, topics::PeerTopic, DidExt, PeerIdExt},
 };
 use chrono::{DateTime, Utc};
 

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -353,7 +353,6 @@ impl std::fmt::Debug for ResponseOption {
 }
 
 impl IdentityStore {
-    #[allow(clippy::type_complexity)]
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         ipfs: Ipfs,
@@ -994,7 +993,7 @@ impl IdentityStore {
             identity.metadata = metadata;
         }
 
-        let kp_did = self.get_keypair_did()?;
+        let kp_did = self.did_key();
 
         let payload = identity.sign(&kp_did)?;
 
@@ -1614,7 +1613,7 @@ impl IdentityStore {
             signature: None,
         };
 
-        let did_kp = self.get_keypair_did()?;
+        let did_kp = self.did_key();
         let identity = identity.sign(&did_kp)?;
 
         let ident_cid = self.ipfs.dag().put().serialize(identity).await?;
@@ -1635,9 +1634,9 @@ impl IdentityStore {
             tracing::warn!(%identity.did, "Unable to export root document: {e}");
         }
 
-        let identity = identity.resolve()?;
         _ = self.announce_identity_to_mesh().await;
-        Ok(identity)
+
+        identity.resolve()
     }
 
     #[tracing::instrument(skip(self))]
@@ -1676,9 +1675,7 @@ impl IdentityStore {
             }
         }
 
-        let identity = self.own_identity().await?;
-
-        Ok(identity)
+        self.own_identity().await
     }
 
     pub async fn import_identity_remote(&mut self) -> Result<Cid, Error> {
@@ -2080,7 +2077,7 @@ impl IdentityStore {
     }
 
     pub async fn identity_update(&mut self, identity: IdentityDocument) -> Result<(), Error> {
-        let kp = self.get_keypair_did()?;
+        let kp = self.did_key();
 
         let identity = identity.sign(&kp)?;
 

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1900,7 +1900,7 @@ impl IdentityStore {
             .map(|identity| identity.did_key())
             .map_err(|_| Error::OtherWithContext("Identity store may not be initialized".into()))?;
 
-        let cache = self.identity_cache.list().await?;
+        let cache = self.identity_cache.list().await;
 
         let mut idents_docs = match &lookup {
             //Note: If this returns more than one identity, then its likely due to frontend cache not clearing out.

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2339,7 +2339,7 @@ impl ConversationInner {
 
         let stream = attachment.download(&self.ipfs, path, &members, None);
 
-        Ok(stream.boxed())
+        Ok(stream)
     }
 
     pub async fn download_stream(
@@ -2374,7 +2374,7 @@ impl ConversationInner {
 
         let stream = attachment.download_stream(&self.ipfs, &members, None);
 
-        Ok(stream.boxed())
+        Ok(stream)
     }
 
     pub async fn add_restricted(

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -80,7 +80,6 @@ pub struct MessageStore {
     _task_cancellation: Arc<DropGuard>,
 }
 
-#[allow(clippy::too_many_arguments)]
 impl MessageStore {
     pub async fn new(
         ipfs: &Ipfs,

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -70,172 +70,14 @@ pub type DownloadStream = BoxStream<'static, Result<Vec<u8>, Error>>;
 
 #[allow(clippy::large_enum_variant)]
 enum MessagingCommand {
-    GetDocument {
-        id: Uuid,
-        response: oneshot::Sender<Result<ConversationDocument, Error>>,
-    },
-    GetKeystore {
-        id: Uuid,
-        response: oneshot::Sender<Result<Keystore, Error>>,
-    },
-    SetDocument {
-        document: ConversationDocument,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    SetKeystore {
-        id: Uuid,
-        document: Keystore,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    Delete {
-        id: Uuid,
-        response: oneshot::Sender<Result<ConversationDocument, Error>>,
-    },
-    Contains {
-        id: Uuid,
-        response: oneshot::Sender<Result<bool, Error>>,
-    },
-    List {
-        response: oneshot::Sender<Result<Vec<ConversationDocument>, Error>>,
-    },
-    Subscribe {
-        id: Uuid,
-        response: oneshot::Sender<Result<tokio::sync::broadcast::Sender<MessageEventKind>, Error>>,
-    },
-
-    CreateConversation {
-        did: DID,
-        response: oneshot::Sender<Result<Conversation, Error>>,
-    },
-    CreateGroupConversation {
-        name: Option<String>,
-        recipients: HashSet<DID>,
-        settings: GroupSettings,
-        response: oneshot::Sender<Result<Conversation, Error>>,
-    },
-    GetMessage {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        response: oneshot::Sender<Result<warp::raygun::Message, Error>>,
-    },
-    GetMessages {
-        conversation_id: Uuid,
-        opt: MessageOptions,
-        response: oneshot::Sender<Result<Messages, Error>>,
-    },
-    GetMessagesCount {
-        conversation_id: Uuid,
-        response: oneshot::Sender<Result<usize, Error>>,
-    },
-    GetMessageReference {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        response: oneshot::Sender<Result<MessageReference, Error>>,
-    },
-    GetMessageReferences {
-        conversation_id: Uuid,
-        opt: MessageOptions,
-        response: oneshot::Sender<Result<BoxStream<'static, MessageReference>, Error>>,
-    },
-    DeleteConversation {
-        conversation_id: Uuid,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    UpdateConversationName {
-        conversation_id: Uuid,
-        name: String,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    UpdateConversationSettings {
-        conversation_id: Uuid,
-        settings: ConversationSettings,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    AddRecipient {
-        conversation_id: Uuid,
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    RemoveRecipient {
-        conversation_id: Uuid,
-        did: DID,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    MessageStatus {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        response: oneshot::Sender<Result<MessageStatus, Error>>,
-    },
-    SendMessage {
-        conversation_id: Uuid,
-        lines: Vec<String>,
-        response: oneshot::Sender<Result<Uuid, Error>>,
-    },
-    EditMessage {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        lines: Vec<String>,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    Reply {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        lines: Vec<String>,
-        response: oneshot::Sender<Result<Uuid, Error>>,
-    },
-    DeleteMessage {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    PinMessage {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        state: PinState,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    React {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        state: ReactionState,
-        emoji: String,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    Attach {
-        conversation_id: Uuid,
-        message_id: Option<Uuid>,
-        locations: Vec<Location>,
-        messages: Vec<String>,
-        response: oneshot::Sender<Result<(Uuid, AttachmentEventStream), Error>>,
-    },
-    Download {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        file: String,
-        path: PathBuf,
-        response: oneshot::Sender<Result<ConstellationProgressStream, Error>>,
-    },
-    DownloadStream {
-        conversation_id: Uuid,
-        message_id: Uuid,
-        file: String,
-        response: oneshot::Sender<Result<DownloadStream, Error>>,
-    },
-    SendEvent {
-        conversation_id: Uuid,
-        event: MessageEvent,
-        response: oneshot::Sender<Result<(), Error>>,
-    },
-    CancelEvent {
-        conversation_id: Uuid,
-        event: MessageEvent,
-        response: oneshot::Sender<Result<(), Error>>,
+    Receiver {
+        ch: mpsc::Receiver<ConversationStreamData>,
     },
 }
 
 #[derive(Clone)]
 pub struct MessageStore {
-    command_tx: mpsc::Sender<MessagingCommand>,
+    inner: Arc<tokio::sync::RwLock<ConversationInner>>,
     _task_cancellation: Arc<DropGuard>,
 }
 
@@ -261,7 +103,7 @@ impl MessageStore {
             }
         }
 
-        let (tx, rx) = futures::channel::mpsc::channel(0);
+        let (tx, rx) = futures::channel::mpsc::channel(1024);
 
         let token = CancellationToken::new();
         let drop_guard = token.clone().drop_guard();
@@ -269,33 +111,44 @@ impl MessageStore {
         let root = identity.root_document().clone();
         let (atx, arx) = mpsc::channel(1);
         let (conversation_mailbox_task_tx, conversation_mailbox_task_rx) = mpsc::channel(2048);
-        let mut task = ConversationTask {
+
+        let mut inner = ConversationInner {
             ipfs: ipfs.clone(),
             event_handler: Default::default(),
-            keypair,
+            keypair: keypair.clone(),
             path,
-            topic_stream: Default::default(),
             conversation_task: HashMap::new(),
-            identity,
-            command_rx: rx,
+            command_tx: tx,
+            identity: identity.clone(),
             root,
             discovery,
             file,
             event,
-            attachment_rx: arx,
             attachment_tx: atx,
             conversation_mailbox_task_tx,
-            conversation_mailbox_task_rx,
             pending_key_exchange: Default::default(),
             message_command,
             queue: Default::default(),
         };
 
-        if let Err(e) = task.migrate().await {
+        if let Err(e) = inner.migrate().await {
             tracing::warn!(error = %e, "unable to migrate conversations to root document");
         }
 
-        task.load_conversations().await;
+        inner.load_conversations().await;
+
+        let inner = Arc::new(tokio::sync::RwLock::new(inner));
+
+        let mut task = ConversationTask {
+            inner: inner.clone(),
+            ipfs: ipfs.clone(),
+            keypair: keypair.clone(),
+            topic_stream: Default::default(),
+            identity,
+            command_rx: rx,
+            attachment_rx: arx,
+            conversation_mailbox_task_rx,
+        };
 
         tokio::spawn({
             async move {
@@ -307,7 +160,7 @@ impl MessageStore {
         });
 
         Self {
-            command_tx: tx,
+            inner,
             _task_cancellation: Arc::new(drop_guard),
         }
     }
@@ -342,106 +195,51 @@ impl MessageStore {
     }
 
     pub async fn get(&self, id: Uuid) -> Result<ConversationDocument, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetDocument { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get(id).await
     }
 
     pub async fn get_keystore(&self, id: Uuid) -> Result<Keystore, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetKeystore { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_keystore(id).await
     }
 
     pub async fn contains(&self, id: Uuid) -> Result<bool, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::Contains { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        Ok(inner.contains(id).await)
     }
 
     pub async fn set(&self, document: ConversationDocument) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::SetDocument {
-                document,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_document(document).await
     }
 
     pub async fn set_keystore(&self, id: Uuid, document: Keystore) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::SetKeystore {
-                id,
-                document,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.set_keystore(id, document).await
     }
 
     pub async fn delete(&self, id: Uuid) -> Result<ConversationDocument, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::Delete { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.delete(id).await
     }
 
     pub async fn list(&self) -> Result<Vec<ConversationDocument>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::List { response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        Ok(inner.list().await)
     }
 
     pub async fn subscribe(
         &self,
         id: Uuid,
     ) -> Result<tokio::sync::broadcast::Sender<MessageEventKind>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::Subscribe { id, response: tx })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.subscribe(id).await
     }
 
     pub async fn create_conversation(&self, did: &DID) -> Result<Conversation, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::CreateConversation {
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.create_conversation(did).await
     }
 
     pub async fn create_group_conversation(
@@ -450,18 +248,10 @@ impl MessageStore {
         members: HashSet<DID>,
         settings: GroupSettings,
     ) -> Result<Conversation, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::CreateGroupConversation {
-                name,
-                recipients: members,
-                settings,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner
+            .create_group_conversation(name, members, settings)
+            .await
     }
 
     pub async fn get_message(
@@ -469,17 +259,8 @@ impl MessageStore {
         conversation_id: Uuid,
         message_id: Uuid,
     ) -> Result<warp::raygun::Message, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetMessage {
-                conversation_id,
-                message_id,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.get_message(conversation_id, message_id).await
     }
 
     pub async fn get_messages(
@@ -487,30 +268,13 @@ impl MessageStore {
         conversation_id: Uuid,
         opt: MessageOptions,
     ) -> Result<Messages, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetMessages {
-                conversation_id,
-                opt,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_messages(conversation_id, opt).await
     }
 
     pub async fn messages_count(&self, conversation_id: Uuid) -> Result<usize, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetMessagesCount {
-                conversation_id,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.messages_count(conversation_id).await
     }
 
     pub async fn get_message_reference(
@@ -518,17 +282,10 @@ impl MessageStore {
         conversation_id: Uuid,
         message_id: Uuid,
     ) -> Result<MessageReference, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetMessageReference {
-                conversation_id,
-                message_id,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner
+            .get_message_reference(conversation_id, message_id)
+            .await
     }
 
     pub async fn get_message_references(
@@ -536,17 +293,8 @@ impl MessageStore {
         conversation_id: Uuid,
         opt: MessageOptions,
     ) -> Result<BoxStream<'static, MessageReference>, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::GetMessageReferences {
-                conversation_id,
-                opt,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.get_message_references(conversation_id, opt).await
     }
 
     pub async fn update_conversation_name<S: Into<String>>(
@@ -555,17 +303,8 @@ impl MessageStore {
         name: S,
     ) -> Result<(), Error> {
         let name = name.into();
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::UpdateConversationName {
-                conversation_id,
-                name,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.update_conversation_name(conversation_id, &name).await
     }
 
     pub async fn update_conversation_settings(
@@ -573,58 +312,25 @@ impl MessageStore {
         conversation_id: Uuid,
         settings: ConversationSettings,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::UpdateConversationSettings {
-                conversation_id,
-                settings,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner
+            .update_conversation_settings(conversation_id, settings)
+            .await
     }
 
     pub async fn delete_conversation(&self, conversation_id: Uuid) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::DeleteConversation {
-                conversation_id,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.delete_conversation(conversation_id, true).await
     }
 
     pub async fn add_recipient(&self, conversation_id: Uuid, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::AddRecipient {
-                conversation_id,
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.add_recipient(conversation_id, did).await
     }
 
     pub async fn remove_recipient(&self, conversation_id: Uuid, did: &DID) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::RemoveRecipient {
-                conversation_id,
-                did: did.clone(),
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.remove_recipient(conversation_id, did, true).await
     }
 
     pub async fn message_status(
@@ -632,17 +338,8 @@ impl MessageStore {
         conversation_id: Uuid,
         message_id: Uuid,
     ) -> Result<MessageStatus, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::MessageStatus {
-                conversation_id,
-                message_id,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner.message_status(conversation_id, message_id).await
     }
 
     pub async fn send_message(
@@ -650,17 +347,8 @@ impl MessageStore {
         conversation_id: Uuid,
         lines: Vec<String>,
     ) -> Result<Uuid, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::SendMessage {
-                conversation_id,
-                lines,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.send_message(conversation_id, lines).await
     }
 
     pub async fn edit_message(
@@ -669,18 +357,8 @@ impl MessageStore {
         message_id: Uuid,
         lines: Vec<String>,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::EditMessage {
-                conversation_id,
-                message_id,
-                lines,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.edit_message(conversation_id, message_id, lines).await
     }
 
     pub async fn reply(
@@ -689,18 +367,10 @@ impl MessageStore {
         message_id: Uuid,
         lines: Vec<String>,
     ) -> Result<Uuid, Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::Reply {
-                conversation_id,
-                message_id,
-                lines,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner
+            .reply_message(conversation_id, message_id, lines)
+            .await
     }
 
     pub async fn delete_message(
@@ -708,17 +378,10 @@ impl MessageStore {
         conversation_id: Uuid,
         message_id: Uuid,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::DeleteMessage {
-                conversation_id,
-                message_id,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner
+            .delete_message(conversation_id, message_id, true)
+            .await
     }
 
     pub async fn pin_message(
@@ -727,18 +390,8 @@ impl MessageStore {
         message_id: Uuid,
         state: PinState,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::PinMessage {
-                conversation_id,
-                message_id,
-                state,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.pin_message(conversation_id, message_id, state).await
     }
 
     pub async fn react<S: Into<String>>(
@@ -749,19 +402,8 @@ impl MessageStore {
         emoji: S,
     ) -> Result<(), Error> {
         let emoji = emoji.into();
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::React {
-                conversation_id,
-                message_id,
-                state,
-                emoji,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.react(conversation_id, message_id, state, emoji).await
     }
 
     pub async fn attach(
@@ -771,19 +413,10 @@ impl MessageStore {
         locations: Vec<Location>,
         messages: Vec<String>,
     ) -> Result<(Uuid, AttachmentEventStream), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::Attach {
-                conversation_id,
-                message_id,
-                locations,
-                messages,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner
+            .attach(conversation_id, message_id, locations, messages)
+            .await
     }
 
     pub async fn download<S: Into<String>, P: AsRef<Path>>(
@@ -795,20 +428,10 @@ impl MessageStore {
     ) -> Result<ConstellationProgressStream, Error> {
         let file = file.into();
         let path = path.as_ref().to_path_buf();
-
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::Download {
-                conversation_id,
-                message_id,
-                file,
-                path,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner
+            .download(conversation_id, message_id, &file, path)
+            .await
     }
 
     pub async fn download_stream<S: Into<String>>(
@@ -818,19 +441,10 @@ impl MessageStore {
         file: S,
     ) -> Result<DownloadStream, Error> {
         let file = file.into();
-
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::DownloadStream {
-                conversation_id,
-                message_id,
-                file,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &*self.inner.read().await;
+        inner
+            .download_stream(conversation_id, message_id, &file)
+            .await
     }
 
     pub async fn send_event(
@@ -838,17 +452,8 @@ impl MessageStore {
         conversation_id: Uuid,
         event: MessageEvent,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::SendEvent {
-                conversation_id,
-                event,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.send_event(conversation_id, event).await
     }
 
     pub async fn cancel_event(
@@ -856,45 +461,23 @@ impl MessageStore {
         conversation_id: Uuid,
         event: MessageEvent,
     ) -> Result<(), Error> {
-        let (tx, rx) = oneshot::channel();
-        let _ = self
-            .command_tx
-            .clone()
-            .send(MessagingCommand::CancelEvent {
-                conversation_id,
-                event,
-                response: tx,
-            })
-            .await;
-        rx.await.map_err(anyhow::Error::from)?
+        let inner = &mut *self.inner.write().await;
+        inner.cancel_event(conversation_id, event).await
     }
 }
 
 type AttachmentChan = (Uuid, MessageDocument, oneshot::Sender<Result<(), Error>>);
 
 struct ConversationTask {
+    inner: Arc<tokio::sync::RwLock<ConversationInner>>,
     ipfs: Ipfs,
-    path: Option<PathBuf>,
     keypair: Arc<DID>,
-    event_handler: HashMap<Uuid, tokio::sync::broadcast::Sender<MessageEventKind>>,
     topic_stream: SelectAll<mpsc::Receiver<ConversationStreamData>>,
-    conversation_task: HashMap<Uuid, JoinHandle<()>>,
-    root: RootDocumentMap,
-    file: FileStore,
-    event: EventSubscription<RayGunEventKind>,
     identity: IdentityStore,
-    discovery: Discovery,
     // used for attachments to store message on document and publish it to the network
     attachment_rx: mpsc::Receiver<AttachmentChan>,
-    attachment_tx: mpsc::Sender<AttachmentChan>,
     command_rx: mpsc::Receiver<MessagingCommand>,
-    conversation_mailbox_task_tx: mpsc::Sender<Result<(Uuid, Vec<MessageDocument>), Error>>,
     conversation_mailbox_task_rx: mpsc::Receiver<Result<(Uuid, Vec<MessageDocument>), Error>>,
-    pending_key_exchange: HashMap<Uuid, Vec<(DID, Vec<u8>, bool)>>,
-
-    message_command: mpsc::Sender<shuttle::message::client::MessageCommand>,
-    // Note: Temporary
-    queue: HashMap<DID, Vec<Queue>>,
 }
 
 impl ConversationTask {
@@ -925,115 +508,15 @@ impl ConversationTask {
         loop {
             tokio::select! {
                 biased;
-                Some(command) = self.command_rx.next() => {
-                    match command {
-                        MessagingCommand::GetDocument { id, response } => {
-                            let _ = response.send(self.get(id).await);
-                        }
-                        MessagingCommand::SetDocument { document, response } => {
-                            let _ = response.send(self.set_document(document).await);
-                        }
-                        MessagingCommand::List { response } => {
-                            let _ = response.send(Ok(self.list().await));
-                        }
-                        MessagingCommand::Delete { id, response } => {
-                            let _ = response.send(self.delete(id).await);
-                        }
-                        MessagingCommand::Subscribe { id, response } => {
-                            let _ = response.send(self.subscribe(id).await);
-                        }
-                        MessagingCommand::Contains { id, response } => {
-                            let _ = response.send(Ok(self.contains(id).await));
-                        }
-                        MessagingCommand::GetKeystore { id, response } => {
-                            let _ = response.send(self.get_keystore(id).await);
-                        }
-                        MessagingCommand::SetKeystore {
-                            id,
-                            document,
-                            response,
-                        } => {
-                            let _ = response.send(self.set_keystore(id, document).await);
-                        }
-                        MessagingCommand::CreateConversation { did, response } => {
-                            _ = response.send(self.create_conversation(&did).await);
-                        },
-                        MessagingCommand::CreateGroupConversation { name, recipients, settings, response } => {
-                            _ = response.send(self.create_group_conversation(name, recipients, settings).await);
-                        },
-                        MessagingCommand::GetMessageReference { conversation_id, message_id, response } => {
-                            _ = response.send(self.get_message_reference(conversation_id, message_id).await);
-                        },
-                        MessagingCommand::GetMessageReferences { conversation_id, opt, response } => {
-                            _ = response.send(self.get_message_references(conversation_id, opt).await)
-                        },
-                        MessagingCommand::GetMessage { conversation_id, message_id, response } => {
-                            _ = response.send(self.get_message(conversation_id, message_id).await);
-                        },
-                        MessagingCommand::GetMessages { conversation_id, opt, response } => {
-                            _ = response.send(self.get_messages(conversation_id, opt).await)
-                        },
-                        MessagingCommand::GetMessagesCount { conversation_id, response } => {
-                            _ = response.send(self.messages_count(conversation_id).await)
-                        }
-                        MessagingCommand::DeleteConversation { conversation_id, response } => {
-                            _ = response.send(self.delete_conversation(conversation_id, true).await)
-                        },
-                        MessagingCommand::UpdateConversationName { conversation_id, name, response } => {
-                            _ = response.send(self.update_conversation_name(conversation_id, &name).await)
-                        },
-                        MessagingCommand::UpdateConversationSettings { conversation_id, settings, response } => {
-                            _ = response.send(self.update_conversation_settings(conversation_id, settings).await)
-                        },
-                        MessagingCommand::AddRecipient { conversation_id, did, response } => {
-                            _ = response.send(self.add_recipient(conversation_id, &did).await)
-                        },
-                        MessagingCommand::RemoveRecipient { conversation_id, did, response } => {
-                            _ = response.send(self.remove_recipient(conversation_id, &did, true).await)
-                        },
-                        MessagingCommand::MessageStatus { conversation_id, message_id, response } => {
-                            _ = response.send(self.message_status(conversation_id, message_id).await)
-                        },
-                        MessagingCommand::SendMessage { conversation_id, lines, response } => {
-                            _ = response.send(self.send_message(conversation_id, lines).await)
-                        },
-                        MessagingCommand::EditMessage { conversation_id, message_id, lines, response } => {
-                            _ = response.send(self.edit_message(conversation_id, message_id, lines).await)
-                        },
-                        MessagingCommand::Reply { conversation_id, message_id, lines, response } => {
-                            _ = response.send(self.reply_message(conversation_id, message_id, lines).await)
-                        },
-                        MessagingCommand::DeleteMessage { conversation_id, message_id, response } => {
-                            _ = response.send(self.delete_message(conversation_id, message_id, true).await)
-                        },
-                        MessagingCommand::PinMessage { conversation_id, message_id, state, response } => {
-                            _ = response.send(self.pin_message(conversation_id, message_id, state).await)
-                        },
-                        MessagingCommand::React { conversation_id, message_id, state, emoji, response } => {
-                            _ = response.send(self.react(conversation_id, message_id, state, emoji).await)
-                        },
-                        MessagingCommand::Attach { conversation_id, message_id, locations, messages, response } => {
-                            _ = response.send(self.attach(conversation_id, message_id, locations, messages).await)
-                        },
-                        MessagingCommand::Download { conversation_id, message_id, file, path, response } => {
-                            _ = response.send(self.download(conversation_id, message_id, &file, path).await)
-                        },
-                        MessagingCommand::DownloadStream { conversation_id, message_id, file, response } => {
-                            _ = response.send(self.download_stream(conversation_id, message_id, &file).await)
-                        },
-                        MessagingCommand::SendEvent { conversation_id, event, response } => {
-                            _ = response.send(self.send_event(conversation_id, event).await)
-                        }
-                        MessagingCommand::CancelEvent { conversation_id, event, response } => {
-                            _ = response.send(self.cancel_event(conversation_id, event).await)
-                        }
-                    }
+                Some(MessagingCommand::Receiver { ch }) = self.command_rx.next() => {
+                    self.topic_stream.push(ch);
                 }
                 Some((conversation_id, message, response)) = self.attachment_rx.next() => {
-                    _ = response.send(self.store_direct_for_attachment(conversation_id, message).await);
+                    let inner = &mut *self.inner.write().await;
+                    _ = response.send(inner.store_direct_for_attachment(conversation_id, message).await);
                 }
                 Some(ev) = identity_stream.next() => {
-                    if let Err(e) = process_identity_events(self, ev).await {
+                    if let Err(e) = process_identity_events(&mut *self.inner.write().await, ev).await {
                         tracing::error!("Error processing identity events: {e}");
                     }
                 }
@@ -1064,15 +547,16 @@ impl ConversationTask {
                         }
                     };
 
-                    if let Err(e) = process_conversation(self, payload, events).await {
+                    if let Err(e) = process_conversation(&mut *self.inner.write().await, payload, events).await {
                         tracing::error!(%sender, error = %e, "error processing conversation");
                     }
                 }
                 Some(item) = self.topic_stream.next() => {
+                    let inner = &mut *self.inner.write().await;
                     match item {
                         ConversationStreamData::RequestResponse(conversation_id, _) |
                             ConversationStreamData::Event(conversation_id, _) |
-                            ConversationStreamData::Message(conversation_id, _) if !self.contains(conversation_id).await => {
+                            ConversationStreamData::Message(conversation_id, _) if !inner.contains(conversation_id).await => {
                                 // Note: If the conversation is deleted prior to processing the events from stream
                                 //       related to the specific we should then ignore those events.
                                 //       Additionally, we could switch back to `StreamMap` and remove the stream
@@ -1081,25 +565,26 @@ impl ConversationTask {
                         },
                         ConversationStreamData::RequestResponse(conversation_id, req) => {
                             let source = req.source;
-                            if let Err(e) = process_request_response_event(self, conversation_id, req).await {
+                            if let Err(e) = process_request_response_event(inner, conversation_id, req).await {
                                 tracing::error!(%conversation_id, sender = ?source, error = %e, name = "request", "Failed to process payload");
                             }
                         },
                         ConversationStreamData::Event(conversation_id, ev) => {
                             let source = ev.source;
-                            if let Err(e) = process_conversation_event(self, conversation_id, ev).await {
+                            if let Err(e) = process_conversation_event(inner, conversation_id, ev).await {
                                 tracing::error!(%conversation_id, sender = ?source, error = %e, name = "ev", "Failed to process payload");
                             }
                         },
                         ConversationStreamData::Message(conversation_id, msg) => {
                             let source = msg.source;
-                            if let Err(e) = self.process_msg_event(conversation_id, msg).await {
+                            if let Err(e) = inner.process_msg_event(conversation_id, msg).await {
                                 tracing::error!(%conversation_id, sender = ?source, error = %e, name = "msg", "Failed to process payload");
                             }
                         },
                     }
                 }
                 Some(result) = self.conversation_mailbox_task_rx.next() => {
+                    let inner = &mut *self.inner.write().await;
                     let (id, messages) = match result {
                         Ok(ok) => ok,
                         Err(e) => {
@@ -1112,24 +597,52 @@ impl ConversationTask {
                         continue;
                     }
                     tracing::info!(conversation_id = %id, num_of_msg = messages.len(), "receive messages from mailbox");
-                    if let Err(e) = self.insert_messages_from_mailbox(id, messages).await {
+
+                    if let Err(e) = inner.insert_messages_from_mailbox(id, messages).await {
                         tracing::error!(conversation_id = %id, error = %e, "unable to get messages from conversation mailbox");
                     }
                 }
                 _ = queue_timer.tick() => {
-                    _ = process_queue(self).await;
+                    let inner = &mut *self.inner.write().await;
+                    _ = process_queue(inner).await;
                 }
                 _ = pending_exchange_timer.tick() => {
-                    _ = process_pending_payload(self).await;
+                    let inner = &mut *self.inner.write().await;
+                    _ = process_pending_payload(inner).await;
                 }
 
                 _ = check_mailbox.tick() => {
-                    _ = self.load_from_mailbox().await;
+                    let inner = &mut *self.inner.write().await;
+                    _ = inner.load_from_mailbox().await;
                 }
             }
         }
     }
+}
 
+struct ConversationInner {
+    ipfs: Ipfs,
+    path: Option<PathBuf>,
+    keypair: Arc<DID>,
+    event_handler: HashMap<Uuid, tokio::sync::broadcast::Sender<MessageEventKind>>,
+    conversation_task: HashMap<Uuid, JoinHandle<()>>,
+    root: RootDocumentMap,
+    file: FileStore,
+    event: EventSubscription<RayGunEventKind>,
+    identity: IdentityStore,
+    discovery: Discovery,
+    command_tx: mpsc::Sender<MessagingCommand>,
+    // used for attachments to store message on document and publish it to the network
+    attachment_tx: mpsc::Sender<AttachmentChan>,
+    conversation_mailbox_task_tx: mpsc::Sender<Result<(Uuid, Vec<MessageDocument>), Error>>,
+    pending_key_exchange: HashMap<Uuid, Vec<(DID, Vec<u8>, bool)>>,
+
+    message_command: mpsc::Sender<shuttle::message::client::MessageCommand>,
+    // Note: Temporary
+    queue: HashMap<DID, Vec<Queue>>,
+}
+
+impl ConversationInner {
     async fn migrate(&mut self) -> Result<(), Error> {
         if let Some(path) = self.path.as_ref() {
             let mid_file = path.join(".message_id");
@@ -3560,7 +3073,10 @@ impl ConversationTask {
             }
         });
 
-        self.topic_stream.push(rx);
+        _ = self
+            .command_tx
+            .send(MessagingCommand::Receiver { ch: rx })
+            .await;
         self.conversation_task.insert(conversation_id, handle);
 
         tracing::info!(%conversation_id, "started conversation");
@@ -3608,7 +3124,7 @@ enum ConversationStreamData {
 }
 
 async fn process_conversation(
-    this: &mut ConversationTask,
+    this: &mut ConversationInner,
     data: Payload<'_>,
     event: ConversationEvents,
 ) -> Result<(), Error> {
@@ -3806,7 +3322,7 @@ async fn process_conversation(
 
 // TODO: de-duplicate logic where possible
 async fn message_event(
-    this: &mut ConversationTask,
+    this: &mut ConversationInner,
     conversation_id: Uuid,
     events: MessagingEvents,
 ) -> Result<(), Error> {
@@ -4246,7 +3762,7 @@ async fn message_event(
 }
 
 async fn process_identity_events(
-    this: &mut ConversationTask,
+    this: &mut ConversationInner,
     event: MultiPassEventKind,
 ) -> Result<(), Error> {
     //TODO: Tie this into a configuration
@@ -4350,7 +3866,7 @@ async fn process_identity_events(
 }
 
 async fn process_request_response_event(
-    this: &mut ConversationTask,
+    this: &mut ConversationInner,
     conversation_id: Uuid,
     req: Message,
 ) -> Result<(), Error> {
@@ -4485,7 +4001,7 @@ async fn process_request_response_event(
     Ok(())
 }
 
-async fn process_pending_payload(this: &mut ConversationTask) {
+async fn process_pending_payload(this: &mut ConversationInner) {
     if this.pending_key_exchange.is_empty() {
         return;
     }
@@ -4529,7 +4045,7 @@ async fn process_pending_payload(this: &mut ConversationTask) {
 }
 
 async fn process_conversation_event(
-    this: &mut ConversationTask,
+    this: &mut ConversationInner,
     conversation_id: Uuid,
     message: Message,
 ) -> Result<(), Error> {
@@ -4607,7 +4123,7 @@ impl Queue {
 }
 
 //TODO: Replace
-async fn process_queue(this: &mut ConversationTask) {
+async fn process_queue(this: &mut ConversationInner) {
     let mut changed = false;
 
     for (did, items) in this.queue.iter_mut() {
@@ -4674,7 +4190,7 @@ async fn process_queue(this: &mut ConversationTask) {
 }
 
 async fn pubkey_or_keystore(
-    conversation: &ConversationTask,
+    conversation: &ConversationInner,
     conversation_id: Uuid,
     keypair: &DID,
 ) -> Result<Either<DID, Keystore>, Error> {

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -55,9 +55,10 @@ use crate::{
         identity::IdentityStore,
         keystore::Keystore,
         payload::Payload,
-        sign_serde, verify_serde_sig, ConversationEvents, ConversationRequestKind,
-        ConversationRequestResponse, ConversationResponseKind, ConversationUpdateKind, DidExt,
-        MessagingEvents, PeerTopic,
+        sign_serde,
+        topics::PeerTopic,
+        verify_serde_sig, ConversationEvents, ConversationRequestKind, ConversationRequestResponse,
+        ConversationResponseKind, ConversationUpdateKind, DidExt, MessagingEvents,
     },
 };
 

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -14,7 +14,7 @@ pub mod request;
 use chrono::{DateTime, Utc};
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Display, time::Duration};
+use std::time::Duration;
 use uuid::Uuid;
 
 use ipfs::{Keypair, PeerId, PublicKey};
@@ -35,28 +35,32 @@ use warp::{
 };
 
 pub(super) mod topics {
-    /// Topic to announce identity updates to network
+    use std::fmt::Display;
+
+    use warp::crypto::DID;
+
+    /// Topic to announce identity updates to the network
     pub const IDENTITY_ANNOUNCEMENT: &str = "/identity/announce/v0";
+
+    pub trait PeerTopic: Display {
+        fn inbox(&self) -> String {
+            format!("/peer/{self}/inbox")
+        }
+
+        fn events(&self) -> String {
+            format!("/peer/{self}/events")
+        }
+        fn messaging(&self) -> String {
+            format!("{self}/messaging")
+        }
+    }
+
+    impl PeerTopic for DID {}
 }
 
 const SHUTTLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 use self::conversation::{ConversationDocument, MessageDocument};
-
-pub trait PeerTopic: Display {
-    fn inbox(&self) -> String {
-        format!("/peer/{self}/inbox")
-    }
-
-    fn events(&self) -> String {
-        format!("/peer/{self}/events")
-    }
-    fn messaging(&self) -> String {
-        format!("{self}/messaging")
-    }
-}
-
-impl PeerTopic for DID {}
 
 pub trait PeerIdExt {
     fn to_public_key(&self) -> Result<PublicKey, anyhow::Error>;

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -117,7 +117,7 @@ impl DidExt for DID {
 }
 
 pub trait VecExt<T: Eq> {
-    fn insert_item(&mut self, item: &T) -> bool;
+    fn insert_item(&mut self, item: T) -> bool;
     fn remove_item(&mut self, item: &T) -> bool;
 }
 
@@ -125,12 +125,12 @@ impl<T> VecExt<T> for Vec<T>
 where
     T: Eq + Clone,
 {
-    fn insert_item(&mut self, item: &T) -> bool {
-        if self.contains(item) {
+    fn insert_item(&mut self, item: T) -> bool {
+        if self.contains(&item) {
             return false;
         }
 
-        self.push(item.clone());
+        self.push(item);
         true
     }
 

--- a/extensions/warp-ipfs/src/store/queue.rs
+++ b/extensions/warp-ipfs/src/store/queue.rs
@@ -19,7 +19,7 @@ use warp::{
     error::Error,
 };
 
-use crate::store::{ecdh_encrypt, PeerIdExt, PeerTopic};
+use crate::store::{ecdh_encrypt, topics::PeerTopic, PeerIdExt};
 
 use super::{connected_to_peer, discovery::Discovery, identity::RequestResponsePayload};
 

--- a/extensions/warp-ipfs/src/store/request.rs
+++ b/extensions/warp-ipfs/src/store/request.rs
@@ -145,16 +145,16 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadRequest<M> {
 }
 
 impl<M> PayloadRequest<M> {
-    pub fn sender(&self) -> PeerId {
-        self.on_behalf.unwrap_or(self.sender)
+    pub fn sender(&self) -> &PeerId {
+        self.on_behalf.as_ref().unwrap_or(&self.sender)
     }
 
-    pub fn original_sender(&self) -> PeerId {
-        self.sender
+    pub fn original_sender(&self) -> &PeerId {
+        &self.sender
     }
 
-    pub fn cosigner(&self) -> Option<PeerId> {
-        self.on_behalf
+    pub fn cosigner(&self) -> Option<&PeerId> {
+        self.on_behalf.as_ref()
     }
 
     pub fn message(&self) -> &M {
@@ -179,7 +179,7 @@ mod test {
         let keypair = Keypair::generate_ed25519();
 
         let payload = PayloadRequest::new(&keypair, None, data)?;
-        assert_eq!(payload.sender(), keypair.public().to_peer_id());
+        assert_eq!(payload.sender(), &keypair.public().to_peer_id());
         payload.verify()?;
         assert_eq!(payload.message(), "Request");
 
@@ -194,8 +194,8 @@ mod test {
 
         let payload = PayloadRequest::new(&keypair, Some(&cosigner_keypair), data)?;
 
-        assert_ne!(payload.sender(), keypair.public().to_peer_id());
-        assert_eq!(payload.sender(), cosigner_keypair.public().to_peer_id());
+        assert_ne!(payload.sender(), &keypair.public().to_peer_id());
+        assert_eq!(payload.sender(), &cosigner_keypair.public().to_peer_id());
         payload.verify()?;
         assert_eq!(payload.message(), "Request");
 
@@ -208,7 +208,7 @@ mod test {
         let keypair = Keypair::generate_ed25519();
 
         let payload = PayloadRequest::new(&keypair, None, data)?;
-        assert_eq!(payload.sender(), keypair.public().to_peer_id());
+        assert_eq!(payload.sender(), &keypair.public().to_peer_id());
         payload.verify()?;
 
         let bytes = payload.to_bytes()?;

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -59,8 +59,8 @@ impl Cipher {
     }
 
     /// Returns the stored key
-    pub fn private_key(&self) -> Vec<u8> {
-        self.private_key.to_owned()
+    pub fn private_key(&self) -> &[u8] {
+        &self.private_key
     }
 
     /// Used to generate and encrypt data with a random key
@@ -145,7 +145,7 @@ impl Cipher {
         stream: impl Stream<Item = std::result::Result<Vec<u8>, std::io::Error>> + Unpin + Send + 'a,
     ) -> Result<impl Stream<Item = Result<Vec<u8>>> + Send + 'a> {
         let cipher = Cipher::new();
-        let key_stream = stream::iter(Ok::<_, Error>(Ok(cipher.private_key())));
+        let key_stream = stream::iter(Ok::<_, Error>(Ok(cipher.private_key().to_owned())));
 
         let cipher_stream = cipher.encrypt_async_stream(stream).await?;
 
@@ -171,7 +171,7 @@ impl Cipher {
         reader: R,
     ) -> Result<impl Stream<Item = Result<Vec<u8>>> + Send + 'a> {
         let cipher = Cipher::new();
-        let key_stream = stream::iter(Ok::<_, Error>(Ok(cipher.private_key())));
+        let key_stream = stream::iter(Ok::<_, Error>(Ok(cipher.private_key().to_owned())));
 
         let cipher_stream = cipher.encrypt_async_read_to_stream(reader).await?;
         let stream = key_stream.chain(cipher_stream);
@@ -396,7 +396,7 @@ impl Cipher {
     /// Encrypts and embeds private key into writer stream
     pub fn self_encrypt_stream(reader: &mut impl Read, writer: &mut impl Write) -> Result<()> {
         let cipher = Cipher::new();
-        writer.write_all(&cipher.private_key())?;
+        writer.write_all(cipher.private_key())?;
         cipher.encrypt_stream(reader, writer)?;
         Ok(())
     }

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -579,101 +579,95 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn cipher_aes256gcm_async_stream_encrypt_decrypt() -> anyhow::Result<()> {
-        futures::executor::block_on(async move {
-            let cipher = Cipher::from(b"this is my key");
-            let message = b"this is my message";
-            let base = stream::iter(Ok::<_, std::io::Error>(Ok(message.to_vec())));
+    #[tokio::test]
+    async fn cipher_aes256gcm_async_stream_encrypt_decrypt() -> anyhow::Result<()> {
+        let cipher = Cipher::from(b"this is my key");
+        let message = b"this is my message";
+        let base = stream::iter(Ok::<_, std::io::Error>(Ok(message.to_vec())));
 
-            let cipher_stream = cipher
-                .encrypt_async_stream(base)
-                .await?
-                .map(|result| result.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other)))
-                .boxed();
+        let cipher_stream = cipher
+            .encrypt_async_stream(base)
+            .await?
+            .map(|result| result.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other)))
+            .boxed();
 
-            let plaintext_stream = cipher.decrypt_async_stream(cipher_stream).await?;
+        let plaintext_stream = cipher.decrypt_async_stream(cipher_stream).await?;
 
-            let plaintext_message = plaintext_stream
-                .try_collect::<Vec<_>>()
-                .await?
-                .iter()
-                .flatten()
-                .copied()
-                .collect::<Vec<_>>();
+        let plaintext_message = plaintext_stream
+            .try_collect::<Vec<_>>()
+            .await?
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
 
-            assert_eq!(
-                String::from_utf8_lossy(&plaintext_message),
-                String::from_utf8_lossy(message)
-            );
-            Ok(())
-        })
+        assert_eq!(
+            String::from_utf8_lossy(&plaintext_message),
+            String::from_utf8_lossy(message)
+        );
+        Ok(())
     }
 
-    #[test]
-    fn cipher_aes256gcm_async_read_to_stream_encrypt_decrypt() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn cipher_aes256gcm_async_read_to_stream_encrypt_decrypt() -> anyhow::Result<()> {
         use futures::io::Cursor;
 
-        futures::executor::block_on(async move {
-            let cipher = Cipher::from(b"this is my key");
-            let mut message = Cursor::new("this is my message");
+        let cipher = Cipher::from(b"this is my key");
+        let mut message = Cursor::new("this is my message");
 
-            let cipher_stream = cipher
-                .encrypt_async_read_to_stream(&mut message)
-                .await?
-                .map(|result| result.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other)));
+        let cipher_stream = cipher
+            .encrypt_async_read_to_stream(&mut message)
+            .await?
+            .map(|result| result.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other)));
 
-            let mut cipher_reader = cipher_stream.into_async_read();
+        let mut cipher_reader = cipher_stream.into_async_read();
 
-            let plaintext_stream = cipher
-                .decrypt_async_read_to_stream(&mut cipher_reader)
-                .await?;
+        let plaintext_stream = cipher
+            .decrypt_async_read_to_stream(&mut cipher_reader)
+            .await?;
 
-            let plaintext_message = plaintext_stream
-                .try_collect::<Vec<_>>()
-                .await?
-                .iter()
-                .flatten()
-                .copied()
-                .collect::<Vec<_>>();
+        let plaintext_message = plaintext_stream
+            .try_collect::<Vec<_>>()
+            .await?
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
 
-            drop(cipher_reader);
+        drop(cipher_reader);
 
-            assert_eq!(
-                String::from_utf8_lossy(&plaintext_message),
-                message.into_inner()
-            );
-            Ok(())
-        })
+        assert_eq!(
+            String::from_utf8_lossy(&plaintext_message),
+            message.into_inner()
+        );
+        Ok(())
     }
 
-    #[test]
-    fn cipher_aes256gcm_async_stream_self_encrypt_decrypt() -> anyhow::Result<()> {
-        futures::executor::block_on(async move {
-            let message = b"this is my message";
-            let base = stream::iter(Ok::<_, std::io::Error>(Ok(message.to_vec())));
+    #[tokio::test]
+    async fn cipher_aes256gcm_async_stream_self_encrypt_decrypt() -> anyhow::Result<()> {
+        let message = b"this is my message";
+        let base = stream::iter(Ok::<_, std::io::Error>(Ok(message.to_vec())));
 
-            let cipher_stream = Cipher::self_encrypt_async_stream(base)
-                .await?
-                .map(|result| result.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other)))
-                .boxed();
+        let cipher_stream = Cipher::self_encrypt_async_stream(base)
+            .await?
+            .map(|result| result.map_err(|_| std::io::Error::from(std::io::ErrorKind::Other)))
+            .boxed();
 
-            let plaintext_stream = Cipher::self_decrypt_async_stream(cipher_stream).await?;
+        let plaintext_stream = Cipher::self_decrypt_async_stream(cipher_stream).await?;
 
-            let plaintext_message = plaintext_stream
-                .try_collect::<Vec<_>>()
-                .await?
-                .iter()
-                .flatten()
-                .copied()
-                .collect::<Vec<_>>();
+        let plaintext_message = plaintext_stream
+            .try_collect::<Vec<_>>()
+            .await?
+            .iter()
+            .flatten()
+            .copied()
+            .collect::<Vec<_>>();
 
-            assert_eq!(
-                String::from_utf8_lossy(&plaintext_message),
-                String::from_utf8_lossy(message)
-            );
+        assert_eq!(
+            String::from_utf8_lossy(&plaintext_message),
+            String::from_utf8_lossy(message)
+        );
 
-            Ok(())
-        })
+        Ok(())
     }
 }

--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -904,18 +904,18 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    pub fn tesseract_event() -> anyhow::Result<()> {
+    #[tokio::test]
+    async fn tesseract_event() -> anyhow::Result<()> {
         let tesseract = Tesseract::default();
         let mut stream = tesseract.subscribe();
         let key = generate::<32>();
 
         tesseract.unlock(&key)?;
-        let event = futures::executor::block_on(stream.next());
+        let event = stream.next().await;
         assert_eq!(event, Some(TesseractEvent::Unlocked));
 
         tesseract.lock();
-        let event = futures::executor::block_on(stream.next());
+        let event = stream.next().await;
         assert_eq!(event, Some(TesseractEvent::Locked));
 
         Ok(())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Simplify logic
- Remove migration code from some portions of the stores
- Optimize initialization code
- Reduce allocations 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- It was under the assumption that dyn-clone would reuse allocation from trait objects when cloning, however while investigating some of the allocations, this seem not to be the case when it comes to boxed objects (which shouldve been obvious, but havent looked into it personally until recently). While `warp-ipfs` it uses `Arc` internally (currently and previously), the allocations are still kept low when the trait object is cloned using dyn-clone, however if one wishes to avoid those allocations, it is advised to use `WarpIpfs` directly.
