### PR TITLE
chore: Rename StreamReader to ReaderStream

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -63,7 +63,7 @@ use crate::store::discovery::Discovery;
 use crate::store::phonebook::PhoneBook;
 use crate::store::{ecdh_decrypt, PeerIdExt};
 use crate::store::{MAX_IMAGE_SIZE, MAX_USERNAME_LENGTH, MIN_USERNAME_LENGTH};
-use crate::utils::{ByteCollection, StreamReader};
+use crate::utils::{ByteCollection, ReaderStream};
 
 mod behaviour;
 pub mod config;
@@ -964,7 +964,7 @@ impl LocalIdentity for WarpIpfs {
                 let async_cursor = futures::io::Cursor::new(inner.into_inner());
 
                 let stream =
-                    StreamReader::from_reader_with_cap(async_cursor, 512, Some(MAX_IMAGE_SIZE));
+                    ReaderStream::from_reader_with_cap(async_cursor, 512, Some(MAX_IMAGE_SIZE));
                 (OptType::Picture(Some(format)), stream.boxed())
             }
             #[cfg(not(target_arch = "wasm32"))]
@@ -999,7 +999,7 @@ impl LocalIdentity for WarpIpfs {
                 tracing::trace!("image size = {}", len);
 
                 let stream =
-                    StreamReader::from_reader_with_cap(file.compat(), 512, Some(MAX_IMAGE_SIZE));
+                    ReaderStream::from_reader_with_cap(file.compat(), 512, Some(MAX_IMAGE_SIZE));
 
                 (OptType::Picture(Some(extension)), stream.boxed())
             }
@@ -1008,7 +1008,7 @@ impl LocalIdentity for WarpIpfs {
                 return Err(Error::Unimplemented);
             }
             IdentityUpdate::PictureStream(stream) => {
-                let stream = StreamReader::from_reader_with_cap(
+                let stream = ReaderStream::from_reader_with_cap(
                     stream.into_async_read(),
                     512,
                     Some(MAX_IMAGE_SIZE),
@@ -1040,7 +1040,7 @@ impl LocalIdentity for WarpIpfs {
                 let async_cursor = futures::io::Cursor::new(inner.into_inner());
 
                 let stream =
-                    StreamReader::from_reader_with_cap(async_cursor, 512, Some(MAX_IMAGE_SIZE));
+                    ReaderStream::from_reader_with_cap(async_cursor, 512, Some(MAX_IMAGE_SIZE));
 
                 (OptType::Banner(Some(format)), stream.boxed())
             }
@@ -1076,7 +1076,7 @@ impl LocalIdentity for WarpIpfs {
                 tracing::trace!("image size = {}", len);
 
                 let stream =
-                    StreamReader::from_reader_with_cap(file.compat(), 512, Some(2 * 1024 * 1024));
+                    ReaderStream::from_reader_with_cap(file.compat(), 512, Some(2 * 1024 * 1024));
 
                 (OptType::Picture(Some(extension)), stream.boxed())
             }
@@ -1085,7 +1085,7 @@ impl LocalIdentity for WarpIpfs {
                 return Err(Error::Unimplemented);
             }
             IdentityUpdate::BannerStream(stream) => {
-                let stream = StreamReader::from_reader_with_cap(
+                let stream = ReaderStream::from_reader_with_cap(
                     stream.into_async_read(),
                     512,
                     Some(MAX_IMAGE_SIZE),

--- a/extensions/warp-ipfs/src/utils.rs
+++ b/extensions/warp-ipfs/src/utils.rs
@@ -187,14 +187,14 @@ impl Future for ByteCollection {
 }
 
 // Small utility that converts AsyncRead to a Stream, while supporting max size from that stream
-pub struct StreamReader<R> {
+pub struct ReaderStream<R> {
     reader: Option<R>,
     buffer: usize,
     size: usize,
     max_cap: Option<usize>,
 }
 
-impl<R> StreamReader<R>
+impl<R> ReaderStream<R>
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
@@ -213,7 +213,7 @@ where
     }
 }
 
-impl<R> Stream for StreamReader<R>
+impl<R> Stream for ReaderStream<R>
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
@@ -260,7 +260,7 @@ where
     }
 }
 
-impl<R> IntoFuture for StreamReader<R>
+impl<R> IntoFuture for ReaderStream<R>
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
@@ -274,7 +274,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::utils::{ByteCollection, StreamReader};
+    use crate::utils::{ByteCollection, ReaderStream};
     use bytes::Bytes;
 
     #[tokio::test]
@@ -283,7 +283,7 @@ mod test {
 
         let cursor = futures::io::Cursor::new(data.clone());
 
-        let st = StreamReader::from_reader(cursor);
+        let st = ReaderStream::from_reader(cursor);
 
         let bytes = st.await?;
 
@@ -313,7 +313,7 @@ mod test {
 
         let cursor = futures::io::Cursor::new(data.clone());
 
-        let st = StreamReader::from_reader_with_cap(cursor, 512, Some(data.len()));
+        let st = ReaderStream::from_reader_with_cap(cursor, 512, Some(data.len()));
 
         let bytes = st.await?;
 
@@ -328,7 +328,7 @@ mod test {
 
         let cursor = futures::io::Cursor::new(data.to_vec());
 
-        let st = StreamReader::from_reader_with_cap(cursor, 512, Some(11));
+        let st = ReaderStream::from_reader_with_cap(cursor, 512, Some(11));
 
         assert!(st.await.is_err());
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Rename `StreamReader` to `ReaderStream` to properly reflect its functionality. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
