### PR TITLE
refactor: Rename subscribe functions

### DIFF
--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -203,7 +203,7 @@ async fn main() -> anyhow::Result<()> {
         own_identity.short_id()
     ))?;
 
-    let mut event_stream = account.subscribe().await?;
+    let mut event_stream = account.multipass_subscribe().await?;
     loop {
         tokio::select! {
             event = event_stream.next() => {

--- a/extensions/warp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-ipfs/examples/ipfs-friends.rs
@@ -34,10 +34,10 @@ async fn main() -> anyhow::Result<()> {
     let mut rng = rand::thread_rng();
 
     let mut account_a = account(None).await?;
-    let mut subscribe_a = account_a.subscribe().await?;
+    let mut subscribe_a = account_a.multipass_subscribe().await?;
 
     let mut account_b = account(None).await?;
-    let mut subscribe_b = account_b.subscribe().await?;
+    let mut subscribe_b = account_b.multipass_subscribe().await?;
 
     let ident_a = account_a.get_own_identity().await?;
     let ident_b = account_b.get_own_identity().await?;

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -267,7 +267,7 @@ async fn main() -> anyhow::Result<()> {
         writeln!(stdout, "Set conversation to {}", topic)?;
     }
 
-    let mut event_stream = chat.subscribe().await?;
+    let mut event_stream = chat.raygun_subscribe().await?;
 
     loop {
         tokio::select! {

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -68,8 +68,8 @@ use warp::multipass::identity::{
     Identifier, Identity, IdentityImage, IdentityProfile, IdentityUpdate, Relationship,
 };
 use warp::multipass::{
-    identity, Friends, FriendsEvent, IdentityImportOption, IdentityInformation, ImportLocation,
-    MultiPass, MultiPassEventKind, MultiPassEventStream, MultiPassImportExport,
+    identity, Friends, IdentityImportOption, IdentityInformation, ImportLocation, MultiPass,
+    MultiPassEvent, MultiPassEventKind, MultiPassEventStream, MultiPassImportExport,
 };
 
 use crate::config::{Bootstrap, DiscoveryType};
@@ -1321,8 +1321,8 @@ impl Friends for WarpIpfs {
 }
 
 #[async_trait::async_trait]
-impl FriendsEvent for WarpIpfs {
-    async fn subscribe(&mut self) -> Result<MultiPassEventStream, Error> {
+impl MultiPassEvent for WarpIpfs {
+    async fn multipass_subscribe(&mut self) -> Result<MultiPassEventStream, Error> {
         let store = self.identity_store(true).await?;
         store.subscribe().await
     }
@@ -1603,10 +1603,11 @@ impl RayGunGroupConversation for WarpIpfs {
 
 #[async_trait::async_trait]
 impl RayGunStream for WarpIpfs {
-    async fn subscribe(&mut self) -> Result<RayGunEventStream, Error> {
+    async fn raygun_subscribe(&mut self) -> Result<RayGunEventStream, Error> {
         let rx = self.raygun_tx.subscribe().await?;
         Ok(rx)
     }
+
     async fn get_conversation_stream(
         &mut self,
         conversation_id: Uuid,
@@ -1728,7 +1729,7 @@ impl Constellation for WarpIpfs {
 
 #[async_trait::async_trait]
 impl ConstellationEvent for WarpIpfs {
-    async fn subscribe(&mut self) -> Result<ConstellationEventStream, Error> {
+    async fn constellation_subscribe(&mut self) -> Result<ConstellationEventStream, Error> {
         let rx = self.constellation_tx.subscribe().await?;
         Ok(ConstellationEventStream(rx))
     }

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -26,8 +26,8 @@ mod test {
         let (_account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -74,8 +74,8 @@ mod test {
         let (_account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -157,8 +157,8 @@ mod test {
         let (_account_a, mut chat_a, _, _, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -238,8 +238,8 @@ mod test {
         let (_account_a, mut chat_a, mut fs_a, _, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -369,8 +369,8 @@ mod test {
         let (_account_a, mut chat_a, _, _, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -472,8 +472,8 @@ mod test {
         let (_account_a, mut chat_a, _, _, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -585,8 +585,8 @@ mod test {
         let (_account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -780,8 +780,8 @@ mod test {
         let (_account_a, mut chat_a, _, _, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -946,8 +946,8 @@ mod test {
         let (_account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 
@@ -1035,11 +1035,11 @@ mod test {
         let (mut _account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (mut _account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut account_subscribe_a = _account_a.subscribe().await?;
-        let mut account_subscribe_b = _account_b.subscribe().await?;
+        let mut account_subscribe_a = _account_a.multipass_subscribe().await?;
+        let mut account_subscribe_b = _account_b.multipass_subscribe().await?;
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a.create_conversation(&did_b).await?;
 

--- a/extensions/warp-ipfs/tests/friends.rs
+++ b/extensions/warp-ipfs/tests/friends.rs
@@ -18,8 +18,8 @@ mod test {
         let (mut account_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (mut account_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_b = account_b.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_b = account_b.multipass_subscribe().await?;
         account_a.send_request(&did_b).await?;
 
         tokio::time::timeout(Duration::from_secs(60), async {
@@ -59,8 +59,8 @@ mod test {
         let (mut account_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (mut account_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_b = account_b.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_b = account_b.multipass_subscribe().await?;
 
         account_a.send_request(&did_b).await?;
 
@@ -122,8 +122,8 @@ mod test {
         let (mut account_a, _, _, _) = accounts.first().cloned().unwrap();
         let (mut account_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_b = account_b.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_b = account_b.multipass_subscribe().await?;
 
         account_a.send_request(&did_b).await?;
 
@@ -163,8 +163,8 @@ mod test {
         let (mut account_a, _, _, _) = accounts.first().cloned().unwrap();
         let (mut account_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_b = account_b.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_b = account_b.multipass_subscribe().await?;
 
         account_a.send_request(&did_b).await?;
 
@@ -216,8 +216,8 @@ mod test {
         let (mut account_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (mut account_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_b = account_b.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_b = account_b.multipass_subscribe().await?;
 
         account_a.send_request(&did_b).await?;
         tokio::time::timeout(Duration::from_secs(60), async {
@@ -259,7 +259,7 @@ mod test {
         let (mut account_a, _, _, _) = accounts.first().cloned().unwrap();
         let (_, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
 
         account_a.send_request(&did_b).await?;
         tokio::time::timeout(Duration::from_secs(60), async {
@@ -298,8 +298,8 @@ mod test {
         let (mut account_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (mut account_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_b = account_b.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_b = account_b.multipass_subscribe().await?;
 
         account_a.block(&did_b).await?;
         account_b.block(&did_a).await?;

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -24,7 +24,7 @@ mod test {
 
         let (_account_a, mut chat_a, _, did_a, _) = accounts[0].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(None, vec![], GroupSettings::default())
@@ -63,7 +63,7 @@ mod test {
 
         let (_account_a, mut chat_a, _, _, _) = accounts[0].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(None, vec![], GroupSettings::default())
@@ -133,9 +133,9 @@ mod test {
         let (_account_b, mut chat_b, _, did_b, _) = accounts[1].clone();
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(
@@ -204,8 +204,8 @@ mod test {
         let (_account_a, mut chat_a, _, did_a, _) = accounts.first().cloned().unwrap();
         let (_account_b, mut chat_b, _, did_b, _) = accounts.last().cloned().unwrap();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(None, vec![did_b.clone()], Default::default())
@@ -301,10 +301,10 @@ mod test {
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
         let (_account_d, mut chat_d, _, did_d, _) = accounts[3].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
-        let mut chat_subscribe_d = chat_d.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
+        let mut chat_subscribe_d = chat_d.raygun_subscribe().await?;
 
         let mut settings = GroupSettings::default();
         settings.set_members_can_change_name(true);
@@ -468,10 +468,10 @@ mod test {
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
         let (_account_d, mut chat_d, _, did_d, _) = accounts[3].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
-        let mut chat_subscribe_d = chat_d.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
+        let mut chat_subscribe_d = chat_d.raygun_subscribe().await?;
 
         let mut settings = GroupSettings::default();
         settings.set_members_can_add_participants(true);
@@ -632,10 +632,10 @@ mod test {
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
         let (_account_d, mut chat_d, _, did_d, _) = accounts[3].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
-        let mut chat_subscribe_d = chat_d.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
+        let mut chat_subscribe_d = chat_d.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(
@@ -785,8 +785,8 @@ mod test {
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
         let (mut account_d, _chat_d, _, did_d, _) = accounts[3].clone();
 
-        let mut subscribe_a = account_a.subscribe().await?;
-        let mut subscribe_d = account_d.subscribe().await?;
+        let mut subscribe_a = account_a.multipass_subscribe().await?;
+        let mut subscribe_d = account_d.multipass_subscribe().await?;
 
         account_a.block(&did_d).await?;
 
@@ -810,9 +810,9 @@ mod test {
         })
         .await?;
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
 
         let mut settings = GroupSettings::default();
         settings.set_members_can_add_participants(true);
@@ -893,10 +893,10 @@ mod test {
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
         let (_account_d, mut chat_d, _, did_d, _) = accounts[3].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
-        let mut chat_subscribe_d = chat_d.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
+        let mut chat_subscribe_d = chat_d.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(
@@ -1110,10 +1110,10 @@ mod test {
         let (_account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
         let (_account_d, mut chat_d, _, did_d, _) = accounts[3].clone();
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
-        let mut chat_subscribe_d = chat_d.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
+        let mut chat_subscribe_d = chat_d.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(
@@ -1263,12 +1263,12 @@ mod test {
         let (_account_b, mut chat_b, _, did_b, _) = accounts[1].clone();
         let (mut _account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
 
-        let mut account_subscribe_a = _account_a.subscribe().await?;
-        let mut account_subscribe_c = _account_c.subscribe().await?;
+        let mut account_subscribe_a = _account_a.multipass_subscribe().await?;
+        let mut account_subscribe_c = _account_c.multipass_subscribe().await?;
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(
@@ -1421,12 +1421,12 @@ mod test {
         let (_account_b, mut chat_b, _, did_b, _) = accounts[1].clone();
         let (mut _account_c, mut chat_c, _, did_c, _) = accounts[2].clone();
 
-        let mut account_subscribe_a = _account_a.subscribe().await?;
-        let mut account_subscribe_c = _account_c.subscribe().await?;
+        let mut account_subscribe_a = _account_a.multipass_subscribe().await?;
+        let mut account_subscribe_c = _account_c.multipass_subscribe().await?;
 
-        let mut chat_subscribe_a = chat_a.subscribe().await?;
-        let mut chat_subscribe_b = chat_b.subscribe().await?;
-        let mut chat_subscribe_c = chat_c.subscribe().await?;
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+        let mut chat_subscribe_b = chat_b.raygun_subscribe().await?;
+        let mut chat_subscribe_c = chat_c.raygun_subscribe().await?;
 
         chat_a
             .create_group_conversation(

--- a/tools/blink-repl/src/main.rs
+++ b/tools/blink-repl/src/main.rs
@@ -404,7 +404,7 @@ async fn main() -> anyhow::Result<()> {
         }
     });
 
-    let multipass_event_stream = multipass.subscribe().await?;
+    let multipass_event_stream = multipass.multipass_subscribe().await?;
     let multipass2 = multipass.clone();
     let multipass_handle = tokio::spawn(async {
         if let Err(e) = handle_multipass_event_stream(multipass2, multipass_event_stream).await {

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -223,7 +223,7 @@ dyn_clone::clone_trait_object!(Constellation);
 #[async_trait::async_trait]
 pub trait ConstellationEvent: Sync + Send {
     /// Subscribe to an stream of events
-    async fn subscribe(&mut self) -> Result<ConstellationEventStream, Error> {
+    async fn constellation_subscribe(&mut self) -> Result<ConstellationEventStream, Error> {
         Err(Error::Unimplemented)
     }
 }

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -70,7 +70,7 @@ pub trait MultiPass:
     + IdentityInformation
     + MultiPassImportExport
     + Friends
-    + FriendsEvent
+    + MultiPassEvent
     + Sync
     + Send
     + SingleHandle
@@ -194,9 +194,9 @@ pub trait Friends: Sync + Send {
 }
 
 #[async_trait::async_trait]
-pub trait FriendsEvent: Sync + Send {
+pub trait MultiPassEvent: Sync + Send {
     /// Subscribe to an stream of events
-    async fn subscribe(&mut self) -> Result<MultiPassEventStream, Error> {
+    async fn multipass_subscribe(&mut self) -> Result<MultiPassEventStream, Error> {
         Err(Error::Unimplemented)
     }
 }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -1094,7 +1094,7 @@ pub trait RayGunStream: Sync + Send {
     }
 
     /// Subscribe to an stream of events
-    async fn subscribe(&mut self) -> Result<RayGunEventStream, Error> {
+    async fn raygun_subscribe(&mut self) -> Result<RayGunEventStream, Error> {
         Err(Error::Unimplemented)
     }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Renames `subscribe` function to include the respective trait name to prevent possible conflicts.
- Renames `FriendEvent` to `MultiPassEvent`

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
