### PR TITLE
chore: fix the rest of warp-ipfs wasm compile errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ resolver = "2"
 
 # Async and futures crates
 futures = { version = "0.3", default-features = false, features = ["std"] }
+futures-io = "0.3"
+futures-util = "0.3"
 async-trait = { version = "0.1" }
 async-stream = "0.3"
 async-broadcast = "0.5"
@@ -76,9 +78,11 @@ tracing = { version = "0.1" }
 either = "1"
 void = "1"
 
-#ipfs dependency
+# ipfs dependency
 rust-ipfs = "0.11.5"
 
+# wasm crates
+gloo = "0.7"
 
 # Blink related crates
 # av-data is needed to use libaom. need to ensure that Warp and libaom use the same version of av-data

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -286,7 +286,10 @@ impl Default for Config {
             store_setting: Default::default(),
             enable_relay: true,
             save_phrase: false,
+            #[cfg(not(target_arch = "wasm32"))] // this number would overflow on wasm32
             max_storage_size: Some(10 * 1024 * 1024 * 1024),
+            #[cfg(target_arch = "wasm32")]
+            max_storage_size: Some(3 * 1024 * 1024 * 1024),
             max_file_size: Some(50 * 1024 * 1024),
             thumbnail_size: (128, 128),
             chunking: None,

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -868,11 +868,9 @@ impl MultiPass for WarpIpfs {
                     )));
                 }
 
-                let file = tokio::fs::File::open(&path).await?;
+                let file = fs::File::open(&path).await?;
 
-                let metadata = file.metadata().await?;
-
-                let len = metadata.len() as _;
+                let len = file.file_size().await?;
 
                 if len == 0 || len > 2 * 1024 * 1024 {
                     return Err(Error::InvalidLength {
@@ -1007,11 +1005,9 @@ impl MultiPass for WarpIpfs {
                     )));
                 }
 
-                let file = tokio::fs::File::open(&path).await?;
+                let file = fs::File::open(&path).await?;
 
-                let metadata = file.metadata().await?;
-
-                let len = metadata.len() as _;
+                let len = file.file_size().await?;
 
                 if len == 0 || len > 2 * 1024 * 1024 {
                     return Err(Error::InvalidLength {

--- a/tools/fs/Cargo.toml
+++ b/tools/fs/Cargo.toml
@@ -9,10 +9,14 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-
+futures-io = { workspace = true}
+futures-util = { workspace = true, features = ["io"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }
+tokio-util = { workspace = true, features = ["compat"]}
+tokio-stream = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-gloo = "0.7"
+gloo = { workspace = true }
+

--- a/tools/fs/src/lib.rs
+++ b/tools/fs/src/lib.rs
@@ -64,3 +64,130 @@ pub async fn file_size(path: impl AsRef<Path>) -> io::Result<usize> {
     #[cfg(target_arch = "wasm32")]
     Ok(read(path).await?.len())
 }
+
+/// A reference to an open file on the filesystem. On wasm, this instead holds a Vec<u8> of the data already read from LocalStorage.
+pub struct File {
+    #[cfg(not(target_arch = "wasm32"))]
+    file: tokio::fs::File,
+    #[cfg(target_arch = "wasm32")]
+    file: Vec<u8>,
+}
+
+impl File {
+    /// Attempts to open a file in read-only mode. On wasm, this reads the file's data from LocalStorage.
+    pub async fn open(path: impl AsRef<Path>) -> io::Result<File> {
+        #[cfg(not(target_arch = "wasm32"))]
+        return Ok(Self {
+            file: tokio::fs::File::open(&path).await?,
+        });
+
+        #[cfg(target_arch = "wasm32")]
+        Ok(Self {
+            file: read(path).await?,
+        })
+    }
+    /// Returns the size of the file contents
+    pub async fn file_size(&self) -> io::Result<usize> {
+        #[cfg(not(target_arch = "wasm32"))]
+        return Ok(self.file.metadata().await?.len() as usize);
+
+        #[cfg(target_arch = "wasm32")]
+        Ok(self.file.len())
+    }
+    /// Wraps self with a compatibility layer that implements futures_io::AsyncRead.
+    pub fn compat(self) -> impl futures_io::AsyncRead {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            use tokio_util::compat::TokioAsyncReadCompatExt;
+            return self.file.compat();
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            LocalStorageReader::new(self.file)
+        }
+    }
+}
+
+/// Allows some arbitrary data to be read with AsyncRead. We needed this to be able use data from LocalStorage in place of streaming a file from the filesystem.
+struct LocalStorageReader {
+    data: Vec<u8>,
+    bytes_read: usize,
+}
+impl LocalStorageReader {
+    /// Create a new LocalStorageReader
+    fn new(data: Vec<u8>) -> Self {
+        Self {
+            data,
+            bytes_read: 0,
+        }
+    }
+}
+impl futures_io::AsyncRead for LocalStorageReader {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<io::Result<usize>> {
+        // calculate how many bytes we can read from self.data to put into the buffer
+        let bytes_to_read = std::cmp::min(self.data.len() - self.bytes_read, buf.len());
+        // read bytes from self.data and write them into the buffer
+        for i in 0..bytes_to_read {
+            buf[i] = self.data[self.bytes_read + i]
+        }
+        // update our tracking of how many bytes we've read from self.data
+        self.get_mut().bytes_read += bytes_to_read;
+        // return how many bytes were written into the buffer
+        core::task::Poll::Ready(Ok(bytes_to_read))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::File;
+    use futures_util::AsyncReadExt;
+
+    /// tests that our LocalStorageReader properly reads data.
+    #[tokio::test]
+    async fn file_compat_reader() -> futures_io::Result<()> {
+        let path = "test_file.txt";
+        let contents = "hello";
+
+        // Create file, read it and compare result
+        crate::write(path, contents).await?;
+        let data = crate::read(path).await?;
+        assert_eq!(
+            data,
+            contents.as_bytes(),
+            "expected data to be {:?}",
+            contents.as_bytes()
+        );
+
+        // use the data to stream file contents, then compare the stream result
+        let mut reader = crate::LocalStorageReader::new(data.clone());
+        let buffer_size = 2;
+        let mut buffer = vec![0u8; buffer_size];
+        let mut stream_result = vec![];
+        loop {
+            match reader.read(&mut buffer).await {
+                Ok(n) => {
+                    stream_result.append(&mut buffer.clone()[0..n].to_vec());
+                    if n < buffer_size {
+                        break;
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        assert_eq!(
+            stream_result, data,
+            "expected stream_result to be {:?}",
+            data
+        );
+
+        // Cleanup
+        crate::remove_file(path).await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
**What this PR does** 📖

Fixes the rest of `warp-ipfs` compile errors when targeting wasm

**Which issue(s) this PR fixes** 🔨

#494 
Note: `warp-blink-wrtc` does not yet compile, however `warp` and `warp-ipfs` do.

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
