### PR TITLE
feat: Generate thumbnail from stream

### DIFF
--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -908,6 +908,10 @@ impl FileTask {
         let max_file_size = self.config.max_file_size();
         let root = self.root_directory();
 
+        let thumbnail_store = self.thumbnail_store.clone();
+        let thumbnail_size = self.config.thumbnail_size();
+        let thumbnail_format = self.config.thumbnail_exact_format();
+
         let progress_stream = async_stream::stream! {
 
             let mut last_written = 0;
@@ -996,10 +1000,31 @@ impl FileTask {
                     }
                 };
 
+            let st = ipfs
+                .cat_unixfs(ipfs_path.clone())
+                .max_length(20*1024*1024)
+                .map(|result| result.map_err(std::io::Error::other))
+                .boxed();
+
+            let ((width, height), exact) = (thumbnail_size, thumbnail_format);
+
+            let ticket = thumbnail_store.insert_stream(&name, st, width, height, exact).await;
+
             let file = warp::constellation::file::File::new(&name);
             file.set_size(total_written);
             file.set_reference(&format!("{ipfs_path}"));
             file.set_file_type(to_file_type(&name));
+
+            match thumbnail_store.get(ticket).await {
+                Ok((extension_type, path, thumbnail)) => {
+                    file.set_thumbnail(&thumbnail);
+                    file.set_thumbnail_format(extension_type.into());
+                    file.set_thumbnail_reference(&path.to_string());
+                }
+                Err(e) => {
+                    tracing::error!(error = %e, ticket = %ticket, "Error generating thumbnail");
+                }
+            }
 
             if let Err(e) = current_directory.add_item(file) {
                 yield Progression::ProgressFailed {

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -47,6 +47,7 @@ pub const MAX_REQUEST: usize = 1_000;
 pub const MAX_METADATA_KEY_LENGTH: usize = 32;
 pub const MAX_METADATA_VALUE_LENGTH: usize = 128;
 pub const MAX_METADATA_ENTRIES: usize = 20;
+pub const MAX_THUMBNAIL_STREAM_SIZE: usize = 20 * 1024 * 1024;
 
 pub(super) mod topics {
     use std::fmt::Display;

--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -170,6 +170,7 @@ impl ThumbnailGenerator {
         width: u32,
         height: u32,
         output_exact: bool,
+        max_size: usize,
     ) -> ThumbnailId {
         let name = PathBuf::from(name.as_ref());
 
@@ -178,7 +179,7 @@ impl ThumbnailGenerator {
         // TODO: We could probably check the signature of the stream first before deciding what to do with it. If its an invalid
         //       stream we could error out and prevent any attempts of generating the thumbnail.
 
-        let bytes = ByteCollection::new_with_max_capacity(stream, 20 * 1024 * 1024);
+        let bytes = ByteCollection::new_with_max_capacity(stream, max_size);
 
         let id = ThumbnailId::default();
 

--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -14,16 +14,17 @@ use std::{
     },
 };
 
+use futures::Stream;
 #[cfg(not(target_arch = "wasm32"))]
 use std::{
     io::{self, ErrorKind},
     path::Path,
 };
-
 use tokio::sync::Mutex;
 use warp::{constellation::file::FileType, error::Error};
 use web_time::Instant;
 
+use crate::utils::ByteCollection;
 use crate::{store::document::image_dag::ImageDag, utils::ExtensionType};
 
 static GLOBAL_ID: AtomicUsize = AtomicUsize::new(0);
@@ -157,6 +158,103 @@ impl ThumbnailGenerator {
         self.tasks.lock().await.insert(id, rx);
 
         Ok(id)
+    }
+
+    pub async fn insert_stream<
+        N: AsRef<str>,
+        S: Stream<Item = io::Result<Bytes>> + Unpin + Send + 'static,
+    >(
+        &self,
+        name: N,
+        stream: S,
+        width: u32,
+        height: u32,
+        output_exact: bool,
+    ) -> ThumbnailId {
+        let name = PathBuf::from(name.as_ref());
+
+        // Note: We have a max of 20mb for the thumbnail generation from stream so if a file exceeds this capacity
+        // the thumbnail will not be generated.
+        // TODO: We could probably check the signature of the stream first before deciding what to do with it. If its an invalid
+        //       stream we could error out and prevent any attempts of generating the thumbnail.
+
+        let bytes = ByteCollection::new_with_max_capacity(stream, 20 * 1024 * 1024);
+
+        let id = ThumbnailId::default();
+
+        let ipfs = self.ipfs.clone();
+
+        let (tx, rx) = oneshot::channel();
+        crate::rt::spawn(async move {
+            let res = async move {
+                let instant = Instant::now();
+
+                let extension = name
+                    .extension()
+                    .and_then(OsStr::to_str)
+                    .map(ExtensionType::from)
+                    .unwrap_or(ExtensionType::Other);
+
+                let result = match extension.into() {
+                    FileType::Mime(media) => match media.ty().as_str() {
+                        "image" => {
+                            let format: ImageFormat = extension.try_into()?;
+
+                            let data = bytes.await.map(|b| b.to_vec())?;
+                            let cursor = io::Cursor::new(data);
+                            let image = ImageReader::new(cursor)
+                                .with_guessed_format()?
+                                .decode()
+                                .map_err(anyhow::Error::from)?;
+
+                            let width = width.min(image.width());
+                            let height = height.min(image.height());
+
+                            let thumbnail = image.thumbnail(width, height);
+                            let mut t_buffer = std::io::Cursor::new(Vec::new());
+                            let output_format = match (output_exact, format) {
+                                (false, _) => ImageFormat::Jpeg,
+                                (true, format) => format,
+                            };
+                            thumbnail
+                                .write_to(&mut t_buffer, output_format)
+                                .map_err(anyhow::Error::from)?;
+                            Ok::<_, Error>((
+                                ExtensionType::try_from(output_format)?,
+                                Bytes::from(t_buffer.into_inner()),
+                            ))
+                        }
+                        _ => Err(Error::Unimplemented),
+                    },
+                    _ => Err(Error::Other),
+                };
+
+                let stop = instant.elapsed();
+
+                let (ty, data) = result?;
+
+                tracing::trace!("Took: {}ms to complete for {}", stop.as_millis(), id);
+
+                let path = ipfs.add_unixfs(data.clone()).await?;
+
+                let link = *path.root().cid().expect("valid cid");
+
+                let image_dag = ImageDag {
+                    link,
+                    size: data.len() as _,
+                    mime: ty.into(),
+                };
+
+                let cid = ipfs.dag().put().serialize(image_dag).await?;
+
+                Ok((ty, IpfsPath::from(cid), data))
+            };
+            _ = tx.send(res.await);
+        });
+
+        self.tasks.lock().await.insert(id, rx);
+
+        id
     }
 
     pub async fn insert_buffer<S: AsRef<str>>(

--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -15,11 +15,11 @@ use std::{
 };
 
 use futures::Stream;
-#[cfg(not(target_arch = "wasm32"))]
-use std::{
-    io::{self, ErrorKind},
-    path::Path,
-};
+use std::io::{self, Cursor};
+
+#[allow(unused_imports)]
+use std::{io::ErrorKind, path::Path};
+
 use tokio::sync::Mutex;
 use warp::{constellation::file::FileType, error::Error};
 use web_time::Instant;
@@ -109,7 +109,7 @@ impl ThumbnailGenerator {
 
                             let thumbnail = image.thumbnail(width, height);
 
-                            let mut t_buffer = std::io::Cursor::new(vec![]);
+                            let mut t_buffer = Cursor::new(vec![]);
                             let output_format = match (output_exact, format) {
                                 (false, _) => ImageFormat::Jpeg,
                                 (true, format) => format,
@@ -201,7 +201,7 @@ impl ThumbnailGenerator {
                             let format: ImageFormat = extension.try_into()?;
 
                             let data = bytes.await.map(|b| b.to_vec())?;
-                            let cursor = io::Cursor::new(data);
+                            let cursor = Cursor::new(data);
                             let image = ImageReader::new(cursor)
                                 .with_guessed_format()?
                                 .decode()
@@ -297,7 +297,7 @@ impl ThumbnailGenerator {
                             let height = height.min(image.height());
 
                             let thumbnail = image.thumbnail(width, height);
-                            let mut t_buffer = std::io::Cursor::new(vec![]);
+                            let mut t_buffer = Cursor::new(vec![]);
                             let output_format = match (output_exact, format) {
                                 (false, _) => ImageFormat::Jpeg,
                                 (true, format) => format,

--- a/extensions/warp-ipfs/tests/files.rs
+++ b/extensions/warp-ipfs/tests/files.rs
@@ -55,6 +55,8 @@ mod test {
             }
         }
         assert!(root_directory.has_item("image.png"));
+        let item = root_directory.get_item("image.png")?;
+        assert!(!item.thumbnail().is_empty());
         Ok(())
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add basic support for thumbnail generation when uploading via `Constellation::put_stream`

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️
- If a file is more than 20MB, then the thumbnail will not be generated. This may change in the future where we will peak ahead on the headers itself and determine if the thumbnail *could* be generated based on what is supported.

**Additional comments** 🎤
- Instead of duplicating the stream itself and have that polled in a separate task along side the primary stream, we opt for providing the stream of the file after-the-fact and only check the first 20mb. Anymore would disable the generation of the thumbnail to prevent oom for any large files.
- As the other generation methods, this is only for images. Other file types does not support thumbnail generation at this time.
