### PR TITLE
refactor: Move references into datastore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ either = "1"
 void = "1"
 
 #ipfs dependency
-rust-ipfs = "0.11.5"
+rust-ipfs = "0.11.8"
 
 
 # Blink related crates

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -589,11 +589,6 @@ impl WarpIpfs {
 
         let message_store = MessageStore::new(
             &ipfs,
-            self.inner
-                .config
-                .path
-                .as_ref()
-                .map(|path| path.join("messages")),
             discovery,
             filestore.clone(),
             self.raygun_tx.clone(),

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -390,6 +390,13 @@ impl WarpIpfs {
 
         let ipfs = uninitialized.start().await?;
 
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(path) = self.inner.config.path.as_ref() {
+            if let Err(e) = store::migrate_to_ds(&ipfs, path).await {
+                tracing::warn!(error = %e, "failed to migrate to datastore");
+            }
+        }
+
         if self.inner.config.enable_relay {
             let mut relay_peers = HashSet::new();
 

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -18,10 +18,12 @@ pub struct IdentityCache {
 
 impl IdentityCache {
     pub async fn new(ipfs: &Ipfs) -> Self {
+        let peer_id = ipfs.keypair().public().to_peer_id();
+        let key = format!("/identity/{peer_id}/cache");
         let list = ipfs
             .repo()
             .data_store()
-            .get(b"cache_id_v0")
+            .get(key.as_bytes())
             .await
             .unwrap_or_default()
             .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
@@ -144,11 +146,14 @@ impl IdentityCacheInner {
 
         let cid_str = cid.to_string();
 
+        let peer_id = self.ipfs.keypair().public().to_peer_id();
+        let key = format!("/identity/{peer_id}/root");
+
         if let Err(e) = self
             .ipfs
             .repo()
             .data_store()
-            .put(b"cache_id_v0", cid_str.as_bytes())
+            .put(key.as_bytes(), cid_str.as_bytes())
             .await
         {
             tracing::error!(error = %e, "unable to store cache cid");

--- a/extensions/warp-ipfs/src/store/document/cache.rs
+++ b/extensions/warp-ipfs/src/store/document/cache.rs
@@ -9,6 +9,8 @@ use rust_ipfs::{Ipfs, IpfsPath};
 use tokio::sync::RwLock;
 use warp::{crypto::DID, error::Error};
 
+use crate::store::ds_key::DataStoreKey;
+
 use super::identity::IdentityDocument;
 
 #[derive(Debug, Clone)]
@@ -18,8 +20,7 @@ pub struct IdentityCache {
 
 impl IdentityCache {
     pub async fn new(ipfs: &Ipfs) -> Self {
-        let peer_id = ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}/cache");
+        let key = ipfs.cache();
         let list = ipfs
             .repo()
             .data_store()
@@ -146,8 +147,7 @@ impl IdentityCacheInner {
 
         let cid_str = cid.to_string();
 
-        let peer_id = self.ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}/root");
+        let key = self.ipfs.cache();
 
         if let Err(e) = self
             .ipfs

--- a/extensions/warp-ipfs/src/store/document/files.rs
+++ b/extensions/warp-ipfs/src/store/document/files.rs
@@ -321,7 +321,7 @@ mod test {
     ) -> Result<FileStore, Error> {
         let key = get_keypair_did(ipfs.keypair())?;
 
-        let root_document = RootDocumentMap::new(ipfs, Arc::new(key), None).await;
+        let root_document = RootDocumentMap::new(ipfs, Arc::new(key)).await;
         let store = FileStore::new(
             ipfs.clone(),
             root_document,

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -31,7 +31,7 @@ pub struct RootDocumentMap {
 impl RootDocumentMap {
     pub async fn new(ipfs: &Ipfs, keypair: Arc<DID>) -> Self {
         let peer_id = ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}");
+        let key = format!("/identity/{peer_id}/root");
 
         let cid = ipfs
             .repo()
@@ -321,7 +321,7 @@ impl RootDocumentInner {
         let old_cid = self.cid.replace(root_cid);
 
         let peer_id = self.ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}");
+        let key = format!("/identity/{peer_id}/root");
 
         let cid_str = root_cid.to_string();
 

--- a/extensions/warp-ipfs/src/store/document/root.rs
+++ b/extensions/warp-ipfs/src/store/document/root.rs
@@ -15,8 +15,8 @@ use warp::{
 };
 
 use crate::store::{
-    conversation::ConversationDocument, ecdh_decrypt, ecdh_encrypt, identity::Request,
-    keystore::Keystore, VecExt,
+    conversation::ConversationDocument, ds_key::DataStoreKey, ecdh_decrypt, ecdh_encrypt,
+    identity::Request, keystore::Keystore, VecExt,
 };
 
 use super::{
@@ -30,8 +30,7 @@ pub struct RootDocumentMap {
 
 impl RootDocumentMap {
     pub async fn new(ipfs: &Ipfs, keypair: Arc<DID>) -> Self {
-        let peer_id = ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}/root");
+        let key = ipfs.root();
 
         let cid = ipfs
             .repo()
@@ -320,8 +319,7 @@ impl RootDocumentInner {
 
         let old_cid = self.cid.replace(root_cid);
 
-        let peer_id = self.ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}/root");
+        let key = self.ipfs.root();
 
         let cid_str = root_cid.to_string();
 

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -47,12 +47,6 @@ impl FileStore {
         constellation_tx: EventSubscription<ConstellationEventKind>,
         span: Span,
     ) -> Result<Self, Error> {
-        if let Some(path) = config.path.as_ref() {
-            if !path.exists() {
-                fs::create_dir_all(path).await?;
-            }
-        }
-
         let config = config.clone();
 
         let index = Directory::new("root");

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -372,21 +372,15 @@ impl IdentityStore {
         }
         let config = config.clone();
 
-        let identity_cache = IdentityCache::new(&ipfs, config.path.as_ref()).await;
+        let identity_cache = IdentityCache::new(&ipfs).await;
 
         let event = tx.clone();
 
         let did_key = Arc::new(did_keypair(&tesseract)?);
 
-        let root_document =
-            RootDocumentMap::new(&ipfs, did_key.clone(), config.path.as_ref()).await;
+        let root_document = RootDocumentMap::new(&ipfs, did_key.clone()).await;
 
-        let queue = Queue::new(
-            ipfs.clone(),
-            did_key.clone(),
-            config.path.clone(),
-            discovery.clone(),
-        );
+        let queue = Queue::new(ipfs.clone(), did_key.clone(), discovery.clone());
 
         let signal = Default::default();
 

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -61,7 +61,7 @@ use crate::{
     },
 };
 
-use super::{document::root::RootDocumentMap, SHUTTLE_TIMEOUT};
+use super::{document::root::RootDocumentMap, ds_key::DataStoreKey, SHUTTLE_TIMEOUT};
 
 const CHAT_DIRECTORY: &str = "chat_media";
 
@@ -639,8 +639,7 @@ impl ConversationInner {
         }
 
         let ipfs = &self.ipfs;
-        let peer_id = self.ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}/messaging_queue");
+        let key = ipfs.messaging_queue();
 
         if let Ok(data) = futures::future::ready(
             ipfs.repo()
@@ -1181,8 +1180,7 @@ impl ConversationInner {
     }
 
     async fn save_queue(&self) {
-        let peer_id = self.ipfs.keypair().public().to_peer_id();
-        let key = format!("/identity/{peer_id}/messaging_queue");
+        let key = self.ipfs.messaging_queue();
         let current_cid = self
             .ipfs
             .repo()
@@ -1207,7 +1205,7 @@ impl ConversationInner {
             .ipfs
             .repo()
             .data_store()
-            .put(b"/messaging/queue", cid_str.as_bytes())
+            .put(key.as_bytes(), cid_str.as_bytes())
             .await
         {
             tracing::error!(error = %e, "unable to save queue");

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -642,7 +642,6 @@ impl ConversationInner {
         let peer_id = self.ipfs.keypair().public().to_peer_id();
         let key = format!("/identity/{peer_id}/messaging_queue");
 
-        
         if let Ok(data) = futures::future::ready(
             ipfs.repo()
                 .data_store()

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -639,11 +639,14 @@ impl ConversationInner {
         }
 
         let ipfs = &self.ipfs;
+        let peer_id = self.ipfs.keypair().public().to_peer_id();
+        let key = format!("/identity/{peer_id}/messaging_queue");
 
+        
         if let Ok(data) = futures::future::ready(
             ipfs.repo()
                 .data_store()
-                .get(b"/messaging/queue")
+                .get(key.as_bytes())
                 .await
                 .unwrap_or_default()
                 .ok_or(Error::Other),
@@ -1179,11 +1182,13 @@ impl ConversationInner {
     }
 
     async fn save_queue(&self) {
+        let peer_id = self.ipfs.keypair().public().to_peer_id();
+        let key = format!("/identity/{peer_id}/messaging_queue");
         let current_cid = self
             .ipfs
             .repo()
             .data_store()
-            .get(b"/messaging/queue")
+            .get(key.as_bytes())
             .await
             .unwrap_or_default()
             .map(|bytes| String::from_utf8_lossy(&bytes).to_string())

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -58,6 +58,58 @@ pub(super) mod topics {
     impl PeerTopic for DID {}
 }
 
+pub(super) mod ds_key {
+
+    use rust_ipfs::{Ipfs, Keypair, PeerId, PublicKey};
+
+    pub trait DataStoreKey {
+        fn base(&self) -> String;
+
+        fn root(&self) -> String {
+            self.base() + "/root"
+        }
+
+        fn cache(&self) -> String {
+            self.base() + "/cache"
+        }
+
+        fn messaging_queue(&self) -> String {
+            self.base() + "/messaging_queue"
+        }
+
+        fn request_queue(&self) -> String {
+            self.base() + "/request_queue"
+        }
+    }
+
+    impl DataStoreKey for Ipfs {
+        fn base(&self) -> String {
+            let peer_id = self.keypair().public().to_peer_id();
+            format!("/identity/{peer_id}")
+        }
+    }
+
+    impl DataStoreKey for PeerId {
+        fn base(&self) -> String {
+            format!("/identity/{self}")
+        }
+    }
+
+    impl DataStoreKey for Keypair {
+        fn base(&self) -> String {
+            let peer_id = self.public().to_peer_id();
+            format!("/identity/{peer_id}")
+        }
+    }
+
+    impl DataStoreKey for PublicKey {
+        fn base(&self) -> String {
+            let peer_id = self.to_peer_id();
+            format!("/identity/{peer_id}")
+        }
+    }
+}
+
 const SHUTTLE_TIMEOUT: Duration = Duration::from_secs(60);
 
 use self::conversation::{ConversationDocument, MessageDocument};

--- a/extensions/warp-ipfs/src/store/queue.rs
+++ b/extensions/warp-ipfs/src/store/queue.rs
@@ -127,11 +127,13 @@ impl Queue {
 impl Queue {
     pub async fn load(&self) -> Result<(), Error> {
         let ipfs = &self.ipfs;
+        let peer_id = self.ipfs.keypair().public().to_peer_id();
+        let key = format!("/identity/{peer_id}/request_queue");
 
         let data = match futures::future::ready(
             ipfs.repo()
                 .data_store()
-                .get(b"/messaging/queue")
+                .get(key.as_bytes())
                 .await
                 .unwrap_or_default()
                 .ok_or(Error::Other),
@@ -180,11 +182,14 @@ impl Queue {
     }
 
     pub async fn save(&self) {
+        let peer_id = self.ipfs.keypair().public().to_peer_id();
+        let key = format!("/identity/{peer_id}/request_queue");
+
         let current_cid = self
             .ipfs
             .repo()
             .data_store()
-            .get(b"/friends/queue")
+            .get(key.as_bytes())
             .await
             .unwrap_or_default()
             .map(|bytes| String::from_utf8_lossy(&bytes).to_string())

--- a/extensions/warp-ipfs/src/store/queue.rs
+++ b/extensions/warp-ipfs/src/store/queue.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::HashMap,
-    path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
 };
 
-use futures::{channel::mpsc, StreamExt};
+use futures::{channel::mpsc, StreamExt, TryFutureExt};
+use libipld::Cid;
 use rust_ipfs::Ipfs;
 use tokio::{sync::RwLock, task::JoinHandle};
 use tracing::error;
@@ -24,7 +24,6 @@ use crate::store::{ecdh_encrypt, topics::PeerTopic, PeerIdExt};
 use super::{connected_to_peer, discovery::Discovery, identity::RequestResponsePayload};
 
 pub struct Queue {
-    path: Option<PathBuf>,
     ipfs: Ipfs,
     entries: Arc<RwLock<HashMap<DID, QueueEntry>>>,
     removal: mpsc::UnboundedSender<DID>,
@@ -35,7 +34,6 @@ pub struct Queue {
 impl Clone for Queue {
     fn clone(&self) -> Self {
         Self {
-            path: self.path.clone(),
             ipfs: self.ipfs.clone(),
             entries: self.entries.clone(),
             removal: self.removal.clone(),
@@ -46,10 +44,9 @@ impl Clone for Queue {
 }
 
 impl Queue {
-    pub fn new(ipfs: Ipfs, did: Arc<DID>, path: Option<PathBuf>, discovery: Discovery) -> Queue {
+    pub fn new(ipfs: Ipfs, did: Arc<DID>, discovery: Discovery) -> Queue {
         let (tx, mut rx) = mpsc::unbounded();
         let queue = Queue {
-            path,
             ipfs,
             entries: Default::default(),
             removal: tx,
@@ -129,61 +126,126 @@ impl Queue {
 
 impl Queue {
     pub async fn load(&self) -> Result<(), Error> {
-        if let Some(path) = self.path.as_ref() {
-            let data = fs::read(path.join(".request_queue")).await?;
+        let ipfs = &self.ipfs;
 
-            let prikey =
-                Ed25519KeyPair::from_secret_key(&self.did.private_key_bytes()).get_x25519();
-            let pubkey = Ed25519KeyPair::from_public_key(&self.did.public_key_bytes()).get_x25519();
+        let data = match futures::future::ready(
+            ipfs.repo()
+                .data_store()
+                .get(b"/messaging/queue")
+                .await
+                .unwrap_or_default()
+                .ok_or(Error::Other),
+        )
+        .and_then(|bytes| async move {
+            let cid_str = String::from_utf8_lossy(&bytes).to_string();
 
-            let prik = std::panic::catch_unwind(|| prikey.key_exchange(&pubkey))
-                .map(Zeroizing::new)
-                .map_err(|_| anyhow::anyhow!("Error performing key exchange"))?;
+            let cid = cid_str.parse::<Cid>().map_err(anyhow::Error::from)?;
 
-            let data = Cipher::direct_decrypt(&data, &prik)?;
-
-            let map: HashMap<DID, RequestResponsePayload> = serde_json::from_slice(&data)?;
-
-            for (did, payload) in map {
-                self.raw_insert(&did, payload).await;
+            Ok(cid)
+        })
+        .and_then(|cid| async move {
+            ipfs.get_dag(cid)
+                .local()
+                .deserialized::<Vec<_>>()
+                .await
+                .map_err(anyhow::Error::from)
+                .map_err(Error::from)
+        })
+        .await
+        {
+            Ok(data) => data,
+            Err(_) => {
+                // We will ignore the error since the queue may not exist initially
+                // though the queue will be dealt away with in the future
+                return Ok(());
             }
+        };
+
+        let prikey = Ed25519KeyPair::from_secret_key(&self.did.private_key_bytes()).get_x25519();
+        let pubkey = Ed25519KeyPair::from_public_key(&self.did.public_key_bytes()).get_x25519();
+
+        let prik = std::panic::catch_unwind(|| prikey.key_exchange(&pubkey))
+            .map(Zeroizing::new)
+            .map_err(|_| anyhow::anyhow!("Error performing key exchange"))?;
+
+        let data = Cipher::direct_decrypt(&data, &prik)?;
+
+        let map: HashMap<DID, RequestResponsePayload> = serde_json::from_slice(&data)?;
+
+        for (did, payload) in map {
+            self.raw_insert(&did, payload).await;
         }
+
         Ok(())
     }
 
     pub async fn save(&self) {
-        if let Some(path) = self.path.as_ref() {
-            let queue_list = self.map().await;
-            let bytes = match serde_json::to_vec(&queue_list) {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    error!("Error serializing queue list into bytes: {e}");
-                    return;
-                }
-            };
+        let current_cid = self
+            .ipfs
+            .repo()
+            .data_store()
+            .get(b"/friends/queue")
+            .await
+            .unwrap_or_default()
+            .map(|bytes| String::from_utf8_lossy(&bytes).to_string())
+            .and_then(|cid_str| cid_str.parse::<Cid>().ok());
 
-            let prikey =
-                Ed25519KeyPair::from_secret_key(&self.did.private_key_bytes()).get_x25519();
-            let pubkey = Ed25519KeyPair::from_public_key(&self.did.public_key_bytes()).get_x25519();
+        let queue_list = self.map().await;
+        let bytes = match serde_json::to_vec(&queue_list) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!("Error serializing queue list into bytes: {e}");
+                return;
+            }
+        };
 
-            let prik = match std::panic::catch_unwind(|| prikey.key_exchange(&pubkey)) {
-                Ok(pri) => Zeroizing::new(pri),
-                Err(e) => {
-                    error!("Error generating key: {e:?}");
-                    return;
-                }
-            };
+        let prikey = Ed25519KeyPair::from_secret_key(&self.did.private_key_bytes()).get_x25519();
+        let pubkey = Ed25519KeyPair::from_public_key(&self.did.public_key_bytes()).get_x25519();
 
-            let data = match Cipher::direct_encrypt(&bytes, &prik) {
-                Ok(d) => d,
-                Err(e) => {
-                    error!("Error encrypting queue: {e}");
-                    return;
-                }
-            };
+        let prik = match std::panic::catch_unwind(|| prikey.key_exchange(&pubkey)) {
+            Ok(pri) => Zeroizing::new(pri),
+            Err(e) => {
+                error!("Error generating key: {e:?}");
+                return;
+            }
+        };
 
-            if let Err(e) = fs::write(path.join(".request_queue"), data).await {
-                error!("Error saving queue: {e}");
+        let data = match Cipher::direct_encrypt(&bytes, &prik) {
+            Ok(d) => d,
+            Err(e) => {
+                error!("Error encrypting queue: {e}");
+                return;
+            }
+        };
+
+        let cid = match self.ipfs.dag().put().serialize(&data).pin(true).await {
+            Ok(cid) => cid,
+            Err(e) => {
+                tracing::error!(error = %e, "unable to save queue");
+                return;
+            }
+        };
+
+        let cid_str = cid.to_string();
+
+        if let Err(e) = self
+            .ipfs
+            .repo()
+            .data_store()
+            .put(b"/friends/queue", cid_str.as_bytes())
+            .await
+        {
+            tracing::error!(error = %e, "unable to save queue");
+            return;
+        }
+
+        tracing::info!("friend request queue saved");
+
+        let old_cid = current_cid;
+
+        if let Some(old_cid) = old_cid {
+            if old_cid != cid && self.ipfs.is_pinned(&old_cid).await.unwrap_or_default() {
+                _ = self.ipfs.remove_pin(&old_cid).recursive().await;
             }
         }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Store the queue into the blockstore
- Moves references to the datastore

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Previously, we would store references in corresponding files due to the lacking of the flatfs datastore, however due to the implementation of the flatfs datastore, it would make more sense to move the references there to reduce fs IO calls and make it more uniform without having to check if a path is set to determine if we should write to file or keep it in memory. 
- This should help with #494 since this would push things to the datastore, which may be compatible with wasm. 