### PR TITLE
refactor: Export WarpIpfs to wasm and remove redundant result

### DIFF
--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -54,6 +54,7 @@ futures-timer = { workspace = true }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 futures-timer = { workspace = true, features = ["wasm-bindgen"] }
 wasm-bindgen-futures = { version = "0.4" }
+wasm-bindgen.workspace = true
 
 [dev-dependencies]
 derive_more.workspace = true

--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -73,7 +73,7 @@ async fn account(
     if opt.enable_discovery {
         let discovery_type = match (&opt.discovery_point, &opt.shuttle_point) {
             (Some(addr), None) => {
-                config.ipfs_setting.bootstrap = false;
+                config.ipfs_setting_mut().bootstrap = false;
                 DiscoveryType::RzPoint {
                     addresses: vec![addr.clone()],
                 }
@@ -91,39 +91,40 @@ async fn account(
                 discovery_type,
             },
         };
-        config.store_setting.discovery = dis_ty;
+        config.store_setting_mut().discovery = dis_ty;
         if let Some(bootstrap) = opt.bootstrap {
-            config.ipfs_setting.bootstrap = bootstrap;
+            config.ipfs_setting_mut().bootstrap = bootstrap;
         }
     } else {
-        config.store_setting.discovery = Discovery::None;
-        config.bootstrap = Bootstrap::None;
-        config.ipfs_setting.bootstrap = false;
+        config.store_setting_mut().discovery = Discovery::None;
+        *config.bootstrap_mut() = Bootstrap::None;
+        config.ipfs_setting_mut().bootstrap = false;
     }
 
     if opt.disable_relay {
-        config.enable_relay = false;
+        *config.enable_relay_mut() = false;
     }
 
     if opt.upnp {
-        config.ipfs_setting.portmapping = true;
+        config.ipfs_setting_mut().portmapping = true;
     }
 
-    config.store_setting.share_platform = opt.provide_platform_info;
+    config.store_setting_mut().share_platform = opt.provide_platform_info;
 
     if let Some(oride) = opt.r#override {
-        config.store_setting.fetch_over_bitswap = oride;
+        config.store_setting_mut().fetch_over_bitswap = oride;
     }
 
-    config.store_setting.friend_request_response_duration = opt.wait.map(Duration::from_millis);
+    config.store_setting_mut().friend_request_response_duration =
+        opt.wait.map(Duration::from_millis);
 
-    config.ipfs_setting.mdns.enable = opt.mdns;
+    config.ipfs_setting_mut().mdns.enable = opt.mdns;
 
     let (mut account, _, _) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     let mut profile = None;
 

--- a/extensions/warp-ipfs/examples/ipfs-example.rs
+++ b/extensions/warp-ipfs/examples/ipfs-example.rs
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
     let (mut account, _, mut filesystem) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
         .finalize()
-        .await?;
+        .await;
 
     account.create_identity(None, None).await?;
 

--- a/extensions/warp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-ipfs/examples/ipfs-friends.rs
@@ -19,7 +19,7 @@ async fn account(username: Option<&str>) -> anyhow::Result<Box<dyn MultiPass>> {
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     account.create_identity(username, None).await?;
     Ok(account)

--- a/extensions/warp-ipfs/examples/ipfs-identity.rs
+++ b/extensions/warp-ipfs/examples/ipfs-identity.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
     let (mut identity, _, _) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
         .finalize()
-        .await?;
+        .await;
 
     let profile = identity.create_identity(None, None).await?;
 

--- a/extensions/warp-ipfs/examples/ipfs-persistent.rs
+++ b/extensions/warp-ipfs/examples/ipfs-persistent.rs
@@ -69,13 +69,13 @@ async fn setup_persistent<P: AsRef<Path>>(
 
     let mut config = Config::production(path);
 
-    config.ipfs_setting.mdns.enable = opt.mdns;
+    config.ipfs_setting_mut().mdns.enable = opt.mdns;
 
     let (mut account, _, filesystem) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     if account.get_own_identity().await.is_err() {
         account.create_identity(username, None).await?;

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -94,7 +94,7 @@ async fn setup<P: AsRef<Path>>(
     if opt.enable_discovery {
         let discovery_type = match (&opt.discovery_point, &opt.shuttle_point) {
             (Some(addr), None) => {
-                config.ipfs_setting.bootstrap = false;
+                config.ipfs_setting_mut().bootstrap = false;
                 DiscoveryType::RzPoint {
                     addresses: vec![addr.clone()],
                 }
@@ -112,37 +112,38 @@ async fn setup<P: AsRef<Path>>(
                 discovery_type,
             },
         };
-        config.store_setting.discovery = dis_ty;
+        config.store_setting_mut().discovery = dis_ty;
         if let Some(bootstrap) = opt.bootstrap {
-            config.ipfs_setting.bootstrap = bootstrap;
+            config.ipfs_setting_mut().bootstrap = bootstrap;
         }
     } else {
-        config.store_setting.discovery = Discovery::None;
-        config.bootstrap = Bootstrap::None;
-        config.ipfs_setting.bootstrap = false;
+        config.store_setting_mut().discovery = Discovery::None;
+        *config.bootstrap_mut() = Bootstrap::None;
+        config.ipfs_setting_mut().bootstrap = false;
     }
 
     if opt.disable_relay {
-        config.enable_relay = false;
+        *config.enable_relay_mut() = false;
     }
     if opt.upnp {
-        config.ipfs_setting.portmapping = true;
+        config.ipfs_setting_mut().portmapping = true;
     }
 
-    config.store_setting.share_platform = opt.provide_platform_info;
+    config.store_setting_mut().share_platform = opt.provide_platform_info;
 
     if let Some(oride) = opt.r#override {
-        config.store_setting.fetch_over_bitswap = oride;
+        config.store_setting_mut().fetch_over_bitswap = oride;
     }
 
-    config.store_setting.friend_request_response_duration = opt.wait.map(Duration::from_millis);
-    config.ipfs_setting.mdns.enable = opt.mdns;
+    config.store_setting_mut().friend_request_response_duration =
+        opt.wait.map(Duration::from_millis);
+    config.ipfs_setting_mut().mdns.enable = opt.mdns;
 
     let (mut account, raygun, filesystem) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     let mut profile = None;
 

--- a/extensions/warp-ipfs/examples/wasm-ipfs-identity/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-identity/src/lib.rs
@@ -40,7 +40,7 @@ pub async fn run() -> Result<(), JsError> {
         .set_config(Config::minimal_testing())
         .set_tesseract(tesseract)
         .finalize()
-        .await?;
+        .await;
 
     let profile = identity.create_identity(None, None).await?;
 

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -1,11 +1,7 @@
 use ipfs::Multiaddr;
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-    time::Duration,
-};
+use std::{path::PathBuf, str::FromStr, time::Duration};
 use warp::{constellation::file::FileType, multipass::identity::Identity};
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
@@ -251,22 +247,112 @@ impl Default for StoreSetting {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Config {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub path: Option<PathBuf>,
-    pub bootstrap: Bootstrap,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub listen_on: Vec<Multiaddr>,
-    pub ipfs_setting: IpfsSetting,
-    pub store_setting: StoreSetting,
-    pub enable_relay: bool,
-    pub save_phrase: bool,
-    pub max_storage_size: Option<usize>,
-    pub max_file_size: Option<usize>,
-    pub thumbnail_size: (u32, u32),
-    pub chunking: Option<usize>,
-    pub thumbnail_exact_format: bool,
+    path: Option<PathBuf>,
+    bootstrap: Bootstrap,
+    listen_on: Vec<Multiaddr>,
+    ipfs_setting: IpfsSetting,
+    store_setting: StoreSetting,
+    enable_relay: bool,
+    save_phrase: bool,
+    max_storage_size: Option<usize>,
+    max_file_size: Option<usize>,
+    thumbnail_size: (u32, u32),
+    thumbnail_exact_format: bool,
+}
+
+impl Config {
+    pub fn path(&self) -> Option<&PathBuf> {
+        self.path.as_ref()
+    }
+
+    pub fn bootstrap(&self) -> &Bootstrap {
+        &self.bootstrap
+    }
+
+    pub fn listen_on(&self) -> &[Multiaddr] {
+        &self.listen_on
+    }
+
+    pub fn ipfs_setting(&self) -> &IpfsSetting {
+        &self.ipfs_setting
+    }
+
+    pub fn store_setting(&self) -> &StoreSetting {
+        &self.store_setting
+    }
+
+    pub fn enable_relay(&self) -> bool {
+        self.enable_relay
+    }
+
+    pub fn save_phrase(&self) -> bool {
+        self.save_phrase
+    }
+
+    pub fn max_storage_size(&self) -> Option<usize> {
+        self.max_storage_size
+    }
+
+    pub fn max_file_size(&self) -> Option<usize> {
+        self.max_file_size
+    }
+
+    pub fn thumbnail_size(&self) -> (u32, u32) {
+        self.thumbnail_size
+    }
+
+    pub fn thumbnail_exact_format(&self) -> bool {
+        self.thumbnail_exact_format
+    }
+}
+
+impl Config {
+    pub fn path_mut(&mut self) -> &mut Option<PathBuf> {
+        &mut self.path
+    }
+
+    pub fn bootstrap_mut(&mut self) -> &mut Bootstrap {
+        &mut self.bootstrap
+    }
+
+    pub fn listen_on_mut(&mut self) -> &mut Vec<Multiaddr> {
+        &mut self.listen_on
+    }
+
+    pub fn ipfs_setting_mut(&mut self) -> &mut IpfsSetting {
+        &mut self.ipfs_setting
+    }
+
+    pub fn store_setting_mut(&mut self) -> &mut StoreSetting {
+        &mut self.store_setting
+    }
+
+    pub fn enable_relay_mut(&mut self) -> &mut bool {
+        &mut self.enable_relay
+    }
+
+    pub fn save_phrase_mut(&mut self) -> &mut bool {
+        &mut self.save_phrase
+    }
+
+    pub fn max_storage_size_mut(&mut self) -> &mut Option<usize> {
+        &mut self.max_storage_size
+    }
+
+    pub fn max_file_size_mut(&mut self) -> &mut Option<usize> {
+        &mut self.max_file_size
+    }
+
+    pub fn thumbnail_size_mut(&mut self) -> &mut (u32, u32) {
+        &mut self.thumbnail_size
+    }
+
+    pub fn thumbnail_exact_format_mut(&mut self) -> &mut bool {
+        &mut self.thumbnail_exact_format
+    }
 }
 
 impl Default for Config {
@@ -295,19 +381,21 @@ impl Default for Config {
             max_storage_size: Some(50 * 1024 * 1024),
             max_file_size: Some(50 * 1024 * 1024),
             thumbnail_size: (128, 128),
-            chunking: None,
             thumbnail_exact_format: true,
         }
     }
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 impl Config {
     /// Default configuration for local development and writing test
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
     pub fn development() -> Config {
         Config::default()
     }
 
     /// Test configuration. Used for in-memory
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
     pub fn testing() -> Config {
         Config {
             bootstrap: Bootstrap::Ipfs,
@@ -331,6 +419,7 @@ impl Config {
     }
 
     /// Minimal testing configuration. Used for in-memory
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
     pub fn minimal_testing() -> Config {
         Config {
             bootstrap: Bootstrap::Ipfs,
@@ -351,6 +440,7 @@ impl Config {
     }
 
     /// Minimal production configuration
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn minimal<P: AsRef<std::path::Path>>(path: P) -> Config {
         Config {
             bootstrap: Bootstrap::Ipfs,
@@ -372,6 +462,7 @@ impl Config {
     }
 
     /// Recommended production configuration
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn production<P: AsRef<std::path::Path>>(path: P) -> Config {
         Config {
             bootstrap: Bootstrap::Ipfs,
@@ -394,139 +485,4 @@ impl Config {
             ..Default::default()
         }
     }
-
-    pub fn from_file<P: AsRef<Path>>(path: P) -> anyhow::Result<Config> {
-        let path = path.as_ref();
-        let bytes = std::fs::read(path)?;
-        let config = serde_json::from_slice(&bytes)?;
-        Ok(config)
-    }
-
-    pub fn to_file<P: AsRef<Path>>(&self, path: P) -> anyhow::Result<()> {
-        let path = path.as_ref();
-        let bytes = serde_json::to_vec(self)?;
-        std::fs::write(path, bytes)?;
-        Ok(())
-    }
-
-    pub fn from_string<S: AsRef<str>>(data: S) -> anyhow::Result<Config> {
-        let data = data.as_ref();
-        let config = serde_json::from_str(data)?;
-        Ok(config)
-    }
 }
-
-// pub mod ffi {
-//     use crate::config::Config;
-
-//     use std::ffi::CStr;
-//     use std::os::raw::c_char;
-//     use warp::error::Error;
-//     use warp::ffi::{FFIResult, FFIResult_Null, FFIResult_String};
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_from_file(
-//         file: *const c_char,
-//     ) -> FFIResult<Config> {
-//         if file.is_null() {
-//             return FFIResult::err(Error::Any(anyhow::anyhow!("file cannot be null")));
-//         }
-
-//         let file = CStr::from_ptr(file).to_string_lossy().to_string();
-
-//         Config::from_file(file).map_err(Error::from).into()
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_to_file(
-//         config: *const Config,
-//         file: *const c_char,
-//     ) -> FFIResult_Null {
-//         if config.is_null() {
-//             return FFIResult_Null::err(Error::NullPointerContext {
-//                 pointer: "config".into(),
-//             });
-//         }
-
-//         if file.is_null() {
-//             return FFIResult_Null::err(Error::NullPointerContext {
-//                 pointer: "file".into(),
-//             });
-//         }
-
-//         let file = CStr::from_ptr(file).to_string_lossy().to_string();
-
-//         Config::to_file(&*config, file)
-//             .map_err(Error::from)
-//             .into()
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_from_str(
-//         config: *const c_char,
-//     ) -> FFIResult<Config> {
-//         if config.is_null() {
-//             return FFIResult::err(Error::Any(anyhow::anyhow!("config cannot be null")));
-//         }
-
-//         let data = CStr::from_ptr(config).to_string_lossy().to_string();
-
-//         Config::from_string(data).map_err(Error::from).into()
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_to_str(
-//         config: *const Config,
-//     ) -> FFIResult_String {
-//         if config.is_null() {
-//             return FFIResult_String::err(Error::Any(anyhow::anyhow!("config cannot be null")));
-//         }
-
-//         serde_json::to_string(&*config).map_err(Error::from).into()
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_development() -> *mut Config {
-//         Box::into_raw(Box::new(Config::development()))
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_testing(experimental: bool) -> *mut Config {
-//         Box::into_raw(Box::new(Config::testing(experimental)))
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_production(
-//         path: *const c_char,
-//         experimental: bool,
-//     ) -> FFIResult<Config> {
-//         if path.is_null() {
-//             return FFIResult::err(Error::Any(anyhow::anyhow!("config cannot be null")));
-//         }
-
-//         let path = CStr::from_ptr(path).to_string_lossy().to_string();
-
-//         FFIResult::ok(Config::production(path, experimental))
-//     }
-
-//     #[allow(clippy::missing_safety_doc)]
-//     #[no_mangle]
-//     pub unsafe extern "C" fn mp_ipfs_config_minimal(
-//         path: *const c_char,
-//     ) -> FFIResult<Config> {
-//         if path.is_null() {
-//             return FFIResult::err(Error::Any(anyhow::anyhow!("config cannot be null")));
-//         }
-
-//         let path = CStr::from_ptr(path).to_string_lossy().to_string();
-
-//         FFIResult::ok(Config::minimal(path))
-//     }
-// }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -134,7 +134,7 @@ impl FileStore {
     }
 
     pub fn max_size(&self) -> usize {
-        self.config.max_storage_size.unwrap_or(1024 * 1024 * 1024)
+        self.config.max_storage_size().unwrap_or(1024 * 1024 * 1024)
     }
 
     pub fn set_path(&mut self, path: PathBuf) {
@@ -512,7 +512,7 @@ impl FileTask {
     }
 
     fn max_size(&self) -> usize {
-        self.config.max_storage_size.unwrap_or(1024 * 1024 * 1024)
+        self.config.max_storage_size().unwrap_or(1024 * 1024 * 1024)
     }
 
     fn get_path(&self) -> PathBuf {
@@ -554,8 +554,8 @@ impl FileTask {
         }
 
         let ((width, height), exact) = (
-            self.config.thumbnail_size,
-            self.config.thumbnail_exact_format,
+            self.config.thumbnail_size(),
+            self.config.thumbnail_exact_format(),
         );
 
         let thumbnail_store = self.thumbnail_store.clone();
@@ -725,8 +725,8 @@ impl FileTask {
         let thumbnail_store = self.thumbnail_store.clone();
         let tx = self.constellation_tx.clone();
         let mut export_tx = self.export_tx.clone();
-        let thumbnail_size = self.config.thumbnail_size;
-        let thumbnail_format = self.config.thumbnail_exact_format;
+        let thumbnail_size = self.config.thumbnail_size();
+        let thumbnail_format = self.config.thumbnail_exact_format();
 
         let (name, dest_path) = split_file_from_path(name)?;
 
@@ -1077,8 +1077,8 @@ impl FileTask {
     fn sync_ref(&mut self, path: &str) -> Result<BoxFuture<'static, Result<(), Error>>, Error> {
         let ipfs = self.ipfs.clone();
         let thumbnail_store = self.thumbnail_store.clone();
-        let thumbnail_size = self.config.thumbnail_size;
-        let thumbnail_format = self.config.thumbnail_exact_format;
+        let thumbnail_size = self.config.thumbnail_size();
+        let thumbnail_format = self.config.thumbnail_exact_format();
 
         let directory = self.current_directory()?;
         let file = directory

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -368,7 +368,7 @@ impl IdentityStore {
         >,
         span: Span,
     ) -> Result<Self, Error> {
-        if let Some(path) = config.path.as_ref() {
+        if let Some(path) = config.path() {
             if !path.exists() {
                 fs::create_dir_all(path).await?;
             }
@@ -478,11 +478,11 @@ impl IdentityStore {
                 futures::pin_mut!(event_stream);
                 futures::pin_mut!(friend_stream);
 
-                let auto_push = store.config.store_setting.auto_push.is_some();
+                let auto_push = store.config.store_setting().auto_push.is_some();
 
                 let interval = store
                     .config
-                    .store_setting
+                    .store_setting()
                     .auto_push
                     .map(|i| {
                         if i.as_millis() < 300000 {
@@ -903,7 +903,7 @@ impl IdentityStore {
     }
 
     pub async fn announce_identity_to_mesh(&self) -> Result<(), Error> {
-        if self.config.store_setting.announce_to_mesh {
+        if self.config.store_setting().announce_to_mesh {
             let kp = self.ipfs.keypair();
             let document = self.own_identity_document().await?;
             let payload = PayloadRequest::new(kp, None, document)?;
@@ -966,7 +966,7 @@ impl IdentityStore {
 
         let is_blocked_by = self.is_blocked_by(out_did).await.unwrap_or_default();
 
-        let share_platform = self.config.store_setting.share_platform;
+        let share_platform = self.config.store_setting().share_platform;
 
         let platform =
             (share_platform && (!is_blocked || !is_blocked_by)).then_some(self.own_platform());
@@ -977,10 +977,10 @@ impl IdentityStore {
         identity.metadata = Default::default();
 
         let include_meta = (matches!(
-            self.config.store_setting.update_events,
+            self.config.store_setting().update_events,
             UpdateEvents::Enabled
         ) || matches!(
-            self.config.store_setting.update_events,
+            self.config.store_setting().update_events,
             UpdateEvents::FriendsOnly
         ) && is_friend)
             && (!is_blocked && !is_blocked_by);
@@ -1196,9 +1196,9 @@ impl IdentityStore {
 
                             let document_did = identity.did.clone();
 
-                            let emit = self.config.store_setting.update_events
+                            let emit = self.config.store_setting().update_events
                                 == UpdateEvents::Enabled
-                                || (self.config.store_setting.update_events
+                                || (self.config.store_setting().update_events
                                     == UpdateEvents::FriendsOnly
                                     && self.is_friend(&document_did).await.unwrap_or_default());
 
@@ -1220,7 +1220,7 @@ impl IdentityStore {
                                         identity.did
                                     );
 
-                                    if !self.config.store_setting.fetch_over_bitswap {
+                                    if !self.config.store_setting().fetch_over_bitswap {
                                         if let Err(e) = self
                                             .request(
                                                 in_did,
@@ -1289,7 +1289,7 @@ impl IdentityStore {
                                         identity.did
                                     );
 
-                                    if !self.config.store_setting.fetch_over_bitswap {
+                                    if !self.config.store_setting().fetch_over_bitswap {
                                         if let Err(e) = self
                                             .request(
                                                 in_did,
@@ -1359,7 +1359,7 @@ impl IdentityStore {
                         let document_did = identity.did.clone();
 
                         if matches!(
-                            self.config.store_setting.update_events,
+                            self.config.store_setting().update_events,
                             UpdateEvents::Enabled
                         ) {
                             let did = document_did.clone();
@@ -1368,9 +1368,9 @@ impl IdentityStore {
                         }
 
                         if !exclude_images {
-                            let emit = self.config.store_setting.update_events
+                            let emit = self.config.store_setting().update_events
                                 == UpdateEvents::Enabled
-                                || (self.config.store_setting.update_events
+                                || (self.config.store_setting().update_events
                                     == UpdateEvents::FriendsOnly
                                     && self.is_friend(&document_did).await.unwrap_or_default());
 
@@ -1387,7 +1387,7 @@ impl IdentityStore {
                                 }
 
                                 if banner.is_some() || picture.is_some() {
-                                    if !self.config.store_setting.fetch_over_bitswap {
+                                    if !self.config.store_setting().fetch_over_bitswap {
                                         self.request(
                                             in_did,
                                             RequestOption::Image { banner, picture },
@@ -1519,7 +1519,7 @@ impl IdentityStore {
     }
 
     fn own_platform(&self) -> Platform {
-        if self.config.store_setting.share_platform {
+        if self.config.store_setting().share_platform {
             if cfg!(any(
                 target_os = "windows",
                 target_os = "macos",
@@ -2228,7 +2228,7 @@ impl IdentityStore {
 
     #[tracing::instrument(skip(self))]
     pub async fn identity_picture(&self, did: &DID) -> Result<IdentityImage, Error> {
-        if self.config.store_setting.disable_images {
+        if self.config.store_setting().disable_images {
             return Err(Error::InvalidIdentityPicture);
         }
 
@@ -2243,7 +2243,12 @@ impl IdentityStore {
                 .map_err(|_| Error::InvalidIdentityPicture);
         }
 
-        if let Some(cb) = self.config.store_setting.default_profile_picture.as_deref() {
+        if let Some(cb) = self
+            .config
+            .store_setting()
+            .default_profile_picture
+            .as_deref()
+        {
             let identity = document.resolve()?;
             let (picture, ty) = cb(&identity)?;
             let mut image = IdentityImage::default();
@@ -2258,7 +2263,7 @@ impl IdentityStore {
 
     #[tracing::instrument(skip(self))]
     pub async fn identity_banner(&self, did: &DID) -> Result<IdentityImage, Error> {
-        if self.config.store_setting.disable_images {
+        if self.config.store_setting().disable_images {
             return Err(Error::InvalidIdentityBanner);
         }
 
@@ -2749,7 +2754,7 @@ impl IdentityStore {
 
         let wait = self
             .config
-            .store_setting
+            .store_setting()
             .friend_request_response_duration
             .is_some();
 
@@ -2784,7 +2789,8 @@ impl IdentityStore {
 
         if !queued && matches!(payload.event, Event::Request) {
             if let Some(rx) = std::mem::take(&mut rx) {
-                if let Some(timeout) = self.config.store_setting.friend_request_response_duration {
+                if let Some(timeout) = self.config.store_setting().friend_request_response_duration
+                {
                     let start = Instant::now();
                     if let Ok(Ok(res)) = rx.timeout(timeout).await {
                         let end = start.elapsed();

--- a/extensions/warp-ipfs/tests/accounts.rs
+++ b/extensions/warp-ipfs/tests/accounts.rs
@@ -126,7 +126,7 @@ mod test {
         let (mut account, _, _) = WarpIpfsBuilder::default()
             .set_tesseract(tesseract)
             .finalize()
-            .await?;
+            .await;
 
         account
             .create_identity(
@@ -156,7 +156,7 @@ mod test {
         let (mut account, _, _) = WarpIpfsBuilder::default()
             .set_tesseract(tesseract)
             .finalize()
-            .await?;
+            .await;
 
         account
             .create_identity(

--- a/extensions/warp-ipfs/tests/common.rs
+++ b/extensions/warp-ipfs/tests/common.rs
@@ -55,17 +55,17 @@ pub async fn create_account(
     let tesseract = Tesseract::default();
     tesseract.unlock(b"internal pass").unwrap();
     let mut config = warp_ipfs::config::Config::development();
-    config.listen_on = vec![Multiaddr::empty().with(Protocol::Memory(0))];
-    config.ipfs_setting.memory_transport = true;
-    config.store_setting.discovery = Discovery::Namespace {
+    *config.listen_on_mut() = vec![Multiaddr::empty().with(Protocol::Memory(0))];
+    config.ipfs_setting_mut().memory_transport = true;
+    config.store_setting_mut().discovery = Discovery::Namespace {
         namespace: context,
         discovery_type: Default::default(),
     };
-    config.store_setting.share_platform = true;
-    config.ipfs_setting.relay_client.relay_address = vec![];
-    config.ipfs_setting.bootstrap = false;
-    config.store_setting.update_events = UpdateEvents::Enabled;
-    config.bootstrap = Bootstrap::None;
+    config.store_setting_mut().share_platform = true;
+    config.ipfs_setting_mut().relay_client.relay_address = vec![];
+    config.ipfs_setting_mut().bootstrap = false;
+    config.store_setting_mut().update_events = UpdateEvents::Enabled;
+    *config.bootstrap_mut() = Bootstrap::None;
 
     let (mut account, _, fs) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
@@ -122,23 +122,23 @@ pub async fn create_account_and_chat(
     let tesseract = Tesseract::default();
     tesseract.unlock(b"internal pass").unwrap();
     let mut config = warp_ipfs::config::Config::development();
-    config.listen_on = vec![Multiaddr::empty().with(Protocol::Memory(0))];
-    config.ipfs_setting.memory_transport = true;
-    config.store_setting.discovery = Discovery::Namespace {
+    *config.listen_on_mut() = vec![Multiaddr::empty().with(Protocol::Memory(0))];
+    config.ipfs_setting_mut().memory_transport = true;
+    config.store_setting_mut().discovery = Discovery::Namespace {
         namespace: context,
         discovery_type: Default::default(),
     };
-    config.store_setting.update_events = UpdateEvents::Enabled;
-    config.store_setting.share_platform = true;
-    config.ipfs_setting.relay_client.relay_address = vec![];
-    config.ipfs_setting.bootstrap = false;
-    config.bootstrap = Bootstrap::None;
+    config.store_setting_mut().update_events = UpdateEvents::Enabled;
+    config.store_setting_mut().share_platform = true;
+    config.ipfs_setting_mut().relay_client.relay_address = vec![];
+    config.ipfs_setting_mut().bootstrap = false;
+    *config.bootstrap_mut() = Bootstrap::None;
 
     let (mut account, raygun, fs) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     let profile = account.create_identity(username, passphrase).await?;
     let identity = profile.identity().clone();

--- a/extensions/warp-ipfs/tests/common.rs
+++ b/extensions/warp-ipfs/tests/common.rs
@@ -71,7 +71,7 @@ pub async fn create_account(
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
     let profile = account.create_identity(username, passphrase).await?;
     let identity = profile.identity().clone();
 

--- a/tools/blink-repl/src/main.rs
+++ b/tools/blink-repl/src/main.rs
@@ -370,7 +370,7 @@ async fn main() -> anyhow::Result<()> {
         .set_tesseract(tesseract.clone())
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     if new_account {
         let random_name: String = rand::thread_rng()

--- a/tools/blink-repl/src/main.rs
+++ b/tools/blink-repl/src/main.rs
@@ -360,11 +360,11 @@ async fn main() -> anyhow::Result<()> {
     tesseract.unlock("abcdefghik".as_bytes())?;
 
     let mut config = Config::production(multipass_dir);
-    config.ipfs_setting.portmapping = true;
-    config.ipfs_setting.agent_version = Some(format!("uplink/{}", env!("CARGO_PKG_VERSION")));
-    config.store_setting.emit_online_event = true;
-    config.store_setting.share_platform = true;
-    config.store_setting.update_events = UpdateEvents::Enabled;
+    config.ipfs_setting_mut().portmapping = true;
+    config.ipfs_setting_mut().agent_version = Some(format!("uplink/{}", env!("CARGO_PKG_VERSION")));
+    config.store_setting_mut().emit_online_event = true;
+    config.store_setting_mut().share_platform = true;
+    config.store_setting_mut().update_events = UpdateEvents::Enabled;
 
     let (mut multipass, _, _) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract.clone())

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -39,10 +39,10 @@ async fn setup<P: AsRef<Path>>(
     tesseract.unlock(passphrase.as_bytes())?;
 
     let mut config = warp_ipfs::config::Config::production(path);
-    config.store_setting.discovery = Discovery::None;
-    config.ipfs_setting.bootstrap = false;
-    config.ipfs_setting.mdns.enable = false;
-    config.enable_relay = false;
+    config.store_setting_mut().discovery = Discovery::None;
+    config.ipfs_setting_mut().bootstrap = false;
+    config.ipfs_setting_mut().mdns.enable = false;
+    *config.enable_relay_mut() = false;
 
     let (identity, raygun, constellation) = WarpIpfsBuilder::default()
         .set_tesseract(tesseract)

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -48,7 +48,7 @@ async fn setup<P: AsRef<Path>>(
         .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
-        .await?;
+        .await;
 
     //validating that account exist
     let _ = identity.get_own_identity().await?;

--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -252,7 +252,10 @@ impl Tesseract {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 impl Tesseract {
     /// To create an instance of Tesseract
-    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen(constructor))]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        wasm_bindgen::prelude::wasm_bindgen(constructor)
+    )]
     pub fn new() -> Tesseract {
         Tesseract::default()
     }

--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -21,6 +21,7 @@ type Result<T> = std::result::Result<T, Error>;
 
 /// The key store that holds encrypted strings that can be used for later use.
 #[derive(Clone)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Tesseract {
     inner: Arc<TesseractInner>,
 }
@@ -248,12 +249,16 @@ impl Tesseract {
     }
 }
 
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 impl Tesseract {
     /// To create an instance of Tesseract
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen(constructor))]
     pub fn new() -> Tesseract {
         Tesseract::default()
     }
+}
 
+impl Tesseract {
     /// Enable the ability to autosave
     ///
     /// # Example


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Remove visibility of `Config` fields and add getters and `_mut` functions
- Remove redundant `Result` from `WarpIpfs::new`
- Export `WarpIpfs`, `Tesseract` and `Config` if target is `wasm32-unknown-unknown`
- Add `WarpIpfsBuilder::into_future` to return `WarpIpfs`

**Which issue(s) this PR fixes** 🔨
- Relates to #494 

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- The `Config` option may be redone to have it fully internal rather than being supported by externally, although this would need to be looked into to determine the best course if we are to also export it to wasm.
