### PR TITLE
chore: fix some wasm compilation issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = { version = "0.1" }
 async-stream = "0.3"
 async-broadcast = "0.5"
 tokio = { version = "1", features = [
+    "macros",
     "fs",
     "net",
     "rt-multi-thread",
@@ -50,7 +51,7 @@ parking_lot = { version = "0.12" }
 once_cell = "1.16"
 
 # Time crate
-chrono = { version = "~0.4.27", default-features = false, features = ["serde", "wasmbind"] }
+chrono = { version = "~0.4.27", default-features = false, features = ["serde", "wasmbind", "now"] }
 
 # Encoding and Serializing Crates
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -12,9 +12,6 @@ warp.workspace = true
 rust-ipfs.workspace = true
 libipld.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }
-tokio = { workspace = true }
-tokio-util = { workspace = true }
-tokio-stream = { workspace = true }
 futures.workspace = true
 async-trait.workspace = true
 async-stream.workspace = true
@@ -41,6 +38,14 @@ bincode.workspace = true
 bytes.workspace = true
 
 shuttle = { path = "../../tools/shuttle", default-features = false }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false, features = ["sync"]}
 
 [dev-dependencies]
 derive_more.workspace = true

--- a/tools/shuttle/Cargo.toml
+++ b/tools/shuttle/Cargo.toml
@@ -18,9 +18,6 @@ warp.workspace = true
 rust-ipfs = { workspace = true }
 libipld.workspace = true
 uuid = { workspace = true, features = ["serde", "v4"] }
-tokio = { workspace = true }
-tokio-util = { workspace = true, features = ["full"] }
-tokio-stream = { workspace = true, features = ["net"] }
 futures.workspace = true
 async-trait.workspace = true
 async-stream.workspace = true
@@ -43,3 +40,18 @@ dotenv = "0.15"
 base64 = "0.21"
 
 bs58.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["full"] }
+tokio-stream = { workspace = true, features = ["net"] }
+gloo = "0.7"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false, features = ["sync", "macros", "io-util", "rt", "time"]}
+tokio-util = { workspace = true}
+tokio-stream = { workspace = true}
+wasm-bindgen = { version = "0.2" }
+gloo = "0.7"
+web-sys = { version = "0.3" }
+js-sys = { version = "0.3" }

--- a/tools/shuttle/src/identity.rs
+++ b/tools/shuttle/src/identity.rs
@@ -8,6 +8,7 @@ use self::document::IdentityDocument;
 pub mod client;
 pub mod document;
 pub mod protocol;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]

--- a/tools/shuttle/src/lib.rs
+++ b/tools/shuttle/src/lib.rs
@@ -13,8 +13,12 @@ pub mod document;
 pub mod gateway;
 pub mod identity;
 pub mod message;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod server;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod store;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod subscription_stream;
 
 pub trait PeerTopic: Display {

--- a/tools/shuttle/src/main.rs
+++ b/tools/shuttle/src/main.rs
@@ -56,6 +56,7 @@ struct Opt {
     enable_relay_server: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenv::dotenv().ok();
@@ -123,3 +124,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/tools/shuttle/src/message.rs
+++ b/tools/shuttle/src/message.rs
@@ -1,3 +1,5 @@
 pub mod client;
 pub mod protocol;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub mod server;

--- a/tools/shuttle/src/store/root.rs
+++ b/tools/shuttle/src/store/root.rs
@@ -33,30 +33,12 @@ pub struct RootStorage {
 impl RootStorage {
     pub async fn new(ipfs: &Ipfs, path: Option<PathBuf>) -> Self {
         
-        #[cfg(not(target_arch = "wasm32"))]
         let root_cid = match path.as_ref() {
             Some(path) => tokio::fs::read(path.join(".root_v0"))
                 .await
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
                 .ok()
                 .and_then(|cid_str| cid_str.parse().ok()),
-            None => None,
-        };
-
-        #[cfg(target_arch = "wasm32")]
-        let root_cid = match path.as_ref() {
-            Some(path) => path.to_str().and_then(|key| {
-                use gloo::storage::{LocalStorage, Storage};
-                let local_storage = LocalStorage::raw();
-                local_storage.get(key).ok().and_then(|key| {
-                    key.and_then(|key|{
-                        LocalStorage::get(key).ok().and_then(|bytes: Vec<u8> |{
-                            let cid_str = String::from_utf8_lossy(&bytes).to_string();
-                            cid_str.parse().ok()
-                        })
-                    })
-                })
-            }),
             None => None,
         };
 
@@ -158,16 +140,8 @@ impl RootInner {
 
         if let Some(path) = self.path.as_ref() {
             let cid = cid.to_string();
-            #[cfg(not(target_arch = "wasm32"))] {
-                if let Err(e) = tokio::fs::write(path.join(".root_v0"), cid).await {
-                    tracing::error!("Error writing cid to file: {e}");
-                }
-            }
-            #[cfg(target_arch = "wasm32")] {
-                use gloo::storage::{LocalStorage, Storage};
-                if let Err(e) = LocalStorage::set(path.join(".root_v0").to_str().unwrap(), cid) {
-                    tracing::error!("Error writing cid to file: {e}");
-                }
+            if let Err(e) = tokio::fs::write(path.join(".root_v0"), cid).await {
+                tracing::error!("Error writing cid to file: {e}");
             }
         }
 

--- a/warp/Cargo.toml
+++ b/warp/Cargo.toml
@@ -62,6 +62,7 @@ mediatype.workspace = true
 tokio = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false, features = ["sync"]}
 wasm-bindgen = { version = "0.2" }
 gloo = "0.7"
 web-sys = { version = "0.3" }

--- a/warp/src/constellation/file.rs
+++ b/warp/src/constellation/file.rs
@@ -5,7 +5,6 @@ use derive_more::Display;
 use mediatype;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-#[cfg(not(target_arch = "wasm32"))]
 use std::io::{Read, Seek};
 use std::sync::Arc;
 use uuid::Uuid;

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::result_large_err)]
 #[allow(unused)]
+
 use std::io::{ErrorKind, Read, Write};
 
 use crate::crypto::hash::sha256_hash;

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::result_large_err)]
 #[allow(unused)]
 
