### PR TITLE
chore: add wasm compatible fs

### DIFF
--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -38,11 +38,13 @@ bincode.workspace = true
 bytes.workspace = true
 
 shuttle = { path = "../../tools/shuttle", default-features = false }
+fs = { path = "../../tools/fs", default-features = false }
+
+tokio-util = { workspace = true }
+tokio-stream = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }
-tokio-util = { workspace = true }
-tokio-stream = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tokio = { version = "1", default-features = false, features = ["sync"]}

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -506,7 +506,7 @@ impl FileAttachmentDocument {
                         };
                     },
                     rust_ipfs::unixfs::UnixfsStatus::FailedStatus { written, error, .. } => {
-                        if let Err(e) = tokio::fs::remove_file(&path).await {
+                        if let Err(e) = fs::remove_file(&path).await {
                             tracing::error!("Error removing file: {e}");
                         }
                         let error = error.map(Error::Any).unwrap_or(Error::Other);

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -19,7 +19,7 @@ pub struct IdentityCache {
 impl IdentityCache {
     pub async fn new(ipfs: &Ipfs, path: Option<&PathBuf>) -> Self {
         let list = match path.as_ref() {
-            Some(path) => tokio::fs::read(path.join(".cache_id_v0"))
+            Some(path) => fs::read(path.join(".cache_id_v0"))
                 .await
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
                 .ok()
@@ -127,7 +127,7 @@ impl IdentityCacheInner {
 
                 if let Some(path) = self.path.as_ref() {
                     let cid = cid.to_string();
-                    if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
+                    if let Err(e) = fs::write(path.join(".cache_id_v0"), cid).await {
                         tracing::error!("Error writing cid to file: {e}");
                     }
                 }
@@ -160,7 +160,7 @@ impl IdentityCacheInner {
 
                 if let Some(path) = self.path.as_ref() {
                     let cid = cid.to_string();
-                    if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
+                    if let Err(e) = fs::write(path.join(".cache_id_v0"), cid).await {
                         tracing::error!("Error writing cid to file: {e}");
                     }
                 }
@@ -227,7 +227,7 @@ impl IdentityCacheInner {
 
         if let Some(path) = self.path.as_ref() {
             let cid = cid.to_string();
-            if let Err(e) = tokio::fs::write(path.join(".cache_id_v0"), cid).await {
+            if let Err(e) = fs::write(path.join(".cache_id_v0"), cid).await {
                 tracing::error!("Error writing cid to file: {e}");
             }
         }

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -31,7 +31,7 @@ pub struct RootDocumentMap {
 impl RootDocumentMap {
     pub async fn new(ipfs: &Ipfs, keypair: Arc<DID>, path: Option<&PathBuf>) -> Self {
         let cid = match path.as_ref() {
-            Some(path) => tokio::fs::read(path.join(".id"))
+            Some(path) => fs::read(path.join(".id"))
                 .await
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
                 .ok()
@@ -321,7 +321,7 @@ impl RootDocumentInner {
 
         if let Some(path) = self.path.as_ref() {
             let cid = root_cid.to_string();
-            if let Err(e) = tokio::fs::write(path.join(".id"), cid).await {
+            if let Err(e) = fs::write(path.join(".id"), cid).await {
                 tracing::error!("Error writing to '.id': {e}.")
             }
         }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -49,7 +49,7 @@ impl FileStore {
     ) -> Result<Self, Error> {
         if let Some(path) = config.path.as_ref() {
             if !path.exists() {
-                tokio::fs::create_dir_all(path).await?;
+                fs::create_dir_all(path).await?;
             }
         }
 
@@ -535,7 +535,7 @@ impl FileTask {
             return Err(Error::FileNotFound);
         }
 
-        let file_size = tokio::fs::metadata(&path).await?.len();
+        let file_size = fs::file_size(&path).await?;
 
         if self.current_size() + (file_size as usize) >= self.max_size() {
             return Err(Error::InvalidLength {

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -367,7 +367,7 @@ impl IdentityStore {
     ) -> Result<Self, Error> {
         if let Some(path) = config.path.as_ref() {
             if !path.exists() {
-                tokio::fs::create_dir_all(path).await?;
+                fs::create_dir_all(path).await?;
             }
         }
         let config = config.clone();

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -96,7 +96,7 @@ impl MessageStore {
 
         if let Some(path) = path.as_ref() {
             if !path.exists() {
-                tokio::fs::create_dir_all(path)
+                fs::create_dir_all(path)
                     .await
                     .expect("able to create directory");
             }
@@ -642,7 +642,7 @@ impl ConversationInner {
             if !mid_file.is_file() {
                 return Ok(());
             }
-            let cid = tokio::fs::read(&mid_file)
+            let cid = fs::read(&mid_file)
                 .await
                 .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
                 .and_then(|cid_str| {
@@ -666,7 +666,7 @@ impl ConversationInner {
                 let _ = self.root.set_conversation_document(document).await;
             }
 
-            _ = tokio::fs::remove_file(mid_file).await;
+            _ = fs::remove_file(mid_file).await;
         }
         Ok(())
     }
@@ -682,7 +682,7 @@ impl ConversationInner {
         }
 
         if let Some(path) = self.path.as_ref() {
-            if let Ok(data) = tokio::fs::read(path.join(".messaging_queue"))
+            if let Ok(data) = fs::read(path.join(".messaging_queue"))
                 .and_then(|data| async move {
                     serde_json::from_slice(&data)
                         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
@@ -1213,7 +1213,7 @@ impl ConversationInner {
                 }
             };
 
-            if let Err(e) = tokio::fs::write(path.join(".messaging_queue"), bytes).await {
+            if let Err(e) = fs::write(path.join(".messaging_queue"), bytes).await {
                 error!("Error saving queue: {e}");
             }
         }

--- a/extensions/warp-ipfs/src/store/queue.rs
+++ b/extensions/warp-ipfs/src/store/queue.rs
@@ -130,7 +130,7 @@ impl Queue {
 impl Queue {
     pub async fn load(&self) -> Result<(), Error> {
         if let Some(path) = self.path.as_ref() {
-            let data = tokio::fs::read(path.join(".request_queue")).await?;
+            let data = fs::read(path.join(".request_queue")).await?;
 
             let prikey =
                 Ed25519KeyPair::from_secret_key(&self.did.private_key_bytes()).get_x25519();
@@ -182,7 +182,7 @@ impl Queue {
                 }
             };
 
-            if let Err(e) = tokio::fs::write(path.join(".request_queue"), data).await {
+            if let Err(e) = fs::write(path.join(".request_queue"), data).await {
                 error!("Error saving queue: {e}");
             }
         }

--- a/tools/fs/Cargo.toml
+++ b/tools/fs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo = "0.7"

--- a/tools/fs/README.md
+++ b/tools/fs/README.md
@@ -1,0 +1,3 @@
+# fs
+
+This crate provides functions to interact with the filesystem in a cross platform way. On `wasm32` targets it uses `LocalStorage`, otherwise it uses `tokio::fs`

--- a/tools/fs/src/lib.rs
+++ b/tools/fs/src/lib.rs
@@ -1,0 +1,66 @@
+use std::{io, path::Path};
+
+#[cfg(target_arch = "wasm32")]
+use gloo::storage::{LocalStorage, Storage};
+
+/// Read the contents of the file at path
+pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::fs::read(path).await;
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let path = path.as_ref().to_str().ok_or(io::ErrorKind::InvalidInput)?;
+        match LocalStorage::get(&path) {
+            Ok(ok) => Ok(ok),
+            Err(e) => Err(io::Error::other(e)),
+        }
+    }
+}
+
+/// Write the contents of the file at path
+pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::fs::write(path, contents).await;
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let path = path.as_ref().to_str().ok_or(io::ErrorKind::InvalidInput)?;
+        match LocalStorage::set(path, contents.as_ref().to_owned()) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(io::Error::other(e)),
+        }
+    }
+}
+
+/// Create all directories in path
+pub async fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::fs::create_dir_all(path).await;
+
+    //Dirs don't need to be created in wasm since we are using the path as a key in LocalStorage
+    #[cfg(target_arch = "wasm32")]
+    Ok(())
+}
+
+/// Delete the file at path
+pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return tokio::fs::remove_file(path).await;
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let path = path.as_ref().to_str().ok_or(io::ErrorKind::InvalidInput)?;
+        LocalStorage::delete(path);
+        Ok(())
+    }
+}
+
+/// Get the size of the file at path
+pub async fn file_size(path: impl AsRef<Path>) -> io::Result<usize> {
+    #[cfg(not(target_arch = "wasm32"))]
+    return Ok(tokio::fs::metadata(&path).await?.len() as usize);
+
+    #[cfg(target_arch = "wasm32")]
+    Ok(read(path).await?.len())
+}

--- a/tools/shuttle/src/store/root.rs
+++ b/tools/shuttle/src/store/root.rs
@@ -32,7 +32,6 @@ pub struct RootStorage {
 
 impl RootStorage {
     pub async fn new(ipfs: &Ipfs, path: Option<PathBuf>) -> Self {
-        
         let root_cid = match path.as_ref() {
             Some(path) => tokio::fs::read(path.join(".root_v0"))
                 .await

--- a/warp/src/crypto/cipher.rs
+++ b/warp/src/crypto/cipher.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::result_large_err)]
 #[allow(unused)]
-
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{Read, Write};
 
@@ -581,7 +580,7 @@ mod test {
         );
         Ok(())
     }
-    
+
     #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn cipher_aes256gcm_async_stream_encrypt_decrypt() -> anyhow::Result<()> {


### PR DESCRIPTION
**What this PR does** 📖

Adds `tools/fs` crate which provides functions to interact with the filesystem in a cross platform way.
In `warp-ipfs` extension, replaces most calls to `tokio::fs::` functions with `tools/fs` equivalent.

**Which issue(s) this PR fixes** 🔨

#494 (partially)

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
