### PR TITLE
refactor: Replace {Hash,BTree}Map with IndexMap for reactions

### DIFF
--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -5,6 +5,7 @@ use futures::{
     stream::{self, BoxStream, FuturesUnordered},
     StreamExt, TryFutureExt,
 };
+use indexmap::IndexMap;
 use libipld::Cid;
 use rust_ipfs::{Ipfs, IpfsPath, Keypair};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -1039,7 +1040,7 @@ impl MessageDocument {
         }
 
         if let Some(cid) = self.reactions {
-            let reactions: BTreeMap<String, Vec<DID>> = ipfs
+            let reactions: IndexMap<String, Vec<DID>> = ipfs
                 .get_dag(cid)
                 .timeout(Duration::from_secs(10))
                 .set_local(local)

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -6,9 +6,7 @@ use tokio_stream::StreamMap;
 use tracing::info;
 
 use std::{
-    collections::{
-        btree_map::Entry as BTreeEntry, hash_map::Entry as HashEntry, BTreeMap, HashMap, HashSet,
-    },
+    collections::{hash_map::Entry as HashEntry, BTreeMap, HashMap, HashSet},
     ffi::OsStr,
     path::{Path, PathBuf},
     str::FromStr,
@@ -1996,7 +1994,7 @@ impl ConversationInner {
             }
             ReactionState::Remove => {
                 match reactions.entry(emoji.clone()) {
-                    BTreeEntry::Occupied(mut e) => {
+                    indexmap::map::Entry::Occupied(mut e) => {
                         let list = e.get_mut();
 
                         if !list.contains(&own_did) {
@@ -2005,10 +2003,10 @@ impl ConversationInner {
 
                         list.retain(|did| did != &own_did);
                         if list.is_empty() {
-                            e.remove();
+                            e.swap_remove();
                         }
                     }
-                    BTreeEntry::Vacant(_) => return Err(Error::ReactionDoesntExist),
+                    indexmap::map::Entry::Vacant(_) => return Err(Error::ReactionDoesntExist),
                 };
 
                 message_document
@@ -3731,7 +3729,7 @@ async fn message_event(
                 }
                 ReactionState::Remove => {
                     match reactions.entry(emoji.clone()) {
-                        BTreeEntry::Occupied(mut e) => {
+                        indexmap::map::Entry::Occupied(mut e) => {
                             let list = e.get_mut();
 
                             if !list.contains(&reactor) {
@@ -3740,10 +3738,10 @@ async fn message_event(
 
                             list.retain(|did| did != &reactor);
                             if list.is_empty() {
-                                e.remove();
+                                e.swap_remove();
                             }
                         }
-                        BTreeEntry::Vacant(_) => return Err(Error::ReactionDoesntExist),
+                        indexmap::map::Entry::Vacant(_) => return Err(Error::ReactionDoesntExist),
                     };
 
                     message_document

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -12,8 +12,8 @@ use futures::stream::BoxStream;
 
 use chrono::{DateTime, Utc};
 use core::ops::Range;
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -681,7 +681,7 @@ pub struct Message {
     pinned: bool,
 
     /// List of the reactions for the `Message`
-    reactions: BTreeMap<String, Vec<DID>>,
+    reactions: IndexMap<String, Vec<DID>>,
 
     /// List of users public keys mentioned in this message
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -699,7 +699,7 @@ pub struct Message {
 
     /// Metadata related to the message. Can be used externally, but more internally focused
     #[serde(flatten)]
-    metadata: HashMap<String, String>,
+    metadata: IndexMap<String, String>,
 }
 
 impl Default for Message {
@@ -712,12 +712,12 @@ impl Default for Message {
             date: Utc::now(),
             modified: None,
             pinned: false,
-            reactions: BTreeMap::new(),
+            reactions: IndexMap::new(),
             mentions: Vec::new(),
             replied: None,
             lines: Vec::new(),
             attachment: Vec::new(),
-            metadata: HashMap::new(),
+            metadata: IndexMap::new(),
         }
     }
 }
@@ -770,7 +770,7 @@ impl Message {
         self.pinned
     }
 
-    pub fn reactions(&self) -> BTreeMap<String, Vec<DID>> {
+    pub fn reactions(&self) -> IndexMap<String, Vec<DID>> {
         self.reactions.clone()
     }
 
@@ -786,7 +786,7 @@ impl Message {
         self.attachment.clone()
     }
 
-    pub fn metadata(&self) -> HashMap<String, String> {
+    pub fn metadata(&self) -> IndexMap<String, String> {
         self.metadata.clone()
     }
 
@@ -824,7 +824,7 @@ impl Message {
         self.pinned = pin
     }
 
-    pub fn set_reactions(&mut self, reaction: BTreeMap<String, Vec<DID>>) {
+    pub fn set_reactions(&mut self, reaction: IndexMap<String, Vec<DID>>) {
         self.reactions = reaction
     }
 
@@ -840,7 +840,7 @@ impl Message {
         self.attachment = attachments
     }
 
-    pub fn set_metadata(&mut self, metadata: HashMap<String, String>) {
+    pub fn set_metadata(&mut self, metadata: IndexMap<String, String>) {
         self.metadata = metadata
     }
 
@@ -855,7 +855,7 @@ impl Message {
         &mut self.pinned
     }
 
-    pub fn reactions_mut(&mut self) -> &mut BTreeMap<String, Vec<DID>> {
+    pub fn reactions_mut(&mut self) -> &mut IndexMap<String, Vec<DID>> {
         &mut self.reactions
     }
 
@@ -863,7 +863,7 @@ impl Message {
         &mut self.lines
     }
 
-    pub fn metadata_mut(&mut self) -> &mut HashMap<String, String> {
+    pub fn metadata_mut(&mut self) -> &mut IndexMap<String, String> {
         &mut self.metadata
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use IndexMap for handling reactions in conversations.

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- The use of `IndexMap` allows us to preserve the order of insertions so the order of the entries will be preserved across messages where possible. 