### PR TITLE
refactor: Change MultiPass::get_identity to return a stream

### DIFF
--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -210,10 +210,9 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
+
                             if !opt.autoaccept_friend {
                                 writeln!(stdout, "> Pending request from {username}. Do \"request accept {did}\" to accept.")?;
                             } else {
@@ -223,139 +222,116 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::FriendRequestSent { to: did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> A request has been sent to {username}. Do \"request close {did}\" to if you wish to close the request")?;
                         }
                         warp::multipass::MultiPassEventKind::IncomingFriendRequestRejected { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> You've rejected {username} request")?;
                         },
                         warp::multipass::MultiPassEventKind::OutgoingFriendRequestRejected { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} rejected your request")?;
                         },
                         warp::multipass::MultiPassEventKind::IncomingFriendRequestClosed { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has retracted their request")?;
                         },
                         warp::multipass::MultiPassEventKind::OutgoingFriendRequestClosed { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
+
 
                             writeln!(stdout, "> Request for {username} has been retracted")?;
                         },
                         warp::multipass::MultiPassEventKind::FriendAdded { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> You are now friends with {username}")?;
                         },
                         warp::multipass::MultiPassEventKind::FriendRemoved { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has been removed from friends list")?;
                         },
                         warp::multipass::MultiPassEventKind::IdentityOnline { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has came online")?;
                         },
                         warp::multipass::MultiPassEventKind::IdentityOffline { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} went offline")?;
                         },
                         warp::multipass::MultiPassEventKind::Blocked { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} was blocked")?;
                         },
                         warp::multipass::MultiPassEventKind::Unblocked { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
+
                             writeln!(stdout, "> {username} was unblocked")?;
                         },
                         warp::multipass::MultiPassEventKind::UnblockedBy { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
+
 
                             writeln!(stdout, "> {username} unblocked you")?;
                         },
                         warp::multipass::MultiPassEventKind::BlockedBy { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
+
 
                             writeln!(stdout, "> {username} blocked you")?;
                         },
                         warp::multipass::MultiPassEventKind::IdentityUpdate { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .ok()
-                                .and_then(|list| list.first().cloned())
                                 .map(|ident| ident.username())
-                                .unwrap_or_else(|| did.to_string());
+                                .unwrap_or_else(|_| did.to_string());
+
                             writeln!(stdout, "> {username} has been updated ")?;
                         }
                     }
