### PR TITLE
feat: Add MultiPass::tesseract

### DIFF
--- a/extensions/warp-ipfs/examples/from-js/ipfs-friends.html
+++ b/extensions/warp-ipfs/examples/from-js/ipfs-friends.html
@@ -10,16 +10,15 @@
       console.log(wasm)
 
       async function account(username) {
-        let tesseract = new wasm.Tesseract()
-        tesseract.load_from_storage()
-
-        const passphrase = new Uint8Array([1,2,3,4,5,6,7,8,9,0]);
-        tesseract.unlock(passphrase)
-        
-        let ipfs = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), tesseract)
+        let ipfs = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), null)
         
         let multipass = ipfs.multipass
         
+        let tesseract = multipass.tesseract()
+
+        const passphrase = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+        tesseract.unlock(passphrase)
+
         let profile = await multipass.create_identity(username, null)
 
         return multipass

--- a/extensions/warp-ipfs/examples/from-js/ipfs-identity.html
+++ b/extensions/warp-ipfs/examples/from-js/ipfs-identity.html
@@ -9,19 +9,17 @@
     init().then(async (_exports) => {
       console.log(wasm)
 
-      let tesseract = new wasm.Tesseract()
-      tesseract.load_from_storage()
-      console.log(`loaded data`)
-
-      const passphrase = new Uint8Array([1,2,3,4,5,6,7,8,9,0]);
-      tesseract.unlock(passphrase)
-      console.log(`unlocked`)
-
-      let ipfs = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), tesseract)
+      let ipfs = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), null)
       console.log(ipfs)
       
       let multipass = ipfs.multipass
       console.log(multipass)
+
+      let tesseract = multipass.tesseract()
+
+      const passphrase = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+      tesseract.unlock(passphrase)
+      console.log(`unlocked`)
 
       //let identity = await multipass.create_identity("username", "crop cash unable insane eight faith inflict route frame loud box vibrant")
       let profile = await multipass.create_identity(null, null)

--- a/extensions/warp-ipfs/examples/from-js/ipfs-persistent.html
+++ b/extensions/warp-ipfs/examples/from-js/ipfs-persistent.html
@@ -8,13 +8,13 @@
     import init, * as wasm from './built-wasm/warp-ipfs/warp_ipfs.js';
     init().then(async (_exports) => {
       console.log(wasm)
+      let ipfs = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), null)
+      
+      let tesseract = multipass.tesseract()
 
-      let tesseract = new wasm.Tesseract()
-      tesseract.load_from_storage()
-      const passphrase = new Uint8Array([1,2,3,4,5,6,7,8,9,0]);
+      const passphrase = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
       tesseract.unlock(passphrase)
 
-      let ipfs = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), tesseract)
       let profile = await ipfs.multipass.create_identity(null, null)
       
       await ipfs.constellation.put_buffer("image.png", IMAGE)

--- a/extensions/warp-ipfs/examples/from-js/ipfs-raygun.html
+++ b/extensions/warp-ipfs/examples/from-js/ipfs-raygun.html
@@ -10,13 +10,12 @@
       console.log(wasm)
 
       async function account() {
-        let tesseract = new wasm.Tesseract()
-        tesseract.load_from_storage()
+        let warp = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), null)
 
-        const passphrase = new Uint8Array([1,2,3,4,5,6,7,8,9,0]);
+        let tesseract = warp.multipass.tesseract()
+
+        const passphrase = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
         tesseract.unlock(passphrase)
-        
-        let warp = await new wasm.WarpIpfs(wasm.Config.minimal_testing(), tesseract)
 
         await warp.multipass.create_identity(null, null)
 

--- a/extensions/warp-ipfs/examples/from-js/tesseract.html
+++ b/extensions/warp-ipfs/examples/from-js/tesseract.html
@@ -10,8 +10,6 @@
       console.log(wasm)
 
       let tesseract = new wasm.Tesseract()
-      tesseract.load_from_storage()
-      console.log(`loaded data`)
 
       const passphrase = new Uint8Array([1,2,3,4,5,6,7,8,9,0]);
       //self.crypto.getRandomValues(passphrase);

--- a/extensions/warp-ipfs/examples/ipfs-example.rs
+++ b/extensions/warp-ipfs/examples/ipfs-example.rs
@@ -1,16 +1,12 @@
-use warp::tesseract::Tesseract;
 use warp_ipfs::WarpIpfsBuilder;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let tesseract = Tesseract::default();
-    tesseract
-        .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
+    let (mut account, _, mut filesystem) = WarpIpfsBuilder::default().finalize().await;
 
-    let (mut account, _, mut filesystem) = WarpIpfsBuilder::default()
-        .set_tesseract(tesseract)
-        .finalize()
-        .await;
+    account
+        .tesseract()
+        .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
 
     account.create_identity(None, None).await?;
 

