### PR TITLE
chore: Add wasm-bindgen-futures, add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,9 @@ hex = "0.4"
 libipld = { version = "0.16", features = ["serde-codec"] }
 bytes = "1"
 bincode = "1"
-image = "0.24"
+image = { version = "0.25.1", default-features = false, features = [
+    "default-formats",
+] }
 mediatype = { version = "0.19", features = ["serde"] }
 
 # Misc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,12 @@ repository = "https://github.com/Satellite-im/Warp"
 
 
 [workspace]
-members = ["extensions/*", "warp", "tools/*"]
+members = [
+    "extensions/*",
+    "warp",
+    "tools/*",
+    "extensions/warp-ipfs/examples/wasm-ipfs-identity",
+]
 exclude = ["deprecated/*", "tools/opencv-test", "tools/video-codec-cli"]
 
 resolver = "2"
@@ -51,7 +56,11 @@ parking_lot = { version = "0.12" }
 once_cell = "1.16"
 
 # Time crate
-chrono = { version = "~0.4.27", default-features = false, features = ["serde", "wasmbind", "now"] }
+chrono = { version = "~0.4.27", default-features = false, features = [
+    "serde",
+    "wasmbind",
+    "now",
+] }
 
 # Encoding and Serializing Crates
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -43,11 +43,14 @@ fs = { path = "../../tools/fs", default-features = false }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }
 
+web-time = "1.1.0"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tokio = { version = "1", default-features = false, features = ["sync"]}
+tokio = { version = "1", default-features = false, features = ["sync"] }
+wasm-bindgen-futures = { version = "0.4" }
 
 [dev-dependencies]
 derive_more.workspace = true

--- a/extensions/warp-ipfs/examples/wasm-ipfs-identity/Cargo.toml
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-identity/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "wasm-ipfs-identity"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+futures = "0.3"
+wasm-bindgen = "0.2.90"
+wasm-bindgen-futures = "0.4.42"
+web-sys = { version = "0.3", features = ['Document', 'Element', 'HtmlElement', 'Node', 'Response', 'Window', "console"] }
+js-sys = "0.3.69"
+console_error_panic_hook = "0.1.7"
+serde_json.workspace = true
+serde.workspace = true
+warp.workspace = true
+warp-ipfs.workspace = true

--- a/extensions/warp-ipfs/examples/wasm-ipfs-identity/readme.md
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-identity/readme.md
@@ -1,0 +1,8 @@
+# wasm-ipfs-identity
+
+To build do the following:
+
+1. Install wasm32-unknown-unknown target by doing `rustup target add wasm32-unknown-unknown`
+2. Install wasm-pack by doing `cargo install wasm-pack`
+3. Run `wasm-pack build --target web --out-dir static`
+4. Use a web server to serve the content from `static` directory. E.g with python install you can do `python3 -m http.server -d ./static`

--- a/extensions/warp-ipfs/examples/wasm-ipfs-identity/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-identity/src/lib.rs
@@ -1,0 +1,54 @@
+use warp::error::Error;
+use warp::multipass::identity::IdentityUpdate;
+use warp::multipass::MultiPass;
+use warp::tesseract::Tesseract;
+use warp_ipfs::config::Config;
+use warp_ipfs::WarpIpfsBuilder;
+use wasm_bindgen::prelude::*;
+
+macro_rules! web_log {
+    ( $( $t:tt )* ) => {
+        web_sys::console::log_1(&format!( $( $t )* ).into());
+    }
+}
+
+async fn update_name(account: &mut dyn MultiPass, name: &str) -> Result<(), Error> {
+    account
+        .update_identity(IdentityUpdate::Username(name.to_string()))
+        .await?;
+    let ident = account.get_own_identity().await?;
+    web_log!("Updated Identity: {}", serde_json::to_string(&ident)?);
+    Ok(())
+}
+
+async fn update_status(account: &mut dyn MultiPass, status: &str) -> Result<(), Error> {
+    account
+        .update_identity(IdentityUpdate::StatusMessage(Some(status.to_string())))
+        .await?;
+    let ident = account.get_own_identity().await?;
+    web_log!("Updated Identity: {}", serde_json::to_string(&ident)?);
+    Ok(())
+}
+
+#[wasm_bindgen]
+pub async fn run() -> Result<(), JsError> {
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    let tesseract = Tesseract::default();
+    tesseract.unlock(b"super duper pass")?;
+
+    let (mut identity, _, _) = WarpIpfsBuilder::default()
+        .set_config(Config::minimal_testing())
+        .set_tesseract(tesseract)
+        .finalize()
+        .await?;
+
+    let profile = identity.create_identity(None, None).await?;
+
+    let ident = profile.identity();
+
+    web_log!("Current Identity: {}", serde_json::to_string(&ident)?);
+
+    update_name(&mut *identity, &warp::multipass::generator::generate_name()).await?;
+    update_status(&mut *identity, "New status message").await?;
+    Ok(())
+}