@@ -392,7 +368,7 @@ async fn main() -> anyhow::Result<()> {
                             };
                             for friend in friends.iter() {
                                 let username = match account.get_identity(Identifier::did_key(friend.clone())).await {
-                                    Ok(idents) => idents.iter().filter(|ident| ident.did_key().eq(friend)).map(|ident| ident.username()).collect::<Vec<_>>().first().cloned().unwrap_or_default(),
+                                    Ok(ident) => ident.username(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -414,7 +390,7 @@ async fn main() -> anyhow::Result<()> {
                             };
                             for item in block_list.iter() {
                                 let username = match account.get_identity(Identifier::did_key(item.clone())).await {
-                                    Ok(idents) => idents.iter().filter(|ident| ident.did_key().eq(item)).map(|ident| ident.username()).collect::<Vec<_>>().first().cloned().unwrap_or_default(),
+                                    Ok(ident) => ident.username(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -621,8 +597,8 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
                             for request in list.iter() {
-                                let username = match account.get_identity(Identifier::did_key(request.clone())).await {
-                                    Ok(idents) => idents.iter().filter(|ident| ident.did_key().eq(request)).map(|ident| ident.username()).collect::<Vec<_>>().first().cloned().unwrap_or(String::from("N/A")),
+                                 let username = match account.get_identity(Identifier::did_key(request.clone())).await {
+                                    Ok(ident) => ident.username(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -644,7 +620,7 @@ async fn main() -> anyhow::Result<()> {
                             };
                             for request in list.iter() {
                                 let username = match account.get_identity(Identifier::did_key(request.clone())).await {
-                                    Ok(idents) => idents.iter().filter(|ident| ident.did_key().eq(request)).map(|ident| ident.username()).collect::<Vec<_>>().first().cloned().unwrap_or(String::from("N/A")),
+                                    Ok(ident) => ident.username(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -717,7 +693,7 @@ async fn main() -> anyhow::Result<()> {
                             writeln!(stdout, "banner updated")?;
                         },
                         Some("lookup") => {
-                            let idents = match cmd_line.next() {
+                            let id = match cmd_line.next() {
                                 Some("username") => {
                                     let username = match cmd_line.next() {
                                         Some(username) => username,
@@ -726,13 +702,7 @@ async fn main() -> anyhow::Result<()> {
                                             continue;
                                         }
                                     };
-                                    match account.get_identity(Identifier::user_name(username)).await {
-                                        Ok(identity) => identity,
-                                        Err(e) => {
-                                            writeln!(stdout, "Error obtaining identity by username: {e}")?;
-                                            continue;
-                                        }
-                                    }
+                                    Identifier::user_name(username)
                                 },
                                 Some("publickey") | Some("public-key") | Some("didkey") | Some("did-key") | Some("did") => {
                                     let mut keys = vec![];
@@ -746,51 +716,76 @@ async fn main() -> anyhow::Result<()> {
                                         };
                                         keys.push(pk);
                                     }
-                                    match account.get_identity(Identifier::did_keys(keys)).await {
-                                        Ok(identity) => identity,
-                                        Err(e) => {
-                                            writeln!(stdout, "Error obtaining identity by public key: {e}")?;
-                                            continue;
-                                        }
-                                    }
+                                    Identifier::did_keys(keys)
                                 },
                                 Some("own") | None => {
-                                    match account.identity().await {
-                                        Ok(identity) => vec![identity],
+                                    let identity = match account.identity().await {
+                                        Ok(identity) => identity,
                                         Err(e) => {
                                             writeln!(stdout, "Error obtaining own identity: {e}")?;
                                             continue;
                                         }
-                                    }
+                                    };
+
+                                    let mut table = Table::new();
+                                    table.set_header(vec!["Username", "Public Key", "Created", "Last Updated", "Status Message", "Banner", "Picture", "Platform", "Status"]);
+                                    let status = account.identity_status(&identity.did_key()).await.unwrap_or(IdentityStatus::Offline);
+                                    let platform = account.identity_platform(&identity.did_key()).await.unwrap_or_default();
+                                    let profile_picture = account.identity_picture(&identity.did_key()).await.unwrap_or_default();
+                                    let profile_banner = account.identity_banner(&identity.did_key()).await.unwrap_or_default();
+                                    let created = identity.created();
+                                    let modified = identity.modified();
+
+                                    table.add_row(vec![
+                                        identity.username(),
+                                        identity.did_key().to_string(),
+                                        created.to_string(),
+                                        modified.to_string(),
+                                        identity.status_message().unwrap_or_default(),
+                                        (!profile_banner.data().is_empty()).to_string(),
+                                        (!profile_picture.data().is_empty()).to_string(),
+                                        platform.to_string(),
+                                        format!("{status:?}"),
+                                    ]);
+                                    writeln!(stdout, "{table}")?;
+                                    continue;
                                 },
                                 _ => {
                                     writeln!(stdout, "/lookup <username | publickey> [username | publickey ...]")?;
                                     continue
                                 }
                             };
-                            let mut table = Table::new();
-                            table.set_header(vec!["Username", "Public Key", "Created", "Last Updated", "Status Message", "Banner", "Picture", "Platform", "Status"]);
-                            for identity in idents {
-                                let status = account.identity_status(&identity.did_key()).await.unwrap_or(IdentityStatus::Offline);
-                                let platform = account.identity_platform(&identity.did_key()).await.unwrap_or_default();
-                                let profile_picture = account.identity_picture(&identity.did_key()).await.unwrap_or_default();
-                                let profile_banner = account.identity_banner(&identity.did_key()).await.unwrap_or_default();
-                                let created = identity.created();
-                                let modified = identity.modified();
+                            let stream = account.get_identity(id);
+                            tokio::spawn({
+                                let mut stdout = stdout.clone();
+                                let account = account.clone();
+                                async move {
+                                    let idents = stream.collect::<Vec<_>>().await;
+                                    let mut table = Table::new();
+                                    table.set_header(vec!["Username", "Public Key", "Created", "Last Updated", "Status Message", "Banner", "Picture", "Platform", "Status"]);
+                                    for identity in idents {
+                                        let status = account.identity_status(&identity.did_key()).await.unwrap_or(IdentityStatus::Offline);
+                                        let platform = account.identity_platform(&identity.did_key()).await.unwrap_or_default();
+                                        let profile_picture = account.identity_picture(&identity.did_key()).await.unwrap_or_default();
+                                        let profile_banner = account.identity_banner(&identity.did_key()).await.unwrap_or_default();
+                                        let created = identity.created();
+                                        let modified = identity.modified();
 
-                                table.add_row(vec![
-                                    identity.username(),
-                                    identity.did_key().to_string(),
-                                    created.to_string(),
-                                    modified.to_string(),
-                                    identity.status_message().unwrap_or_default(),
-                                    (!profile_banner.data().is_empty()).to_string(),
-                                    (!profile_picture.data().is_empty()).to_string(),
-                                    platform.to_string(),
-                                    format!("{status:?}"),
-                                ]);
-                            }
-                            writeln!(stdout, "{table}")?;
+                                        table.add_row(vec![
+                                            identity.username(),
+                                            identity.did_key().to_string(),
+                                            created.to_string(),
+                                            modified.to_string(),
+                                            identity.status_message().unwrap_or_default(),
+                                            (!profile_banner.data().is_empty()).to_string(),
+                                            (!profile_picture.data().is_empty()).to_string(),
+                                            platform.to_string(),
+                                            format!("{status:?}"),
+                                        ]);
+                                    }
+                                    writeln!(stdout, "{table}").unwrap();
+                                }
+                            });
                         }
                         _ => continue
                     }

--- a/extensions/warp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-ipfs/examples/ipfs-friends.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use futures::StreamExt;
 
 use warp::crypto::rand::{self, prelude::*};
-use warp::error::Error;
 use warp::multipass::identity::{Identifier, Identity};
 use warp::multipass::{MultiPass, MultiPassEventKind};
 use warp_ipfs::config::Config;
@@ -77,20 +76,14 @@ async fn main() -> anyhow::Result<()> {
     println!("{} Outgoing request:", username(&ident_a));
 
     for outgoing in account_a.list_outgoing_request().await? {
-        let ident = account_a
-            .get_identity(Identifier::from(outgoing))
-            .await
-            .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+        let ident = account_a.get_identity(Identifier::from(outgoing)).await?;
         println!("To: {}", username(&ident));
         println!();
     }
 
     println!("{} Incoming request:", username(&ident_b));
     for incoming in account_b.list_incoming_request().await? {
-        let ident = account_b
-            .get_identity(Identifier::from(incoming))
-            .await
-            .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+        let ident = account_b.get_identity(Identifier::from(incoming)).await?;
 
         println!("From: {}", username(&ident));
         println!();
@@ -115,10 +108,7 @@ async fn main() -> anyhow::Result<()> {
 
             println!("{} Friends:", username(&ident_a));
             for friend in account_a.list_friends().await? {
-                let friend = account_a
-                    .get_identity(Identifier::did_key(friend))
-                    .await
-                    .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+                let friend = account_a.get_identity(Identifier::did_key(friend)).await?;
                 println!("Username: {}", username(&friend));
                 println!("Public Key: {}", friend.did_key());
                 println!();
@@ -126,10 +116,7 @@ async fn main() -> anyhow::Result<()> {
 
             println!("{} Friends:", username(&ident_b));
             for friend in account_b.list_friends().await? {
-                let friend = account_b
-                    .get_identity(Identifier::did_key(friend))
-                    .await
-                    .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+                let friend = account_b.get_identity(Identifier::did_key(friend)).await?;
                 println!("Username: {}", username(&friend));
                 println!("Public Key: {}", friend.did_key());
                 println!();

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -271,10 +271,8 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
                         if !opt.autoaccept_friend {
                             writeln!(stdout, "> Pending request from {username}. Do \"/accept-request {did}\" to accept.")?;
                         } else {
@@ -284,129 +282,103 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::FriendRequestSent { to: did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> A request has been sent to {username}. Do \"/close-request {did}\" to if you wish to close the request")?;
                     }
                     warp::multipass::MultiPassEventKind::IncomingFriendRequestRejected { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> You've rejected {username} request")?;
                     },
                     warp::multipass::MultiPassEventKind::OutgoingFriendRequestRejected { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} rejected your request")?;
                     },
                     warp::multipass::MultiPassEventKind::IncomingFriendRequestClosed { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} has retracted their request")?;
                     },
                     warp::multipass::MultiPassEventKind::OutgoingFriendRequestClosed { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> Request for {username} has been retracted")?;
                     },
                     warp::multipass::MultiPassEventKind::FriendAdded { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> You are now friends with {username}")?;
                     },
                     warp::multipass::MultiPassEventKind::FriendRemoved { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} has been removed from friends list")?;
                     },
                     warp::multipass::MultiPassEventKind::IdentityOnline { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} has came online")?;
                     },
                     warp::multipass::MultiPassEventKind::IdentityOffline { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} went offline")?;
                     },
                     warp::multipass::MultiPassEventKind::Blocked { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} was blocked")?;
                     },
                     warp::multipass::MultiPassEventKind::Unblocked { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
                         writeln!(stdout, "> {username} was unblocked")?;
                     },
                     warp::multipass::MultiPassEventKind::UnblockedBy { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} unblocked you")?;
                     },
                     warp::multipass::MultiPassEventKind::BlockedBy { did } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .ok()
-                            .and_then(|list| list.first().cloned())
                             .map(|ident| ident.username())
-                            .unwrap_or_else(|| did.to_string());
+                            .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} blocked you")?;
                     },
@@ -962,13 +934,7 @@ async fn main() -> anyhow::Result<()> {
                             }
                         },
                         Lookup(id) => {
-                            let identities = match new_account.get_identity(id).await {
-                                Ok(identity) => identity,
-                                Err(e) => {
-                                    writeln!(stdout, "Error obtaining own identity: {e}")?;
-                                    continue;
-                                }
-                            };
+                            let identities = new_account.get_identity(id).collect::<Vec<_>>().await;
                             let mut table = Table::new();
                             table.set_header(vec!["Username", "Public Key", "Created", "Last Updated", "Status Message", "Banner", "Picture", "Platform", "Status"]);
                             for identity in identities {
@@ -1010,11 +976,7 @@ async fn get_username(account: &dyn MultiPass, did: DID) -> String {
     account
         .get_identity(Identifier::did_key(did.clone()))
         .await
-        .map(|list| {
-            list.first()
-                .map(|identity| format!("{}#{}", identity.username(), identity.short_id()))
-                .unwrap_or(did.to_string())
-        })
+        .map(|id| format!("{}#{}", id.username(), id.short_id()))
         .unwrap_or(did.to_string())
 }
 

--- a/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
@@ -93,20 +93,14 @@ pub async fn run() -> Result<(), JsError> {
     body.append_p(&format!("{} Outgoing request:", username(&ident_a)))?;
 
     for outgoing in account_a.list_outgoing_request().await? {
-        let ident = account_a
-            .get_identity(Identifier::from(outgoing))
-            .await
-            .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+        let ident = account_a.get_identity(Identifier::from(outgoing)).await?;
         body.append_p(&format!("To: {}", username(&ident)))?;
         body.append_p("")?;
     }
 
     body.append_p(&format!("{} Incoming request:", username(&ident_b)))?;
     for incoming in account_b.list_incoming_request().await? {
-        let ident = account_b
-            .get_identity(Identifier::from(incoming))
-            .await
-            .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+        let ident = account_b.get_identity(Identifier::from(incoming)).await?;
 
         body.append_p(&format!("From: {}", username(&ident)))?;
         body.append_p("")?;
@@ -131,10 +125,7 @@ pub async fn run() -> Result<(), JsError> {
 
             body.append_p(&format!("{} Friends:", username(&ident_a)))?;
             for friend in account_a.list_friends().await? {
-                let friend = account_a
-                    .get_identity(Identifier::did_key(friend))
-                    .await
-                    .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+                let friend = account_a.get_identity(Identifier::did_key(friend)).await?;
                 body.append_p(&format!("Username: {}", username(&friend)))?;
                 body.append_p(&format!("Public Key: {}", friend.did_key()))?;
                 body.append_p("")?;
@@ -142,10 +133,7 @@ pub async fn run() -> Result<(), JsError> {
 
             body.append_p(&format!("{} Friends:", username(&ident_b)))?;
             for friend in account_b.list_friends().await? {
-                let friend = account_b
-                    .get_identity(Identifier::did_key(friend))
-                    .await
-                    .and_then(|list| list.first().cloned().ok_or(Error::IdentityDoesntExist))?;
+                let friend = account_b.get_identity(Identifier::did_key(friend)).await?;
                 body.append_p(&format!("Username: {}", username(&friend)))?;
                 body.append_p(&format!("Public Key: {}", friend.did_key()))?;
                 body.append_p("")?;

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1446,10 +1446,7 @@ impl IdentityInformation for WarpIpfs {
     }
 
     async fn identity_relationship(&self, did: &DID) -> Result<identity::Relationship, Error> {
-        // self.get_identity(Identifier::did_key(did.clone()))
-        //     .await.timeout(Duration::n)
-        //     .first()
-        //     .ok_or(Error::IdentityDoesntExist)?;
+        self.get_identity(did.into()).await?;
         let friends = self.has_friend(did).await?;
         let received_friend_request = self.received_friend_request_from(did).await?;
         let sent_friend_request = self.sent_friend_request_to(did).await?;

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -871,7 +871,7 @@ impl MultiPass for WarpIpfs {
             _ => return GetIdentity::new(id, stream::empty().boxed()),
         };
 
-        store.lookup_stream(id)
+        store.lookup(id)
     }
 }
 

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1953,15 +1953,13 @@ impl IdentityStore {
                                 yield document.into();
                             }
                         }
-                    } else {
-                        if let (Some(name), Some(code)) = (
+                    } else if let (Some(name), Some(code)) = (
                             split_data.first().map(|s| s.to_lowercase()),
                             split_data.last().map(|s| s.to_lowercase()),
-                        ) {
-                            for await document in cache {
-                                if document.username.to_lowercase().eq(&name) && String::from_utf8_lossy(&document.short_id).to_lowercase().eq(&code) {
+                    ) {
+                        for await document in cache {
+                            if document.username.to_lowercase().eq(&name) && String::from_utf8_lossy(&document.short_id).to_lowercase().eq(&code) {
                                     yield document.into();
-                                }
                             }
                         }
                     }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1954,18 +1954,15 @@ impl IdentityStore {
                             }
                         }
                     } else {
-                        match (
+                        if let (Some(name), Some(code)) = (
                             split_data.first().map(|s| s.to_lowercase()),
                             split_data.last().map(|s| s.to_lowercase()),
                         ) {
-                            (Some(name), Some(code)) => {
-                                for await document in cache {
-                                    if document.username.to_lowercase().eq(&name) && String::from_utf8_lossy(&document.short_id).to_lowercase().eq(&code) {
-                                        yield document.into();
-                                    }
+                            for await document in cache {
+                                if document.username.to_lowercase().eq(&name) && String::from_utf8_lossy(&document.short_id).to_lowercase().eq(&code) {
+                                    yield document.into();
                                 }
                             }
-                            _ => {},
                         }
                     }
                 }

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1952,12 +1952,12 @@ impl IdentityStore {
                             }
                         }
                     } else if let (Some(name), Some(code)) = (
-                            split_data.first().map(|s| s.to_lowercase()),
-                            split_data.last().map(|s| s.to_lowercase()),
+                        split_data.first().map(|s| s.to_lowercase()),
+                        split_data.last().map(|s| s.to_lowercase()),
                     ) {
                         for await document in cache {
                             if document.username.to_lowercase().eq(&name) && String::from_utf8_lossy(&document.short_id).to_lowercase().eq(&code) {
-                                    yield document.into();
+                                yield document.into();
                             }
                         }
                     }

--- a/extensions/warp-ipfs/tests/accounts.rs
+++ b/extensions/warp-ipfs/tests/accounts.rs
@@ -71,11 +71,7 @@ mod test {
         //used to wait for the nodes to discover eachother and provide their identity to each other
         let identity_b = crate::common::timeout(Duration::from_secs(60), async {
             loop {
-                if let Ok(Some(id)) = account_a
-                    .get_identity(did_b.clone().into())
-                    .await
-                    .map(|s| s.first().cloned())
-                {
+                if let Ok(id) = account_a.get_identity(did_b.clone().into()).await {
                     break id;
                 }
             }
@@ -111,13 +107,7 @@ mod test {
 
         let identity_b = crate::common::timeout(Duration::from_secs(60), async {
             loop {
-                if let Some(id) = account_a
-                    .get_identity(String::from("JaneDoe").into())
-                    .await
-                    .expect("Should not fail")
-                    .first()
-                    .cloned()
-                {
+                if let Ok(id) = account_a.get_identity(String::from("JaneDoe").into()).await {
                     break id;
                 }
             }

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -359,6 +359,12 @@ impl From<DID> for Identifier {
     }
 }
 
+impl From<&DID> for Identifier {
+    fn from(did: &DID) -> Self {
+        Self::DID(did.clone())
+    }
+}
+
 impl From<String> for Identifier {
     fn from(username: String) -> Self {
         Self::Username(username)

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -86,7 +86,7 @@ pub trait MultiPass:
     ) -> Result<IdentityProfile, Error>;
 
     /// Obtain an [`Identity`] using [`Identifier`]
-    async fn get_identity(&self, id: Identifier) -> Result<Vec<Identity>, Error>;
+    async fn get_identity(&self, id: Identifier) -> BoxStream<'static, Identity>;
 }
 
 dyn_clone::clone_trait_object!(MultiPass);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- return stream `GetIdentity` for `MultiPass::get_identity`
- remove async signature
- impl future for `GetIdentity` to return a single `Identity`

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- resolves #546

**Special notes for reviewers** 🗒️
- wasm js export of `MultiPass::get_identity` will continue to mimic the previous design for the time being but may add an additional function to work along side so the stream could be used in js instead (eg when asynchronously loading the list). 

**Additional comments** 🎤
- `GetIdentity` is used instead of `BoxStream` since we are also implementing `Future` for the struct to return a single `Identity` if the `Identifier` isnt a list of public keys, though this may change so so only a single key can be used when awaiting the future so it is guaranteed to provide the single `Identity` if it that specific key is available and discoverable. 