--- a/extensions/warp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-ipfs/examples/ipfs-friends.rs
@@ -1,25 +1,24 @@
 use std::time::Duration;
 
 use futures::StreamExt;
+
 use warp::crypto::rand::{self, prelude::*};
 use warp::error::Error;
 use warp::multipass::identity::{Identifier, Identity};
 use warp::multipass::{MultiPass, MultiPassEventKind};
-use warp::tesseract::Tesseract;
 use warp_ipfs::config::Config;
 use warp_ipfs::WarpIpfsBuilder;
 
 async fn account(username: Option<&str>) -> anyhow::Result<Box<dyn MultiPass>> {
-    let tesseract = Tesseract::default();
-    tesseract
-        .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
-
     let config = Config::development();
     let (mut account, _, _) = WarpIpfsBuilder::default()
-        .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
         .await;
+
+    account
+        .tesseract()
+        .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
 
     account.create_identity(username, None).await?;
     Ok(account)

--- a/extensions/warp-ipfs/examples/ipfs-identity.rs
+++ b/extensions/warp-ipfs/examples/ipfs-identity.rs
@@ -33,6 +33,10 @@ async fn main() -> anyhow::Result<()> {
         .finalize()
         .await;
 
+    identity
+        .tesseract()
+        .unlock(b"this is my totally secured password that should nnever be embedded in code")?;
+
     let profile = identity.create_identity(None, None).await?;
 
     let ident = profile.identity();

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -1,18 +1,20 @@
+use std::env::temp_dir;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::time::Duration;
+
 use clap::Parser;
 use comfy_table::Table;
 use futures::prelude::*;
 use futures::stream::BoxStream;
 use rust_ipfs::Multiaddr;
 use rustyline_async::{Readline, SharedWriter};
-use std::env::temp_dir;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::time::Duration;
 use strum::IntoEnumIterator;
 use tokio_stream::StreamMap;
 use tracing_subscriber::EnvFilter;
 use uuid::Uuid;
+
 use warp::constellation::{Constellation, Progression};
 use warp::crypto::zeroize::Zeroizing;
 use warp::crypto::DID;
@@ -23,7 +25,6 @@ use warp::raygun::{
     MessageEventKind, MessageOptions, MessageStream, MessageType, Messages, MessagesType, PinState,
     RayGun, ReactionState,
 };
-use warp::tesseract::Tesseract;
 use warp_ipfs::config::{Bootstrap, Discovery, DiscoveryType};
 use warp_ipfs::WarpIpfsBuilder;
 
@@ -75,19 +76,6 @@ async fn setup<P: AsRef<Path>>(
     (Box<dyn MultiPass>, Box<dyn RayGun>, Box<dyn Constellation>),
     Option<IdentityProfile>,
 )> {
-    let tesseract = match path.as_ref() {
-        Some(path) => {
-            let path = path.as_ref();
-            let tesseract = Tesseract::from_file(path.join("tesseract_store")).unwrap_or_default();
-            tesseract.set_file(path.join("tesseract_store"));
-            tesseract.set_autosave();
-            tesseract
-        }
-        None => Tesseract::default(),
-    };
-
-    tesseract.unlock(passphrase.as_bytes())?;
-
     let mut config = match path.as_ref() {
         Some(path) => warp_ipfs::config::Config::production(path),
         None => warp_ipfs::config::Config::testing(),
@@ -135,10 +123,11 @@ async fn setup<P: AsRef<Path>>(
     config.ipfs_setting_mut().mdns.enable = opt.mdns;
 
     let (mut account, raygun, filesystem) = WarpIpfsBuilder::default()
-        .set_tesseract(tesseract)
         .set_config(config)
         .finalize()
         .await;
+
+    account.tesseract().unlock(passphrase.as_bytes())?;
 
     let mut profile = None;
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -188,7 +188,7 @@ impl WarpIpfs {
             None => {
                 #[cfg(target_arch = "wasm32")]
                 {
-                    let mut tesseract = Tesseract::default();
+                    let tesseract = Tesseract::default();
                     _ = tesseract.load_from_storage();
                     tesseract
                 }

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -106,7 +106,7 @@ pub struct WarpIpfsBuilder {
     // use_multipass: bool,
     // use_raygun: bool,
     // use_constellation: bool,
-    tesseract: Tesseract,
+    tesseract: Option<Tesseract>,
 }
 
 impl WarpIpfsBuilder {
@@ -116,7 +116,7 @@ impl WarpIpfsBuilder {
     }
 
     pub fn set_tesseract(mut self, tesseract: Tesseract) -> Self {
-        self.tesseract = tesseract;
+        self.tesseract = Some(tesseract);
         self
     }
 
@@ -163,7 +163,10 @@ impl WarpIpfs {
         target_arch = "wasm32",
         wasm_bindgen::prelude::wasm_bindgen(constructor)
     )]
-    pub async fn new_wasm(config: Config, tesseract: Tesseract) -> warp::js_exports::WarpInstance {
+    pub async fn new_wasm(
+        config: Config,
+        tesseract: Option<Tesseract>,
+    ) -> warp::js_exports::WarpInstance {
         let warp_ipfs = WarpIpfs::new(config, tesseract).await;
         let mp = Box::new(warp_ipfs.clone()) as Box<_>;
         let rg = Box::new(warp_ipfs.clone()) as Box<_>;
@@ -173,11 +176,35 @@ impl WarpIpfs {
 }
 
 impl WarpIpfs {
-    pub async fn new(config: Config, tesseract: Tesseract) -> WarpIpfs {
+    pub async fn new(config: Config, tesseract: impl Into<Option<Tesseract>>) -> WarpIpfs {
         let multipass_tx = EventSubscription::new();
         let raygun_tx = EventSubscription::new();
         let constellation_tx = EventSubscription::new();
         let span = RwLock::new(Span::current());
+
+        let tesseract = match tesseract.into() {
+            Some(tesseract) => tesseract,
+            None if !config.persist() => Tesseract::default(),
+            None => {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    let mut tesseract = Tesseract::default();
+                    _ = tesseract.load_from_storage();
+                    tesseract
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    // Note: We could probably assert here since a path should be supplied when is it persist,
+                    //       but for now we will create a default tesseract if Config::path is `None`
+                    match config.path() {
+                        Some(path) => {
+                            Tesseract::open_or_create(path, "tesseract.bin").unwrap_or_default()
+                        }
+                        None => Tesseract::default(),
+                    }
+                }
+            }
+        };
 
         let inner = Arc::new(Inner {
             config,
@@ -1143,6 +1170,10 @@ impl MultiPass for WarpIpfs {
         }
 
         store.identity_update(identity).await
+    }
+
+    fn tesseract(&self) -> Tesseract {
+        self.tesseract.clone()
     }
 }
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -190,6 +190,7 @@ impl WarpIpfs {
                 {
                     let tesseract = Tesseract::default();
                     _ = tesseract.load_from_storage();
+                    tesseract.set_autosave();
                     tesseract
                 }
                 #[cfg(not(target_arch = "wasm32"))]

--- a/tools/relay-server/src/config.rs
+++ b/tools/relay-server/src/config.rs
@@ -36,6 +36,7 @@ impl Identity {
         let engine = GeneralPurpose::new(&STANDARD, PAD);
         let keypair_bytes = Zeroizing::new(engine.decode(self.priv_key.as_bytes())?);
         let keypair = Keypair::from_protobuf_encoding(&keypair_bytes)?;
+        assert_eq!(self.peer_id, keypair.public().to_peer_id());
         Ok(keypair)
     }
 }

--- a/warp/src/js_exports/multipass.rs
+++ b/warp/src/js_exports/multipass.rs
@@ -6,6 +6,7 @@ use crate::{
         identity::{self, Identity, IdentityProfile},
         MultiPass,
     },
+    tesseract::Tesseract,
 };
 use futures::StreamExt;
 use js_sys::Uint8Array;
@@ -51,6 +52,10 @@ impl MultiPassBox {
 
     pub async fn identity(&self) -> Result<Identity, JsError> {
         self.inner.identity().await.map_err(|e| e.into())
+    }
+
+    pub fn tesseract(&self) -> Tesseract {
+        self.inner.tesseract()
     }
 
     pub async fn update_identity(

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -1,6 +1,4 @@
 #![allow(clippy::result_large_err)]
-pub mod generator;
-pub mod identity;
 
 use std::path::PathBuf;
 
@@ -8,15 +6,18 @@ use dyn_clone::DynClone;
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 
-use crate::error::Error;
-
-use crate::{Extension, SingleHandle};
 use identity::Identity;
 
 use crate::crypto::DID;
+use crate::error::Error;
 use crate::multipass::identity::{Identifier, IdentityUpdate};
+use crate::tesseract::Tesseract;
+use crate::{Extension, SingleHandle};
 
 use self::identity::{IdentityImage, IdentityProfile, IdentityStatus, Platform, Relationship};
+
+pub mod generator;
+pub mod identity;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -95,6 +96,8 @@ pub trait MultiPass:
 
     /// Update your own [`Identity`] using [`IdentityUpdate`]
     async fn update_identity(&mut self, option: IdentityUpdate) -> Result<(), Error>;
+
+    fn tesseract(&self) -> Tesseract;
 }
 
 dyn_clone::clone_trait_object!(MultiPass);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add `MultiPass::tesseract`
- Support creating/loading tesseract instance if one is not supplied

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This PR will allow one to move away from using any of tesseract loading/creating functions and move it internally if a tesseract instance is not supplied to `WarpIpfs`.
- Additionally, This PR will be used in a later PR that introduces `MultiPass::unlock` and `MultiPass::lock` to allow explicit locking/unlocking. 
