### PR TITLE
feat: Implement functionality to [un]archived conversations

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -396,6 +396,12 @@ async fn main() -> anyhow::Result<()> {
 
                             stream_map.insert(conversation_id, stream);
                         },
+                        warp::raygun::RayGunEventKind::ConversationArchived { conversation_id } => {
+                            writeln!(stdout, "Conversation {conversation_id} has been archived")?;
+                        },
+                        warp::raygun::RayGunEventKind::ConversationUnarchived { conversation_id } => {
+                            writeln!(stdout, "Conversation {conversation_id} has been unarchived")?;
+                        },
                         warp::raygun::RayGunEventKind::ConversationDeleted { conversation_id } => {
                             stream_map.remove(&conversation_id);
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1613,6 +1613,18 @@ impl RayGun for WarpIpfs {
             .update_conversation_settings(conversation_id, settings)
             .await
     }
+
+    async fn archived_conversation(&mut self, conversation_id: Uuid) -> Result<(), Error> {
+        self.messaging_store()?
+            .archived_conversation(conversation_id)
+            .await
+    }
+
+    async fn unarchived_conversation(&mut self, conversation_id: Uuid) -> Result<(), Error> {
+        self.messaging_store()?
+            .unarchived_conversation(conversation_id)
+            .await
+    }
 }
 
 #[async_trait::async_trait]

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -55,6 +55,8 @@ pub struct ConversationDocument {
     pub recipients: Vec<DID>,
     #[serde(default)]
     pub favorite: bool,
+    #[serde(default)]
+    pub archived: bool,
     pub excluded: HashMap<DID, String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub restrict: Vec<DID>,
@@ -167,6 +169,7 @@ impl ConversationDocument {
             created,
             modified,
             favorite: false,
+            archived: false,
             settings,
             excluded,
             messages,
@@ -681,6 +684,7 @@ impl From<&ConversationDocument> for Conversation {
         conversation.set_settings(document.settings);
         conversation.set_modified(document.modified);
         conversation.set_favorite(document.favorite);
+        conversation.set_archived(document.archived);
         conversation
     }
 }

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -462,6 +462,16 @@ impl MessageStore {
         let inner = &mut *self.inner.write().await;
         inner.cancel_event(conversation_id, event).await
     }
+
+    pub async fn archived_conversation(&self, conversation_id: Uuid) -> Result<(), Error> {
+        let inner = &mut *self.inner.write().await;
+        inner.archived_conversation(conversation_id).await
+    }
+
+    pub async fn unarchived_conversation(&self, conversation_id: Uuid) -> Result<(), Error> {
+        let inner = &mut *self.inner.write().await;
+        inner.unarchived_conversation(conversation_id).await
+    }
 }
 
 type AttachmentChan = (Uuid, MessageDocument, oneshot::Sender<Result<(), Error>>);
@@ -2960,6 +2970,32 @@ impl ConversationInner {
         self.send_message_event(conversation_id, event).await
     }
 
