### PR TITLE
chore: Remove unused function

### DIFF
--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -39,7 +39,7 @@ use warp::{
 
 use crate::{
     config::{self, Discovery as DiscoveryConfig},
-    store::{discovery::Discovery, topics::PeerTopic, DidExt, PeerIdExt},
+    store::{MAX_STATUS_LENGTH, discovery::Discovery, topics::PeerTopic, DidExt, PeerIdExt},
 };
 
 use super::payload::PayloadBuilder;

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -2351,12 +2351,12 @@ impl IdentityStore {
         {
             if let Some(status) = identity.status_message() {
                 let len = status.chars().count();
-                if len >= 512 {
+                if len >= MAX_STATUS_LENGTH {
                     return Err(Error::InvalidLength {
                         context: "status".into(),
                         current: len,
                         minimum: None,
-                        maximum: Some(512),
+                        maximum: Some(MAX_STATUS_LENGTH),
                     });
                 }
             }


### PR DESCRIPTION
**What this PR does** 📖


Uses the const `MAX_STATUS_LENGTH` instead of `512`. It was already being used everywhere else in `warp-ipfs`, but not in this case. Also, `512` is value of `MAX_STATUS_LENGTH`

**Which issue(s) this PR fixes** 🔨

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
