### PR TITLE
fix(wasm): fix a field and method named wrongly from files to message id

### DIFF
--- a/warp/src/js_exports/raygun.rs
+++ b/warp/src/js_exports/raygun.rs
@@ -782,14 +782,14 @@ impl Into<raygun::Location> for AttachmentFile {
 
 #[wasm_bindgen]
 pub struct AttachmentResult {
-    file: String,
+    message_id: String,
     stream: AsyncIterator,
 }
 
 #[wasm_bindgen]
 impl AttachmentResult {
-    pub fn get_file(&self) -> String {
-        self.file.clone()
+    pub fn get_message_id(&self) -> String {
+        self.message_id.clone()
     }
 
     pub async fn next(&mut self) -> std::result::Result<Promise, JsError> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖

- Fixes a wrongly named method/name for attachments. Where it was named file but it actually returns the message id