+    pub async fn archived_conversation(&mut self, conversation_id: Uuid) -> Result<(), Error> {
+        let mut conversation = self.get(conversation_id).await?;
+        let prev = conversation.archived;
+        conversation.archived = true;
+        self.set_document(conversation).await?;
+        if !prev {
+            self.event
+                .emit(RayGunEventKind::ConversationArchived { conversation_id })
+                .await;
+        }
+        Ok(())
+    }
+
+    pub async fn unarchived_conversation(&mut self, conversation_id: Uuid) -> Result<(), Error> {
+        let mut conversation = self.get(conversation_id).await?;
+        let prev = conversation.archived;
+        conversation.archived = false;
+        self.set_document(conversation).await?;
+        if prev {
+            self.event
+                .emit(RayGunEventKind::ConversationUnarchived { conversation_id })
+                .await;
+        }
+        Ok(())
+    }
+
     pub async fn send_message_event(
         &mut self,
         conversation_id: Uuid,
@@ -3339,6 +3375,7 @@ async fn process_conversation(
 
             //TODO: Resolve message list
             conversation.messages = None;
+            conversation.archived = false;
             conversation.favorite = false;
 
             this.set_document(conversation).await?;
@@ -3783,6 +3820,7 @@ async fn message_event(
                     conversation.excluded = document.excluded;
                     conversation.messages = document.messages;
                     conversation.favorite = document.favorite;
+                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = this.request_key(conversation_id, &did).await {
@@ -3810,6 +3848,7 @@ async fn message_event(
                     conversation.excluded = document.excluded;
                     conversation.messages = document.messages;
                     conversation.favorite = document.favorite;
+                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if can_emit {
@@ -3842,6 +3881,7 @@ async fn message_event(
                     conversation.excluded = document.excluded;
                     conversation.messages = document.messages;
                     conversation.favorite = document.favorite;
+                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = tx.send(MessageEventKind::ConversationNameUpdated {
@@ -3856,6 +3896,7 @@ async fn message_event(
                     conversation.excluded = document.excluded;
                     conversation.messages = document.messages;
                     conversation.favorite = document.favorite;
+                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = tx.send(MessageEventKind::ConversationNameUpdated {
@@ -3878,6 +3919,7 @@ async fn message_event(
                     conversation.excluded = document.excluded;
                     conversation.messages = document.messages;
                     conversation.favorite = document.favorite;
+                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = tx.send(MessageEventKind::ConversationSettingsUpdated {

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -21,6 +21,8 @@ mod test {
 
     #[cfg(not(target_arch = "wasm32"))]
     use tokio::test as async_test;
+    use uuid::Uuid;
+    use warp::error::Error;
 
     #[async_test]
     async fn create_empty_group_conversation() -> anyhow::Result<()> {
@@ -1555,6 +1557,67 @@ mod test {
             }
         })
         .await?;
+
+        Ok(())
+    }
+
+    #[async_test]
+    async fn archive_unarchive_conversation() -> anyhow::Result<()> {
+        let accounts = create_accounts_and_chat(vec![(
+            None,
+            None,
+            Some("test::archive_unarchive_conversation".into()),
+        )])
+        .await?;
+
+        let (_account_a, mut chat_a, _, _, _) = accounts.first().cloned().unwrap();
+
+        let mut chat_subscribe_a = chat_a.raygun_subscribe().await?;
+
+        chat_a
+            .create_group_conversation(None, vec![], Default::default())
+            .await?;
+
+        crate::common::timeout(Duration::from_secs(60), async {
+            let mut c_id = Uuid::nil();
+            let mut archived = false;
+            let mut unarchived = false;
+            loop {
+                tokio::select! {
+                    Some(event) = chat_subscribe_a.next() => {
+                        match event {
+                            RayGunEventKind::ConversationCreated{ conversation_id } => {
+                                c_id = conversation_id;
+                                chat_a.archived_conversation(conversation_id).await?;
+                            }
+                            RayGunEventKind::ConversationArchived{ conversation_id } => {
+                                assert_eq!(conversation_id, c_id);
+                                assert!(!archived);
+                                assert!(!unarchived);
+                                let conversation = chat_a.get_conversation(c_id).await?;
+                                assert!(conversation.archived());
+                                archived = true;
+                                chat_a.unarchived_conversation(conversation_id).await?;
+                            }
+                            RayGunEventKind::ConversationUnarchived{ conversation_id } => {
+                                assert_eq!(conversation_id, c_id);
+                                assert!(archived);
+                                assert!(!unarchived);
+                                let conversation = chat_a.get_conversation(conversation_id).await?;
+                                assert!(!conversation.archived());
+                                unarchived = true;
+                            }
+                            RayGunEventKind::ConversationDeleted{ .. } => unreachable!()
+                        }
+                    }
+                }
+                if c_id != Uuid::nil() && archived && unarchived {
+                    break;
+                }
+            }
+            Ok::<_, Error>(())
+        })
+        .await??;
 
         Ok(())
     }

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -1607,7 +1607,7 @@ mod test {
                                 assert!(!conversation.archived());
                                 unarchived = true;
                             }
-                            RayGunEventKind::ConversationDeleted{ .. } => unreachable!()
+                            RayGunEventKind::ConversationDeleted { .. } => unreachable!()
                         }
                     }
                 }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -1133,10 +1133,10 @@ pub trait RayGun:
     ) -> Result<(), Error>;
 
     /// Archive a conversation
-    async fn archived_conversation(&mut self, _: Uuid) -> Result<(), Error>;
+    async fn archived_conversation(&mut self, conversation_id: Uuid) -> Result<(), Error>;
 
     /// Unarchived a conversation
-    async fn unarchived_conversation(&mut self, _: Uuid) -> Result<(), Error>;
+    async fn unarchived_conversation(&mut self, conversation_id: Uuid) -> Result<(), Error>;
 }
 
 dyn_clone::clone_trait_object!(RayGun);

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -25,6 +25,8 @@ use self::group::GroupChat;
 #[serde(rename_all = "snake_case")]
 pub enum RayGunEventKind {
     ConversationCreated { conversation_id: Uuid },
+    ConversationArchived { conversation_id: Uuid },
+    ConversationUnarchived { conversation_id: Uuid },
     ConversationDeleted { conversation_id: Uuid },
 }
 
@@ -358,6 +360,7 @@ pub struct Conversation {
     favorite: bool,
     modified: DateTime<Utc>,
     settings: ConversationSettings,
+    archived: bool,
     recipients: Vec<DID>,
 }
 
@@ -388,6 +391,7 @@ impl Default for Conversation {
             favorite: false,
             modified: timestamp,
             settings: ConversationSettings::default(),
+            archived: false,
             recipients,
         }
     }
@@ -432,6 +436,10 @@ impl Conversation {
     pub fn recipients(&self) -> Vec<DID> {
         self.recipients.clone()
     }
+
+    pub fn archived(&self) -> bool {
+        self.archived
+    }
 }
 
 impl Conversation {
@@ -465,6 +473,10 @@ impl Conversation {
 
     pub fn set_recipients(&mut self, recipients: Vec<DID>) {
         self.recipients = recipients;
+    }
+
+    pub fn set_archived(&mut self, archived: bool) {
+        self.archived = archived;
     }
 }
 
@@ -1119,6 +1131,12 @@ pub trait RayGun:
         conversation_id: Uuid,
         settings: ConversationSettings,
     ) -> Result<(), Error>;
+
+    /// Archive a conversation
+    async fn archived_conversation(&mut self, _: Uuid) -> Result<(), Error>;
+
+    /// Unarchived a conversation
+    async fn unarchived_conversation(&mut self, _: Uuid) -> Result<(), Error>;
 }
 
 dyn_clone::clone_trait_object!(RayGun);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Implement functionality to mark conversations as archived.

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Marking a conversation as archive does not do anything internally besides marking it, but would allow frontend implementations to handle things differently such as ignoring specific events, etc. This may change in the future where specific events are ignored, however this might require the frontend to perform a refresh of the conversation itself.  