### PR TITLE
chore: Disable dcutr under wasm target and update default relay addr

### DIFF
--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -405,16 +405,12 @@ impl Config {
     #[cfg(target_arch = "wasm32")]
     #[wasm_bindgen::prelude::wasm_bindgen]
     pub fn minimal_with_relay(addresses: Vec<String>) -> Config {
-        Config {
+        let mut config = Config {
             persist: true,
             bootstrap: Bootstrap::None,
             listen_on: vec![],
             ipfs_setting: IpfsSetting {
                 relay_client: RelayClient {
-                    relay_address: addresses
-                        .into_iter()
-                        .filter_map(|addr| addr.parse().ok())
-                        .collect::<Vec<_>>(),
                     background: false,
                     ..Default::default()
                 },
@@ -426,7 +422,15 @@ impl Config {
                 ..Default::default()
             },
             ..Default::default()
+        };
+        let addrs = addresses
+            .into_iter()
+            .filter_map(|addr| addr.parse().ok())
+            .collect::<Vec<_>>();
+        if !addrs.is_empty() {
+            config.ipfs_setting.relay_client.relay_address = addrs;
         }
+        config
     }
 
     /// Minimal production configuration

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -361,13 +361,14 @@ impl Config {
     pub fn minimal_testing() -> Config {
         Config {
             bootstrap: Bootstrap::None,
-            listen_on: vec![Multiaddr::empty().with(Protocol::Memory(0))],
+            listen_on: vec![],
             ipfs_setting: IpfsSetting {
                 mdns: Mdns { enable: true },
                 relay_client: RelayClient {
+                    background: false,
                     ..Default::default()
                 },
-                memory_transport: true,
+                memory_transport: false,
                 ..Default::default()
             },
             store_setting: StoreSetting {
@@ -383,12 +384,13 @@ impl Config {
         Config {
             persist: true,
             bootstrap: Bootstrap::None,
-            listen_on: vec![Multiaddr::empty().with(Protocol::Memory(0))],
+            listen_on: vec![],
             ipfs_setting: IpfsSetting {
                 relay_client: RelayClient {
+                    background: false,
                     ..Default::default()
                 },
-                memory_transport: true,
+                memory_transport: false,
                 ..Default::default()
             },
             store_setting: StoreSetting {

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -405,16 +405,17 @@ impl Config {
         Config {
             persist: true,
             bootstrap: Bootstrap::None,
-            listen_on: vec![Multiaddr::empty().with(Protocol::Memory(0))],
+            listen_on: vec![],
             ipfs_setting: IpfsSetting {
                 relay_client: RelayClient {
                     relay_address: addresses
                         .into_iter()
                         .filter_map(|addr| addr.parse().ok())
                         .collect::<Vec<_>>(),
+                    background: false,
                     ..Default::default()
                 },
-                memory_transport: true,
+                memory_transport: false,
                 ..Default::default()
             },
             store_setting: StoreSetting {

--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -86,18 +86,19 @@ impl Default for RelayClient {
                 "/ip4/24.199.86.91/tcp/46315/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap()
             ],
             // Relays that are meant to be used from a web standpoint.
-            // Note: webrtc addresses are prone to change due an upstream issue and shouldnt be relied on for primary connections
             #[cfg(target_arch="wasm32")]
             relay_address: vec![
-                //NYC-1
-                "/ip4/146.190.184.59/tcp/4001/wss/p2p/12D3KooWCHWLQXTR2N6ukWM99pZYc4TM82VS7eVaDE4Ryk8ked8h".parse().unwrap(),
-                "/ip4/146.190.184.59/udp/4002/webrtc-direct/certhash/uEiC7m8m2pxf_DHr488akg-wSAxsa-f2agH5zc2nE70vx_g/p2p/12D3KooWCHWLQXTR2N6ukWM99pZYc4TM82VS7eVaDE4Ryk8ked8h".parse().unwrap(),
-                //SF-1
-                "/ip4/64.225.88.100/tcp/4001/wss/p2p/12D3KooWMfyuTCbehQYy68zPH6vpGUwg8raKbrS7pd3qZrG7bFuB".parse().unwrap(),
-                "/ip4/64.225.88.100/udp/4002/webrtc-direct/certhash/uEiD25LqH8FlAgimcIY4XB1QiHHROlCYn7WJIukuRMe3tfQ/p2p/12D3KooWMfyuTCbehQYy68zPH6vpGUwg8raKbrS7pd3qZrG7bFuB".parse().unwrap(),
-                //NYC-1-EXP
-                "/ip4/24.199.86.91/tcp/46315/wss/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap(),
-                "/ip4/24.199.86.91/udp/4002/webrtc-direct/certhash/uEiCZ8YAx_IZ7_x5dKltFESWHe4TUg8_gYpla6tmWR9jlfw/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap()
+                // Note: This should not be used in production and may change in the near future
+                "/ip4/167.71.93.202/tcp/4001/ws/p2p/12D3KooWSsn13GxHchpG6dtr7o6ARqSkcMtsBuojgL9XU9t1M1uE".parse().unwrap()
+                // // NYC-1
+                // "/ip4/146.190.184.59/tcp/4001/wss/p2p/12D3KooWCHWLQXTR2N6ukWM99pZYc4TM82VS7eVaDE4Ryk8ked8h".parse().unwrap(),
+                // "/ip4/146.190.184.59/udp/4002/webrtc-direct/certhash/uEiC7m8m2pxf_DHr488akg-wSAxsa-f2agH5zc2nE70vx_g/p2p/12D3KooWCHWLQXTR2N6ukWM99pZYc4TM82VS7eVaDE4Ryk8ked8h".parse().unwrap(),
+                // //SF-1
+                // "/ip4/64.225.88.100/tcp/4001/wss/p2p/12D3KooWMfyuTCbehQYy68zPH6vpGUwg8raKbrS7pd3qZrG7bFuB".parse().unwrap(),
+                // "/ip4/64.225.88.100/udp/4002/webrtc-direct/certhash/uEiD25LqH8FlAgimcIY4XB1QiHHROlCYn7WJIukuRMe3tfQ/p2p/12D3KooWMfyuTCbehQYy68zPH6vpGUwg8raKbrS7pd3qZrG7bFuB".parse().unwrap(),
+                // //NYC-1-EXP
+                // "/ip4/24.199.86.91/tcp/46315/wss/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap(),
+                // "/ip4/24.199.86.91/udp/4002/webrtc-direct/certhash/uEiCZ8YAx_IZ7_x5dKltFESWHe4TUg8_gYpla6tmWR9jlfw/p2p/12D3KooWQcyxuNXxpiM7xyoXRZC7Vhfbh2yCtRg272CerbpFkhE6".parse().unwrap()
             ],
             background: true,
             quorum: Default::default()

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -331,7 +331,7 @@ impl WarpIpfs {
                 max_transmit_size: PUBSUB_MAX_BUF,
                 ..Default::default()
             })
-            .with_relay(true)
+            .with_relay(!cfg!(target_arch = "wasm32"))
             .set_listening_addrs(self.inner.config.listen_on().to_vec())
             .with_custom_behaviour(behaviour)
             .set_keypair(&keypair)

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -342,7 +342,7 @@ impl WarpIpfs {
                 // as such connections would be established through the relay
                 enable_websocket: cfg!(target_arch = "wasm32"),
                 enable_secure_websocket: cfg!(target_arch = "wasm32"),
-                enable_webrtc: cfg!(target_arch = "wasm32"),
+                // enable_webrtc: cfg!(target_arch = "wasm32"),
                 ..Default::default()
             });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Disables dcutr under wasm target to prevent hole punching attempts since the browser doesnt allow hole punching.
- Remove memory addresses from under minimal config
- Disable relay background task under minimal config
- Update relay addrs

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️
- Note that while connecting to the relay will run sequentially, this may stall the initialization operation until the connection and reservation has either completed or failed.

**Additional comments** 🎤
