### PR TITLE
feature(raygun): add filesize to message attach

### DIFF
--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2170,7 +2170,7 @@ impl ConversationInner {
                             },
                         }
                     }
-                    Location::Stream { name, stream } => {
+                    Location::Stream { name, size, stream } => {
                         let mut filename = name;
 
                         let original = filename.clone();
@@ -2212,7 +2212,7 @@ impl ConversationInner {
 
                         let filename = format!("/{CHAT_DIRECTORY}/{conversation_id}/{filename}");
 
-                        let mut progress = match constellation.put_stream(&filename, None, stream).await {
+                        let mut progress = match constellation.put_stream(&filename, size, stream).await {
                             Ok(stream) => stream,
                             Err(e) => {
                                 error!(%conversation_id, "Error uploading {filename}: {e}");

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -476,6 +476,7 @@ mod test {
                 None,
                 vec![Location::Stream {
                     name: "image.png".into(),
+                    size: Some(PROFILE_IMAGE.len()),
                     stream: futures::stream::once(async { PROFILE_IMAGE.to_vec() }).boxed(),
                 }],
                 vec![],

--- a/warp/src/js_exports/raygun.rs
+++ b/warp/src/js_exports/raygun.rs
@@ -6,7 +6,7 @@ use crate::{
         PinState, RayGun, ReactionState,
     },
 };
-use futures::{StreamExt};
+use futures::StreamExt;
 use js_sys::Promise;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -766,13 +766,13 @@ impl AttachmentFile {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[wasm_bindgen]
 pub struct AttachmentStream {
-    size: usize,
+    size: Option<usize>,
     stream: web_sys::ReadableStream,
 }
 #[wasm_bindgen]
 impl AttachmentStream {
     #[wasm_bindgen(constructor)]
-    pub fn new(size: usize, stream: web_sys::ReadableStream) -> Self {
+    pub fn new(size: Option<usize>, stream: web_sys::ReadableStream) -> Self {
         Self { size, stream }
     }
 }
@@ -781,9 +781,11 @@ impl Into<raygun::Location> for AttachmentFile {
         if let Some(attachment) = self.stream {
             Location::Stream {
                 name: self.file,
-                size: Some(attachment.size),
+                size: attachment.size,
                 stream: {
-                    let stream = InnerStream::from(wasm_streams::ReadableStream::from_raw(attachment.stream));
+                    let stream = InnerStream::from(wasm_streams::ReadableStream::from_raw(
+                        attachment.stream,
+                    ));
                     Box::pin(stream)
                 },
             }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -920,6 +920,7 @@ pub enum Location {
     /// Stream of bytes
     Stream {
         name: String,
+        size: Option<usize>,
         stream: BoxStream<'static, Vec<u8>>,
     },
 }


### PR DESCRIPTION
**What this PR does** 📖

Adds a size field to `Location::Stream`. And changes the wasm part to also pass in the size with the stream