-use std::io::{ErrorKind, Read, Write};
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::{Read, Write};
+
+use std::io::ErrorKind;
 
 use crate::crypto::hash::sha256_hash;
 use futures::{stream, AsyncRead, AsyncReadExt, Stream, StreamExt, TryStreamExt};

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::result_large_err)]
 #[allow(unused)]
-#[cfg(not(target_arch = "wasm32"))]
 use std::io::{ErrorKind, Read, Write};
 
 use crate::crypto::hash::sha256_hash;
@@ -578,7 +577,8 @@ mod test {
         );
         Ok(())
     }
-
+    
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn cipher_aes256gcm_async_stream_encrypt_decrypt() -> anyhow::Result<()> {
         let cipher = Cipher::from(b"this is my key");
@@ -608,6 +608,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn cipher_aes256gcm_async_read_to_stream_encrypt_decrypt() -> anyhow::Result<()> {
         use futures::io::Cursor;
@@ -643,6 +644,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn cipher_aes256gcm_async_stream_self_encrypt_decrypt() -> anyhow::Result<()> {
         let message = b"this is my message";

--- a/warp/src/crypto/hash.rs
+++ b/warp/src/crypto/hash.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::result_large_err)]
 use digest::Digest;
 use sha2::Sha256;
-#[cfg(not(target_arch = "wasm32"))]
 use std::io::Read;
 
 use crate::error::Error;
@@ -9,7 +8,6 @@ use crate::error::Error;
 #[allow(dead_code)]
 type Result<T> = std::result::Result<T, Error>;
 
-#[cfg(not(target_arch = "wasm32"))]
 pub fn sha256_hash_stream(reader: &mut impl Read, salt: Option<&[u8]>) -> Result<Vec<u8>> {
     let mut hasher = Sha256::new();
     std::io::copy(reader, &mut hasher)?;

--- a/warp/src/crypto/multihash.rs
+++ b/warp/src/crypto/multihash.rs
@@ -52,7 +52,6 @@ macro_rules! create_hash_functions {
                 multihash_slice::<$code>(Code::$code, slice).map_err(crate::error::Error::from)
             }
 
-            #[cfg(not(target_arch = "wasm32"))]
             pub fn [<$code:lower _multihash_file>]<P: AsRef<std::path::Path>>(file: P) -> Result<Vec<u8>, crate::error::Error> {
                 multihash_file::<$code, _>(Code::$code, file).map_err(crate::error::Error::from)
             }
@@ -67,7 +66,6 @@ pub fn multihash_slice<H: Hasher + Default>(code: Code, slice: &[u8]) -> anyhow:
     Ok(digest.to_bytes())
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub fn multihash_reader<H: Hasher + Default + std::io::Write>(
     code: Code,
     reader: &mut impl std::io::Read,
@@ -78,7 +76,6 @@ pub fn multihash_reader<H: Hasher + Default + std::io::Write>(
     Ok(digest.to_bytes())
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 pub fn multihash_file<H: Hasher + Default, P: AsRef<std::path::Path>>(
     code: Code,
     file: P,

--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -552,7 +552,9 @@ impl TesseractInner {
         }
         Ok(())
     }
+}
 
+impl TesseractInner {
     fn export(&self) -> Result<HashMap<String, String>> {
         if !self.is_unlock() {
             return Err(Error::TesseractLocked);
@@ -571,9 +573,7 @@ impl TesseractInner {
         }
         Ok(map)
     }
-}
 
-impl TesseractInner {
     fn set_autosave(&self) {
         let autosave = self.autosave_enabled();
         self.autosave.store(!autosave, Ordering::Relaxed);
@@ -775,7 +775,7 @@ impl TesseractInner {
         let length = LocalStorage::length();
 
         for index in 0..length {
-            let key = local_storage.key(index).unwrap().unwrap_throw();
+            let key = local_storage.key(index).unwrap().unwrap();
             let value: Vec<u8> = LocalStorage::get(&key).unwrap();
             self.internal.write().insert(key, value);
         }
@@ -904,6 +904,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn tesseract_event() -> anyhow::Result<()> {
         let tesseract = Tesseract::default();


### PR DESCRIPTION
**What this PR does** 📖

fixes some of the compilation issues on wasm. 
Package `warp` now compiles, and package `warp-ipfs` almost compiles (1 error left) 
`tools/shuttle` now uses `LocalStorage` instead of `Tokio:fs` when compiled for wasm

**Which issue(s) this PR fixes** 🔨

#494 (partially)

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
