### PR TITLE
refactor: Poll future, dropping task if entry is dropped or cancelled.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "warp",
     "tools/*",
     "extensions/warp-ipfs/examples/wasm-ipfs-identity",
+    "extensions/warp-ipfs/examples/wasm-ipfs-friends",
 ]
 exclude = ["deprecated/*", "tools/opencv-test", "tools/video-codec-cli"]
 
@@ -93,13 +94,13 @@ void = "1"
 rust-ipfs = "0.11.16"
 
 # wasm crates
-wasm-bindgen = "0.2" 
+wasm-bindgen = "0.2"
 gloo = "0.7"
-web-sys = "0.3" 
-js-sys = "0.3" 
+web-sys = "0.3"
+js-sys = "0.3"
 console_error_panic_hook = "0.1.6"
 wasm-streams = "0.4"
-wasm-bindgen-futures = "0.4" 
+wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.4"
 
 # Blink related crates

--- a/extensions/warp-ipfs/examples/wasm-ipfs-friends/Cargo.toml
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-friends/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "wasm-ipfs-friends"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+futures = "0.3"
+wasm-bindgen = "0.2.90"
+wasm-bindgen-futures = "0.4.42"
+web-sys = { version = "0.3", features = ['Document', 'Element', 'HtmlElement', 'Node', 'Response', 'Window', "console"] }
+js-sys = "0.3.69"
+console_error_panic_hook = "0.1.7"
+serde_json.workspace = true
+serde.workspace = true
+warp.workspace = true
+warp-ipfs.workspace = true
+tracing-wasm = "0.2.1"
+futures-timeout = "0.1"
+tokio = { version = "1", default-features = false, features = ["sync"] }

