### PR TITLE
fix: Use String::contains instead of String::eq

### DIFF
--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1965,7 +1965,7 @@ impl IdentityStore {
                 LookupBy::Username(ref username) => {
                     let username = username.to_lowercase();
                     for await document in cache {
-                        if document.username.to_lowercase().eq(&username) {
+                        if document.username.to_lowercase().contains(&username) {
                             yield document.into();
                         }
                     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use `String::contains` when checking supplied username in lookup.

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Previously, we would check if the username matches the exact case, however we should be checking if it contained within the username of the document being evaluated as it previously was done before `MultiPass::get_identity` was converted to a stream.