--- a/extensions/warp-ipfs/examples/wasm-ipfs-identity/static/index.html
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-identity/static/index.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <title>Identity Example</title>
+    </head>
+    <body>
+        <script type="module" defer>
+            import init, { run } from "./wasm_ipfs_identity.js"
+            await init();
+            run();
+        </script>
+    </body>
+</html>

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -274,10 +274,13 @@ impl Default for Config {
         Config {
             path: None,
             bootstrap: Bootstrap::Ipfs,
+            #[cfg(not(target_arch = "wasm32"))]
             listen_on: ["/ip4/0.0.0.0/tcp/0", "/ip4/0.0.0.0/udp/0/quic-v1"]
                 .iter()
                 .filter_map(|s| Multiaddr::from_str(s).ok())
                 .collect::<Vec<_>>(),
+            #[cfg(target_arch = "wasm32")]
+            listen_on: vec![],
             ipfs_setting: IpfsSetting {
                 mdns: Mdns { enable: true },
                 bootstrap: false,
@@ -286,7 +289,10 @@ impl Default for Config {
             store_setting: Default::default(),
             enable_relay: true,
             save_phrase: false,
+            #[cfg(not(target_arch = "wasm32"))]
             max_storage_size: Some(10 * 1024 * 1024 * 1024),
+            #[cfg(target_arch = "wasm32")]
+            max_storage_size: Some(50 * 1024 * 1024),
             max_file_size: Some(50 * 1024 * 1024),
             thumbnail_size: (128, 128),
             chunking: None,
@@ -318,6 +324,26 @@ impl Config {
                     namespace: None,
                     discovery_type: Default::default(),
                 },
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// Minimal testing configuration. Used for in-memory
+    pub fn minimal_testing() -> Config {
+        Config {
+            bootstrap: Bootstrap::Ipfs,
+            ipfs_setting: IpfsSetting {
+                bootstrap: true,
+                mdns: Mdns { enable: true },
+                relay_client: RelayClient {
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            store_setting: StoreSetting {
+                discovery: Discovery::None,
                 ..Default::default()
             },
             ..Default::default()

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use config::Config;
 use futures::channel::mpsc::channel;
 use futures::stream::BoxStream;
+#[allow(unused_imports)] //TODO: Remove
 use futures::{AsyncReadExt, StreamExt};
 use ipfs::libp2p::core::muxing::StreamMuxerBox;
 use ipfs::libp2p::core::transport::{Boxed, MemoryTransport, OrTransport};
@@ -33,7 +34,7 @@ use store::identity::{IdentityStore, LookupBy};
 use store::message::MessageStore;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_util::compat::TokioAsyncReadCompatExt;
-use tracing::{debug, error, info, trace, warn, Instrument, Span};
+use tracing::{error, info, warn, Instrument, Span};
 use utils::ExtensionType;
 use uuid::Uuid;
 use warp::constellation::directory::Directory;
@@ -788,6 +789,7 @@ impl MultiPass for WarpIpfs {
     async fn update_identity(&mut self, option: IdentityUpdate) -> Result<(), Error> {
         let mut store = self.identity_store(true).await?;
         let mut identity = store.own_identity_document().await?;
+        #[allow(unused_variables)] // due to stub; TODO: Remove
         let ipfs = self.ipfs()?;
 
         let mut old_cid = None;
@@ -819,7 +821,7 @@ impl MultiPass for WarpIpfs {
                         });
                     }
 
-                    trace!("image size = {}", len);
+                    tracing::trace!("image size = {}", len);
 
                     let (data, format) = tokio::task::spawn_blocking(move || {
                         let cursor = std::io::Cursor::new(data);
@@ -847,11 +849,13 @@ impl MultiPass for WarpIpfs {
                     )
                     .await?;
 
-                    debug!("Image cid: {cid}");
+                    tracing::debug!("Image cid: {cid}");
 
                     if let Some(picture_cid) = identity.metadata.profile_picture {
                         if picture_cid == cid {
-                            debug!("Picture is already on document. Not updating identity");
+                            tracing::debug!(
+                                "Picture is already on document. Not updating identity"
+                            );
                             return Ok(());
                         }
 
@@ -900,7 +904,7 @@ impl MultiPass for WarpIpfs {
                         .map(ExtensionType::from)
                         .unwrap_or(ExtensionType::Other);
 
-                    trace!("image size = {}", len);
+                    tracing::trace!("image size = {}", len);
 
                     let stream = async_stream::stream! {
                         let mut reader = file.compat();
@@ -929,11 +933,13 @@ impl MultiPass for WarpIpfs {
                     )
                     .await?;
 
-                    debug!("Image cid: {cid}");
+                    tracing::debug!("Image cid: {cid}");
 
                     if let Some(picture_cid) = identity.metadata.profile_picture {
                         if picture_cid == cid {
-                            debug!("Picture is already on document. Not updating identity");
+                            tracing::debug!(
+                                "Picture is already on document. Not updating identity"
+                            );
                             return Ok(());
                         }
 
@@ -972,7 +978,7 @@ impl MultiPass for WarpIpfs {
                         });
                     }
 
-                    trace!("image size = {}", len);
+                    tracing::trace!("image size = {}", len);
 
                     let (data, format) = tokio::task::spawn_blocking(move || {
                         let cursor = std::io::Cursor::new(data);
@@ -1000,11 +1006,11 @@ impl MultiPass for WarpIpfs {
                     )
                     .await?;
 
-                    debug!("Image cid: {cid}");
+                    tracing::debug!("Image cid: {cid}");
 
                     if let Some(banner_cid) = identity.metadata.profile_banner {
                         if banner_cid == cid {
-                            debug!("Banner is already on document. Not updating identity");
+                            tracing::debug!("Banner is already on document. Not updating identity");
                             return Ok(());
                         }
 
@@ -1053,7 +1059,7 @@ impl MultiPass for WarpIpfs {
                         .map(ExtensionType::from)
                         .unwrap_or(ExtensionType::Other);
 
-                    trace!("image size = {}", len);
+                    tracing::trace!("image size = {}", len);
 
                     let stream = async_stream::stream! {
                         let mut reader = file.compat();
@@ -1082,11 +1088,11 @@ impl MultiPass for WarpIpfs {
                     )
                     .await?;
 
-                    debug!("Image cid: {cid}");
+                    tracing::debug!("Image cid: {cid}");
 
                     if let Some(banner_cid) = identity.metadata.profile_banner {
                         if banner_cid == cid {
-                            debug!("Banner is already on document. Not updating identity");
+                            tracing::debug!("Banner is already on document. Not updating identity");
                             return Ok(());
                         }
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -315,6 +315,15 @@ impl WarpIpfs {
                 ..Default::default()
             });
 
+        // TODO: Uncomment for persistence on wasm once config option is added
+        // #[cfg(target_arch = "wasm32")]
+        // {
+        //     // Namespace will used the public key to prevent conflicts between multiple instances during testing.
+        //     uninitialized = uninitialized.set_storage_type(rust_ipfs::StorageType::IndexedDb {
+        //         namespace: Some(keypair.public().to_peer_id().to_string()),
+        //     });
+        // }
+
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(path) = self.inner.config.path.as_ref() {
             info!("Instance will be persistent");
@@ -399,6 +408,8 @@ impl WarpIpfs {
             }
         }
 
+        //TODO: Remove attr when bug is fixed upstream
+        #[cfg(not(target_arch = "wasm32"))]
         if self.inner.config.enable_relay {
             let mut relay_peers = HashSet::new();
 

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -1,0 +1,5 @@
+#[cfg(not(target_arch = "wasm32"))]
+pub use tokio::task::spawn;
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm_bindgen_futures::spawn_local as spawn;

--- a/extensions/warp-ipfs/src/store/event_subscription.rs
+++ b/extensions/warp-ipfs/src/store/event_subscription.rs
@@ -43,7 +43,7 @@ impl<T: Clone + Debug + Send + 'static> EventSubscription<T> {
 
         let token = CancellationToken::new();
         let drop_guard = token.clone().drop_guard();
-        tokio::spawn(async move {
+        crate::rt::spawn(async move {
             select! {
                 _ = token.cancelled() => {}
                 _ = task.run() => {}

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -92,7 +92,7 @@ impl FileStore {
         let token = CancellationToken::new();
         let _guard = Arc::new(token.clone().drop_guard());
 
-        tokio::spawn(async move {
+        crate::rt::spawn(async move {
             tokio::select! {
                 _ = task.run().instrument(span) => {}
                 _ = token.cancelled() => {}

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -16,11 +16,11 @@ use libipld::Cid;
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
 use shuttle::identity::{RequestEvent, RequestPayload};
-use web_time::Instant;
 use std::{
     collections::{HashMap, HashSet},
     time::Duration,
 };
+use web_time::Instant;
 
 use tokio::sync::RwLock;
 use tracing::{error, warn, Span};

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -12,8 +12,10 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
     sync::Arc,
-    time::{Duration, Instant},
+    time::Duration,
 };
+
+use web_time::Instant;
 
 use futures::{
     channel::{mpsc, oneshot},
@@ -148,7 +150,7 @@ impl MessageStore {
             conversation_mailbox_task_rx,
         };
 
-        tokio::spawn({
+        crate::rt::spawn({
             async move {
                 select! {
                     _ = token.cancelled() => {}
@@ -792,7 +794,7 @@ impl ConversationInner {
                 };
 
 
-                tokio::spawn(async move {
+                crate::rt::spawn(async move {
                     let result = fut.await;
                     let _ = tx.send(result).await;
                 });

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -115,6 +115,7 @@ pub(crate) async fn migrate_to_ds<P: AsRef<std::path::Path>>(
     ipfs: &rust_ipfs::Ipfs,
     path: P,
 ) -> Result<(), Error> {
+    use ds_key::DataStoreKey;
     use libipld::Cid;
 
     let path = path.as_ref();
@@ -172,10 +173,7 @@ pub(crate) async fn migrate_to_ds<P: AsRef<std::path::Path>>(
 
 const SHUTTLE_TIMEOUT: Duration = Duration::from_secs(60);
 
-use self::{
-    conversation::{ConversationDocument, MessageDocument},
-    ds_key::DataStoreKey,
-};
+use self::conversation::{ConversationDocument, MessageDocument};
 
 pub trait PeerIdExt {
     fn to_public_key(&self) -> Result<PublicKey, anyhow::Error>;

--- a/extensions/warp-ipfs/src/store/queue.rs
+++ b/extensions/warp-ipfs/src/store/queue.rs
@@ -1,12 +1,6 @@
-use std::{
-    collections::HashMap,
-    path::PathBuf,
-    sync::Arc,
-    time::{Duration, Instant},
-};
-
 use futures::{channel::mpsc, StreamExt};
 use rust_ipfs::Ipfs;
+use std::{collections::HashMap, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{sync::RwLock, task::JoinHandle};
 use tracing::error;
 use warp::{
@@ -18,6 +12,7 @@ use warp::{
     },
     error::Error,
 };
+use web_time::Instant;
 
 use crate::store::{ecdh_encrypt, topics::PeerTopic, PeerIdExt};
 
@@ -57,7 +52,7 @@ impl Queue {
             discovery,
         };
 
-        tokio::spawn({
+        crate::rt::spawn({
             let queue = queue.clone();
 
             async move {
@@ -228,73 +223,76 @@ impl QueueEntry {
         let task = tokio::spawn({
             let entry = entry.clone();
             async move {
-                let mut retry = 10;
-                loop {
-                    let entry = entry.clone();
-                    //TODO: Replace with future event to detect connection/disconnection from peer as well as pubsub subscribing event
-                    let (connection_result, peers_result) = futures::join!(
-                        connected_to_peer(&entry.ipfs, entry.recipient.clone()),
-                        entry.ipfs.pubsub_peers(Some(entry.recipient.inbox()))
-                    );
-
-                    if matches!(
-                        connection_result,
-                        Ok(crate::store::PeerConnectionType::Connected)
-                    ) && peers_result
-                        .map(|list| {
-                            list.iter()
-                                .filter_map(|peer_id| peer_id.to_did().ok())
-                                .any(|did| did.eq(&entry.recipient))
-                        })
-                        .unwrap_or_default()
-                    {
-                        tracing::info!(
-                            "{} is connected. Attempting to send request",
-                            entry.recipient.clone()
-                        );
+                _ = async {
+                    let mut retry = 10;
+                    loop {
                         let entry = entry.clone();
+                        //TODO: Replace with future event to detect connection/disconnection from peer as well as pubsub subscribing event
+                        let (connection_result, peers_result) = futures::join!(
+                            connected_to_peer(&entry.ipfs, entry.recipient.clone()),
+                            entry.ipfs.pubsub_peers(Some(entry.recipient.inbox()))
+                        );
 
-                        let recipient = entry.recipient.clone();
+                        if matches!(
+                            connection_result,
+                            Ok(crate::store::PeerConnectionType::Connected)
+                        ) && peers_result
+                            .map(|list| {
+                                list.iter()
+                                    .filter_map(|peer_id| peer_id.to_did().ok())
+                                    .any(|did| did.eq(&entry.recipient))
+                            })
+                            .unwrap_or_default()
+                        {
+                            tracing::info!(
+                                "{} is connected. Attempting to send request",
+                                entry.recipient.clone()
+                            );
+                            let entry = entry.clone();
 
-                        let res = async move {
-                            let kp = &*entry.did;
-                            let payload_bytes = serde_json::to_vec(&entry.item)?;
+                            let recipient = entry.recipient.clone();
 
-                            let bytes = ecdh_encrypt(kp, Some(&recipient), payload_bytes)?;
+                            let res = async move {
+                                let kp = &*entry.did;
+                                let payload_bytes = serde_json::to_vec(&entry.item)?;
 
-                            tracing::trace!("Payload size: {} bytes", bytes.len());
+                                let bytes = ecdh_encrypt(kp, Some(&recipient), payload_bytes)?;
 
-                            tracing::info!("Sending request to {}", recipient);
+                                tracing::trace!("Payload size: {} bytes", bytes.len());
 
-                            let time = Instant::now();
+                                tracing::info!("Sending request to {}", recipient);
 
-                            entry.ipfs.pubsub_publish(recipient.inbox(), bytes).await?;
+                                let time = Instant::now();
 
-                            let elapsed = time.elapsed();
+                                entry.ipfs.pubsub_publish(recipient.inbox(), bytes).await?;
 
-                            tracing::info!("took {}ms to send", elapsed.as_millis());
+                                let elapsed = time.elapsed();
 
-                            Ok::<_, anyhow::Error>(())
-                        };
+                                tracing::info!("took {}ms to send", elapsed.as_millis());
 
-                        match res.await {
-                            Ok(_) => {
-                                let _ = tx.clone().unbounded_send(entry.recipient.clone()).ok();
-                                break;
-                            }
-                            Err(e) => {
-                                tracing::error!(
-                                    "Error sending request for {}: {e}. Retrying in {}s",
-                                    &entry.recipient,
-                                    retry
-                                );
-                                tokio::time::sleep(Duration::from_secs(retry)).await;
-                                retry += 5;
+                                Ok::<_, anyhow::Error>(())
+                            };
+
+                            match res.await {
+                                Ok(_) => {
+                                    let _ = tx.clone().unbounded_send(entry.recipient.clone()).ok();
+                                    break;
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        "Error sending request for {}: {e}. Retrying in {}s",
+                                        &entry.recipient,
+                                        retry
+                                    );
+                                    tokio::time::sleep(Duration::from_secs(retry)).await;
+                                    retry += 5;
+                                }
                             }
                         }
+                        tokio::time::sleep(Duration::from_secs(1)).await;
                     }
-                    tokio::time::sleep(Duration::from_secs(1)).await;
                 }
+                .await;
             }
         });
 

--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -9,9 +9,8 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         Arc,
     },
-    time::Instant,
 };
-
+use web_time::Instant;
 use image::io::Reader as ImageReader;
 use image::ImageFormat;
 use rust_ipfs::{Ipfs, IpfsPath};

--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -1,3 +1,6 @@
+use image::io::Reader as ImageReader;
+use image::ImageFormat;
+use rust_ipfs::{Ipfs, IpfsPath};
 use std::{
     collections::BTreeMap,
     ffi::OsStr,
@@ -10,13 +13,10 @@ use std::{
         Arc,
     },
 };
-use web_time::Instant;
-use image::io::Reader as ImageReader;
-use image::ImageFormat;
-use rust_ipfs::{Ipfs, IpfsPath};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 use warp::{constellation::file::FileType, error::Error};
+use web_time::Instant;
 
 use crate::{store::document::image_dag::ImageDag, utils::ExtensionType};
 

--- a/tools/fs/src/lib.rs
+++ b/tools/fs/src/lib.rs
@@ -40,7 +40,10 @@ pub async fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
 
     //Dirs don't need to be created in wasm since we are using the path as a key in LocalStorage
     #[cfg(target_arch = "wasm32")]
-    Ok(())
+    {
+        _ = path;
+        Ok(())
+    }
 }
 
 /// Delete the file at path

--- a/warp/src/constellation/item.rs
+++ b/warp/src/constellation/item.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::result_large_err)]
-#[cfg(not(target_arch = "wasm32"))]
 use chrono::{DateTime, Utc};
 
 use serde::{Deserialize, Serialize};
@@ -110,7 +109,6 @@ impl Item {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl Item {
     /// Get id of `Item`
     pub fn id(&self) -> Uuid {

--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::result_large_err)]
 use futures::{stream::BoxStream, StreamExt};
-use std::{collections::HashMap, fmt::Debug, io::ErrorKind, sync::atomic::Ordering};
+use std::{collections::HashMap, fmt::Debug, sync::atomic::Ordering};
 use zeroize::Zeroize;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -93,7 +93,7 @@ impl Tesseract {
 
         match Self::from_file(&path) {
             Ok(tesseract) => Ok(tesseract),
-            Err(Error::IoError(e)) if e.kind() == ErrorKind::NotFound => {
+            Err(Error::IoError(e)) if e.kind() == std::io::ErrorKind::NotFound => {
                 let tesseract = Tesseract::default();
                 tesseract.inner.check.store(true, Ordering::Relaxed);
                 let file = std::fs::canonicalize(&path).unwrap_or(path);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Adds wasm-bindgen-futures
- Add a `rt` module in `warp-ipfs` to add a alias between spawning tokio and wasm-bindgen task
- Use `web-time` as a drop-in replacement for `std::time::Instant`
- Disable rayon in image due to incompatibility with wasm target

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
Relates to #494 

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- The `rt` module, while it supports spawning a task for tokio or wasm, does not return a handler for wasm side, so it is best to use for task that dont expect to return anything
- Example is added, which is based on `ipfs-identity`, which creates and update the identity. This does not use any networking bits at this time.