### PR TITLE
chore: fix js tesseract.save() panic on None key

### DIFF
--- a/warp/src/tesseract/mod.rs
+++ b/warp/src/tesseract/mod.rs
@@ -824,11 +824,14 @@ impl TesseractInner {
                 let local_storage = LocalStorage::raw();
                 let length = LocalStorage::length();
                 for index in 0..length {
-                    let key = local_storage.key(index).unwrap().unwrap();
-                    if !key.starts_with(Self::NAMESPACE) {
-                        continue;
+                    if let Ok(key) = local_storage.key(index) {
+                        if let Some(key) = key {
+                            if !key.starts_with(Self::NAMESPACE) {
+                                continue;
+                            }
+                            LocalStorage::delete(&key);
+                        }
                     }
-                    LocalStorage::delete(&key);
                 }
             }
             for (k, v) in &*self.internal.read() {


### PR DESCRIPTION
**What this PR does** 📖

I ran into an issue where Tesseract.save() on js panics when a key turns out to be None. This prevents save() from panicking when that happens.

**Which issue(s) this PR fixes** 🔨

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