--- a/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
@@ -1,0 +1,241 @@
+use std::time::Duration;
+
+use futures::StreamExt;
+use futures_timeout::TimeoutExt;
+use warp::crypto::rand::{self, Rng};
+use warp::error::Error;
+use warp::multipass::identity::{Identifier, Identity};
+use warp::multipass::{MultiPass, MultiPassEventKind};
+use warp::tesseract::Tesseract;
+use warp_ipfs::config::Config;
+use warp_ipfs::WarpIpfsBuilder;
+use wasm_bindgen::prelude::*;
+use web_sys::{Document, HtmlElement};
+
+async fn account(username: Option<&str>) -> Result<Box<dyn MultiPass>, Error> {
+    let tesseract = Tesseract::default();
+    tesseract
+        .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
+
+    let config = Config::minimal_testing();
+    let (mut account, _, _) = WarpIpfsBuilder::default()
+        .set_tesseract(tesseract)
+        .set_config(config)
+        .finalize()
+        .await;
+
+    account.create_identity(username, None).await?;
+    Ok(account)
+}
+
+fn username(ident: &Identity) -> String {
+    format!("{}#{}", &ident.username(), &ident.short_id())
+}
+
+#[wasm_bindgen]
+pub async fn run() -> Result<(), JsError> {
+    let mut rng = rand::thread_rng();
+    tracing_wasm::set_as_global_default();
+    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+    let body = Body::from_current_window()?;
+
+    let mut account_a = account(None).await?;
+    let mut subscribe_a = account_a.multipass_subscribe().await?;
+
+    let mut account_b = account(None).await?;
+    let mut subscribe_b = account_b.multipass_subscribe().await?;
+
+    let ident_a = account_a.get_own_identity().await?;
+    let ident_b = account_b.get_own_identity().await?;
+
+    body.append_p(&format!(
+        "{} with {}",
+        username(&ident_a),
+        ident_a.did_key()
+    ))?;
+
+    body.append_p(&format!(
+        "{} with {}",
+        username(&ident_b),
+        ident_b.did_key()
+    ))?;
+    body.append_p("")?;
+
+    account_a.send_request(&ident_b.did_key()).await?;
+    let mut sent = false;
+    let mut received = false;
+    let mut seen_a = false;
+    let mut seen_b = false;
+    loop {
+        tokio::select! {
+            Some(ev) = subscribe_a.next() => {
+                match ev {
+                    MultiPassEventKind::FriendRequestSent { .. } => sent = true,
+                    MultiPassEventKind::IdentityUpdate { did } if did == ident_b.did_key() => seen_b = true,
+                    _ => {}
+                }
+            }
+            Some(ev) = subscribe_b.next() => {
+                match ev {
+                    MultiPassEventKind::FriendRequestReceived { .. } => received = true,
+                    MultiPassEventKind::IdentityUpdate { did } if did == ident_a.did_key() => seen_a = true,
+                    _ => {}
+                }
+            }
+        }
+
+        if sent && received && seen_a && seen_b {
+            break;
+        }
+    }
+
+    body.append_p(&format!("{} Outgoing request:", username(&ident_a)))?;
+
+    for outgoing in account_a.list_outgoing_request().await? {
+        let ident = account_a
+            .get_identity(Identifier::from(outgoing))
+            .await
+            .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+        body.append_p(&format!("To: {}", username(&ident)))?;
+        body.append_p("")?;
+    }
+
+    body.append_p(&format!("{} Incoming request:", username(&ident_b)))?;
+    for incoming in account_b.list_incoming_request().await? {
+        let ident = account_b
+            .get_identity(Identifier::from(incoming))
+            .await
+            .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+
+        body.append_p(&format!("From: {}", username(&ident)))?;
+        body.append_p("")?;
+    }
+
+    let coin = rng.gen_range(0..2);
+    match coin {
+        0 => {
+            body.append_p(&format!("Denying {} friend request", username(&ident_a)))?;
+            account_b.deny_request(&ident_a.did_key()).await?;
+        }
+        _ => {
+            account_b.accept_request(&ident_a.did_key()).await?;
+
+            body.append_p(&format!(
+                "{} accepted {} request",
+                ident_b.username(),
+                ident_a.username()
+            ))?;
+
+            delay().await;
+
+            body.append_p(&format!("{} Friends:", username(&ident_a)))?;
+            for friend in account_a.list_friends().await? {
+                let friend = account_a
+                    .get_identity(Identifier::did_key(friend))
+                    .await
+                    .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+                body.append_p(&format!("Username: {}", username(&friend)))?;
+                body.append_p(&format!("Public Key: {}", friend.did_key()))?;
+                body.append_p("")?;
+            }
+
+            body.append_p(&format!("{} Friends:", username(&ident_b)))?;
+            for friend in account_b.list_friends().await? {
+                let friend = account_b
+                    .get_identity(Identifier::did_key(friend))
+                    .await
+                    .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+                body.append_p(&format!("Username: {}", username(&friend)))?;
+                body.append_p(&format!("Public Key: {}", friend.did_key()))?;
+                body.append_p("")?;
+            }
+
+            if rand::random() {
+                account_a.remove_friend(&ident_b.did_key()).await?;
+                if account_a.has_friend(&ident_b.did_key()).await? {
+                    body.append_p(&format!(
+                        "{} is stuck with {} forever",
+                        username(&ident_a),
+                        username(&ident_b)
+                    ))?;
+                } else {
+                    body.append_p(&format!(
+                        "{} removed {}",
+                        username(&ident_a),
+                        username(&ident_b)
+                    ))?;
+                }
+            } else {
+                account_b.remove_friend(&ident_a.did_key()).await?;
+                if account_b.has_friend(&ident_a.did_key()).await? {
+                    body.append_p(&format!(
+                        "{} is stuck with {} forever",
+                        username(&ident_b),
+                        username(&ident_a)
+                    ))?;
+                } else {
+                    body.append_p(&format!(
+                        "{} removed {}",
+                        username(&ident_b),
+                        username(&ident_a)
+                    ))?;
+                }
+            }
+        }
+    }
+
+    body.append_p("")?;
+
+    Ok(())
+}
+
+//Note: Because of the internal nature of this extension and not reliant on a central confirmation, this will be used to add delays to allow the separate
+//      background task to complete its action
+async fn delay() {
+    fixed_delay(1500).await;
+}
+
+async fn fixed_delay(millis: u64) {
+    _ = futures::future::pending::<()>()
+        .timeout(Duration::from_millis(millis))
+        .await
+}
+
+struct Body {
+    body: HtmlElement,
+    document: Document,
+}
+
+impl Body {
+    fn from_current_window() -> Result<Self, JsError> {
+        // Use `web_sys`'s global `window` function to get a handle on the global
+        // window object.
+        let document = web_sys::window()
+            .ok_or(js_error("no global `window` exists"))?
+            .document()
+            .ok_or(js_error("should have a document on window"))?;
+        let body = document
+            .body()
+            .ok_or(js_error("document should have a body"))?;
+
+        Ok(Self { body, document })
+    }
+
+    fn append_p(&self, msg: &str) -> Result<(), JsError> {
+        let val = self
+            .document
+            .create_element("p")
+            .map_err(|_| js_error("failed to create <p>"))?;
+        val.set_text_content(Some(msg));
+        self.body
+            .append_child(&val)
+            .map_err(|_| js_error("failed to append <p>"))?;
+
+        Ok(())
+    }
+}
+
+fn js_error(msg: &str) -> JsError {
+    std::io::Error::new(std::io::ErrorKind::Other, msg).into()
+}

--- a/extensions/warp-ipfs/examples/wasm-ipfs-friends/static/index.html
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-friends/static/index.html
@@ -1,0 +1,12 @@
+<html>
+    <head>
+        <title>Friends Example</title>
+    </head>
+    <body>
+        <script type="module" defer>
+            import init, { run } from "./wasm_ipfs_friends.js"
+            await init();
+            run();
+        </script>
+    </body>
+</html>

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -1,4 +1,4 @@
-use ipfs::Multiaddr;
+use ipfs::{Multiaddr, Protocol};
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
 use std::{path::PathBuf, str::FromStr, time::Duration};
