### PR TITLE
refactor: Change most bytes streams to `Stream<Item = std::io::Result<Vec<u8>>>`

### DIFF
--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["cdylib", "rlib", "staticlib"]
 warp.workspace = true
 
 futures-timeout.workspace = true
+futures-finally = "0.1.0-alpha.2"
 cbor4ii.workspace = true
 rust-ipfs = { workspace = true, features = ["webrtc_transport", "experimental_stream"] }
 libipld.workspace = true

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1658,7 +1658,7 @@ impl RayGunAttachment for WarpIpfs {
         conversation_id: Uuid,
         message_id: Uuid,
         file: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
         self.messaging_store()?
             .download_stream(conversation_id, message_id, file)
             .await

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1777,7 +1777,7 @@ impl Constellation for WarpIpfs {
         &mut self,
         name: &str,
         total_size: Option<usize>,
-        stream: BoxStream<'static, Vec<u8>>,
+        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
     ) -> Result<ConstellationProgressStream, Error> {
         self.file_store()?
             .put_stream(name, total_size, stream)

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1788,7 +1788,7 @@ impl Constellation for WarpIpfs {
     async fn get_stream(
         &self,
         name: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
         self.file_store()?.get_stream(name).await
     }
 

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -533,10 +533,10 @@ impl FileAttachmentDocument {
         ipfs: &Ipfs,
         members: &[PeerId],
         timeout: Option<Duration>,
-    ) -> BoxStream<'static, Result<Vec<u8>, Error>> {
+    ) -> BoxStream<'static, Result<Vec<u8>, std::io::Error>> {
         let link = match Cid::from_str(&self.data) {
             Ok(link) => link,
-            Err(e) => return stream::once(async { Err(anyhow::Error::from(e).into()) }).boxed(),
+            Err(e) => return stream::once(async { Err(std::io::Error::other(e)) }).boxed(),
         };
 
         let stream = ipfs
@@ -547,8 +547,7 @@ impl FileAttachmentDocument {
             .map(|result| {
                 result
                     .map(|b| b.into())
-                    .map_err(anyhow::Error::from)
-                    .map_err(Error::from)
+                    .map_err(std::io::Error::other)
             });
 
         stream.boxed()

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -544,11 +544,7 @@ impl FileAttachmentDocument {
             .cat(link)
             .providers(members)
             .timeout(timeout.unwrap_or(Duration::from_secs(60)))
-            .map(|result| {
-                result
-                    .map(|b| b.into())
-                    .map_err(std::io::Error::other)
-            });
+            .map(|result| result.map(|b| b.into()).map_err(std::io::Error::other));
 
         stream.boxed()
     }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -974,7 +974,10 @@ impl FileTask {
     }
 
     /// Used to download data from the filesystem using a stream
-    fn get_stream(&self, name: &str) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    fn get_stream(
+        &self,
+        name: &str,
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
         let ipfs = self.ipfs.clone();
 
         let item = self.current_directory()?.get_item_by_path(name)?;

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -74,7 +74,7 @@ use super::{
 
 const CHAT_DIRECTORY: &str = "chat_media";
 
-pub type DownloadStream = BoxStream<'static, Result<Vec<u8>, Error>>;
+pub type DownloadStream = BoxStream<'static, Result<Vec<u8>, std::io::Error>>;
 
 enum MessagingCommand {
     Receiver {
@@ -2470,7 +2470,7 @@ impl ConversationInner {
         conversation_id: Uuid,
         message_id: Uuid,
         file: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
         let conversation = self.get(conversation_id).await?;
 
         let members = conversation

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -476,7 +476,7 @@ mod test {
                 None,
                 vec![Location::Stream {
                     name: "image.png".into(),
-                    stream: futures::stream::once(async { PROFILE_IMAGE.to_vec() }).boxed(),
+                    stream: futures::stream::iter(vec![Ok(PROFILE_IMAGE.to_vec())]).boxed(),
                 }],
                 vec![],
             )

--- a/extensions/warp-ipfs/tests/files.rs
+++ b/extensions/warp-ipfs/tests/files.rs
@@ -40,7 +40,7 @@ mod test {
     async fn upload_file_stream() -> anyhow::Result<()> {
         let (_, mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        let stream = stream::once(async { PROFILE_IMAGE.to_vec() }).boxed();
+        let stream = stream::iter(vec![Ok(PROFILE_IMAGE.to_vec())]).boxed();
         let mut status = fs.put_stream("image.png", None, stream).await?;
         while let Some(progress) = status.next().await {
             match progress {

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -190,7 +190,7 @@ pub trait Constellation:
     async fn get_stream(
         &self,
         _: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
         Err(Error::Unimplemented)
     }
 

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -181,7 +181,7 @@ pub trait Constellation:
         &mut self,
         _: &str,
         _: Option<usize>,
-        _: BoxStream<'static, Vec<u8>>,
+        _: BoxStream<'static, std::io::Result<Vec<u8>>>,
     ) -> Result<ConstellationProgressStream, Error> {
         Err(Error::Unimplemented)
     }

--- a/warp/src/js_exports/stream.rs
+++ b/warp/src/js_exports/stream.rs
@@ -69,7 +69,8 @@ impl Stream for InnerStream {
             }
             Some(Err(e)) => {
                 //TODO: Make inner stream optional and take from stream to prevent repeated polling
-                return Poll::Ready(Some(Err(std::io::Error::other(e))));
+                let str: String = serde_wasm_bindgen::from_value(e).expect("valid string");
+                return Poll::Ready(Some(Err(std::io::Error::other(str))));
             }
             _ => {
                 // Any other condition should cause this stream to end

--- a/warp/src/js_exports/stream.rs
+++ b/warp/src/js_exports/stream.rs
@@ -59,13 +59,17 @@ impl From<wasm_streams::ReadableStream> for InnerStream {
 }
 
 impl Stream for InnerStream {
-    type Item = Vec<u8>;
+    type Item = std::io::Result<Vec<u8>>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
         match futures::ready!(Pin::new(&mut this.inner).poll_next(cx)) {
             Some(Ok(val)) => {
                 let bytes = serde_wasm_bindgen::from_value(val).expect("valid bytes");
-                return Poll::Ready(Some(bytes));
+                return Poll::Ready(Some(Ok(bytes)));
+            }
+            Some(Err(e)) => {
+                //TODO: Make inner stream optional and take from stream to prevent repeated polling
+                return Poll::Ready(Some(Err(std::io::Error::other(e))));
             }
             _ => {
                 // Any other condition should cause this stream to end

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -920,7 +920,7 @@ pub enum Location {
     /// Stream of bytes
     Stream {
         name: String,
-        stream: BoxStream<'static, Vec<u8>>,
+        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
     },
 }
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -1174,7 +1174,7 @@ pub trait RayGunAttachment: Sync + Send {
         _: Uuid,
         _: Uuid,
         _: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
         Err(Error::Unimplemented)
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Change streams of bytes to be handled by `Result<Vec<u8>, std::io::Error>`
- Cleanup streams

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Previously, most streams would be handled either by just bytes representation or may contain a result using warp `Error`. While this may not be a problem now, it could be a problem in the future because converting `Stream<Item = Result<Vec<u8>, _>>` to `Stream<Item = Vec<u8>>` may cause the stream to fail silently, providing data that may not be complete or corrupted, and using warp error for IO streams may be considered redundant. As a result, byte streams will use `Stream<Item = Result<Vec<u8>, std::io::Error>>` to make it more idiomatic, supply error handling and reduce redundancy.
