### PR TITLE
chore(wasm): Increase default size limit for files and storage

### DIFF
--- a/extensions/warp-ipfs/src/config.rs
+++ b/extensions/warp-ipfs/src/config.rs
@@ -308,8 +308,8 @@ impl Default for Config {
             #[cfg(not(target_arch = "wasm32"))]
             max_storage_size: Some(10 * 1024 * 1024 * 1024),
             #[cfg(target_arch = "wasm32")]
-            max_storage_size: Some(50 * 1024 * 1024),
-            max_file_size: Some(50 * 1024 * 1024),
+            max_storage_size: Some(2 * 1024 * 1024 * 1024),
+            max_file_size: Some(100 * 1024 * 1024),
             thumbnail_size: (128, 128),
             thumbnail_exact_format: true,
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- increases the default storage size limit from 50mb to 2GB in wasm
- increases the default file size limit from 50mb to 100mb

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