@@ -399,6 +399,7 @@ impl Config {
     pub fn testing() -> Config {
         Config {
             bootstrap: Bootstrap::Ipfs,
+            listen_on: vec![Multiaddr::empty().with(Protocol::Memory(0))],
             ipfs_setting: IpfsSetting {
                 bootstrap: true,
                 mdns: Mdns { enable: true },
@@ -424,6 +425,7 @@ impl Config {
     pub fn minimal_testing() -> Config {
         Config {
             bootstrap: Bootstrap::Ipfs,
+            listen_on: vec![Multiaddr::empty().with(Protocol::Memory(0))],
             ipfs_setting: IpfsSetting {
                 bootstrap: true,
                 mdns: Mdns { enable: true },

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -439,7 +439,7 @@ impl Config {
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
     pub fn minimal_testing() -> Config {
         Config {
-            bootstrap: Bootstrap::Ipfs,
+            bootstrap: Bootstrap::None,
             listen_on: vec![Multiaddr::empty().with(Protocol::Memory(0))],
             ipfs_setting: IpfsSetting {
                 bootstrap: true,

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -405,6 +405,7 @@ impl Config {
                 relay_client: RelayClient {
                     ..Default::default()
                 },
+                memory_transport: true,
                 ..Default::default()
             },
             store_setting: StoreSetting {
@@ -429,6 +430,7 @@ impl Config {
                 relay_client: RelayClient {
                     ..Default::default()
                 },
+                memory_transport: true,
                 ..Default::default()
             },
             store_setting: StoreSetting {

--- a/extensions/warp-ipfs/src/store/discovery.rs
+++ b/extensions/warp-ipfs/src/store/discovery.rs
@@ -12,6 +12,7 @@ use tokio::{
     sync::{broadcast, RwLock},
     task::JoinHandle,
 };
+use tokio_util::sync::{CancellationToken, DropGuard};
 use warp::{crypto::DID, error::Error};
 
 use crate::config::{Discovery as DiscoveryConfig, DiscoveryType};
@@ -313,7 +314,7 @@ pub struct DiscoveryEntry {
     ipfs: Ipfs,
     peer_id: PeerId,
     config: DiscoveryConfig,
-    task: Arc<RwLock<Option<JoinHandle<()>>>>,
+    drop_guard: Arc<RwLock<Option<DropGuard>>>,
     sender: broadcast::Sender<DID>,
     relays: Vec<Multiaddr>,
 }
@@ -344,20 +345,23 @@ impl DiscoveryEntry {
             ipfs: ipfs.clone(),
             peer_id,
             config,
-            task: Arc::default(),
+            drop_guard: Arc::default(),
             sender,
             relays,
         }
     }
 
     pub async fn start(&self) {
-        let holder = &mut *self.task.write().await;
+        let holder = &mut *self.drop_guard.write().await;
 
         if holder.is_some() {
             return;
         }
 
-        let task = tokio::spawn({
+        let token = CancellationToken::new();
+        let drop_guard = token.clone().drop_guard();
+
+        let fut = {
             let entry = self.clone();
             let ipfs = self.ipfs.clone();
             let peer_id = self.peer_id;
@@ -433,9 +437,18 @@ impl DiscoveryEntry {
                     futures_timer::Delay::new(Duration::from_secs(10)).await;
                 }
             }
+        };
+
+        crate::rt::spawn(async move {
+            futures::pin_mut!(fut);
+
+            tokio::select! {
+                _ = token.cancelled() => {}
+                _ = &mut fut => {}
+            }
         });
 
-        *holder = Some(task);
+        *holder = Some(drop_guard);
     }
 
     /// Returns a peer id
@@ -444,11 +457,9 @@ impl DiscoveryEntry {
     }
 
     pub async fn cancel(&self) {
-        let task = std::mem::take(&mut *self.task.write().await);
-        if let Some(task) = task {
-            if !task.is_finished() {
-                task.abort();
-            }
+        let task = std::mem::take(&mut *self.drop_guard.write().await);
+        if let Some(guard) = task {
+            drop(guard)
         }
     }
 }

--- a/warp/src/js_exports.rs
+++ b/warp/src/js_exports.rs
@@ -1,10 +1,10 @@
-use js_sys::Uint8Array;
-use std::str::FromStr;
 use crate::crypto::DID;
 use crate::multipass::{
     identity::{self, Identity, IdentityProfile},
     MultiPass,
 };
+use js_sys::Uint8Array;
+use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Poll future directly
- Drop task when cancelled or when entry is dropped
- Use `rt::spawn` instead for compatibility between native and wasm.

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
Relates to #494 

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
