### PR TITLE
feat: Add description to conversations

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -1157,6 +1157,20 @@ async fn message_event_handle(
                 writeln!(stdout, ">>> Conversation settings updated: {settings}")?;
             }
         }
+        MessageEventKind::ConversationDescriptionChanged {
+            conversation_id,
+            description,
+        } => {
+            if main_conversation_id == conversation_id {
+                match description {
+                    Some(desc) => writeln!(
+                        stdout,
+                        ">>> Conversation description changed to: \"{desc}\""
+                    )?,
+                    None => writeln!(stdout, ">>> Conversation description removed")?,
+                }
+            }
+        }
     }
 
     Ok(())

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -52,8 +52,8 @@ use warp::multipass::{
 use warp::raygun::{
     AttachmentEventStream, Conversation, ConversationSettings, EmbedState, GroupSettings, Location,
     Message, MessageEvent, MessageEventStream, MessageOptions, MessageReference, MessageStatus,
-    Messages, PinState, RayGun, RayGunAttachment, RayGunEventKind, RayGunEventStream, RayGunEvents,
-    RayGunGroupConversation, RayGunStream, ReactionState,
+    Messages, PinState, RayGun, RayGunAttachment, RayGunConversationInformation, RayGunEventKind,
+    RayGunEventStream, RayGunEvents, RayGunGroupConversation, RayGunStream, ReactionState,
 };
 use warp::tesseract::{Tesseract, TesseractEvent};
 use warp::{Extension, SingleHandle};
@@ -1718,6 +1718,19 @@ impl RayGunEvents for WarpIpfs {
     ) -> Result<(), Error> {
         self.messaging_store()?
             .cancel_event(conversation_id, event)
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl RayGunConversationInformation for WarpIpfs {
+    async fn set_conversation_description(
+        &mut self,
+        conversation_id: Uuid,
+        description: Option<&str>,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .set_description(conversation_id, description)
             .await
     }
 }

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -63,6 +63,8 @@ pub struct ConversationDocument {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub messages: Option<Cid>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub signature: Option<String>,
 }
 
@@ -173,6 +175,7 @@ impl ConversationDocument {
             signature,
             restrict,
             deleted: false,
+            description: None,
         };
 
         if document.signature.is_some() {
@@ -264,6 +267,7 @@ impl ConversationDocument {
                 [
                     Some(self.id().into_bytes().to_vec()),
                     // self.name.as_deref().map(|s| s.as_bytes().to_vec()),
+                    self.description.as_ref().map(|d| d.as_bytes().to_vec()),
                     Some(creator.to_string().as_bytes().to_vec()),
                     Some(Vec::from_iter(
                         self.restrict
@@ -317,6 +321,7 @@ impl ConversationDocument {
                     [
                         Some(self.id().into_bytes().to_vec()),
                         // self.name.as_deref().map(|s| s.as_bytes().to_vec()),
+                        self.description.as_ref().map(|d| d.as_bytes().to_vec()),
                         Some(creator.to_string().as_bytes().to_vec()),
                         Some(Vec::from_iter(
                             self.restrict
@@ -681,6 +686,7 @@ impl From<&ConversationDocument> for Conversation {
         conversation.set_settings(document.settings);
         conversation.set_modified(document.modified);
         conversation.set_favorite(document.favorite);
+        conversation.set_description(document.description.clone());
         conversation
     }
 }

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -66,8 +66,8 @@ use crate::{
 };
 
 use super::{
-    document::root::RootDocumentMap, ds_key::DataStoreKey, PeerIdExt, MAX_MESSAGE_SIZE,
-    SHUTTLE_TIMEOUT,
+    document::root::RootDocumentMap, ds_key::DataStoreKey, PeerIdExt, MAX_CONVERSATION_DESCRIPTION,
+    MAX_MESSAGE_SIZE, SHUTTLE_TIMEOUT,
 };
 
 const CHAT_DIRECTORY: &str = "chat_media";
@@ -461,6 +461,15 @@ impl MessageStore {
     ) -> Result<(), Error> {
         let inner = &mut *self.inner.write().await;
         inner.cancel_event(conversation_id, event).await
+    }
+
+    pub async fn set_description(
+        &self,
+        conversation_id: Uuid,
+        desc: Option<&str>,
+    ) -> Result<(), Error> {
+        let inner = &mut *self.inner.write().await;
+        inner.set_description(conversation_id, desc).await
     }
 }
 
@@ -2498,6 +2507,58 @@ impl ConversationInner {
         Ok(stream)
     }
 
+    pub async fn set_description(
+        &mut self,
+        conversation_id: Uuid,
+        desc: Option<&str>,
+    ) -> Result<(), Error> {
+        let mut conversation = self.get(conversation_id).await?;
+        let tx = self.subscribe(conversation_id).await?;
+        let own_did = &self.identity.did_key();
+
+        if conversation.conversation_type() == ConversationType::Group {
+            let Some(creator) = conversation.creator.as_ref() else {
+                return Err(Error::InvalidConversation);
+            };
+            if own_did != creator {
+                return Err(Error::InvalidConversation); //TODO:
+            }
+        }
+
+        if let Some(desc) = desc {
+            if desc.len() == 0 || desc.len() > MAX_CONVERSATION_DESCRIPTION {
+                return Err(Error::InvalidLength {
+                    context: "description".into(),
+                    minimum: Some(1),
+                    maximum: Some(MAX_CONVERSATION_DESCRIPTION),
+                    current: desc.len(),
+                });
+            }
+        }
+
+        conversation.description = desc.map(ToString::to_string);
+
+        self.set_document(conversation).await?;
+
+        let conversation = self.get(conversation_id).await?;
+
+        let ev = MessageEventKind::ConversationDescriptionChanged {
+            conversation_id,
+            description: desc.map(ToString::to_string),
+        };
+
+        _ = tx.send(ev);
+
+        let event = MessagingEvents::UpdateConversation {
+            conversation,
+            kind: ConversationUpdateKind::ChangeDescription {
+                description: desc.map(ToString::to_string),
+            },
+        };
+
+        self.publish(conversation_id, None, event, true).await
+    }
+
     pub async fn add_restricted(
         &mut self,
         conversation_id: Uuid,
@@ -3883,6 +3944,34 @@ async fn message_event(
                     if let Err(e) = tx.send(MessageEventKind::ConversationSettingsUpdated {
                         conversation_id,
                         settings,
+                    }) {
+                        tracing::warn!(%conversation_id, error = %e, "Error broadcasting event");
+                    }
+                }
+                ConversationUpdateKind::ChangeDescription { description } => {
+                    if let Some(desc) = description.as_ref() {
+                        if desc.len() == 0 || desc.len() > MAX_CONVERSATION_DESCRIPTION {
+                            return Err(Error::InvalidLength {
+                                context: "description".into(),
+                                minimum: Some(1),
+                                maximum: Some(MAX_CONVERSATION_DESCRIPTION),
+                                current: desc.len(),
+                            });
+                        }
+
+                        if matches!(document.description.as_ref(), Some(current_desc) if current_desc == desc)
+                        {
+                            return Ok(());
+                        }
+                    }
+
+                    conversation.excluded = document.excluded;
+                    conversation.messages = document.messages;
+                    conversation.favorite = document.favorite;
+                    this.set_document(conversation).await?;
+                    if let Err(e) = tx.send(MessageEventKind::ConversationDescriptionChanged {
+                        conversation_id,
+                        description,
                     }) {
                         tracing::warn!(%conversation_id, error = %e, "Error broadcasting event");
                     }

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -3950,7 +3950,7 @@ async fn message_event(
                 }
                 ConversationUpdateKind::ChangeDescription { description } => {
                     if let Some(desc) = description.as_ref() {
-                        if desc.is_empty() == 0 || desc.len() > MAX_CONVERSATION_DESCRIPTION {
+                        if desc.is_empty() || desc.len() > MAX_CONVERSATION_DESCRIPTION {
                             return Err(Error::InvalidLength {
                                 context: "description".into(),
                                 minimum: Some(1),

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2526,7 +2526,7 @@ impl ConversationInner {
         }
 
         if let Some(desc) = desc {
-            if desc.len() == 0 || desc.len() > MAX_CONVERSATION_DESCRIPTION {
+            if desc.is_empty() || desc.len() > MAX_CONVERSATION_DESCRIPTION {
                 return Err(Error::InvalidLength {
                     context: "description".into(),
                     minimum: Some(1),
@@ -3950,7 +3950,7 @@ async fn message_event(
                 }
                 ConversationUpdateKind::ChangeDescription { description } => {
                     if let Some(desc) = description.as_ref() {
-                        if desc.len() == 0 || desc.len() > MAX_CONVERSATION_DESCRIPTION {
+                        if desc.is_empty() == 0 || desc.len() > MAX_CONVERSATION_DESCRIPTION {
                             return Err(Error::InvalidLength {
                                 context: "description".into(),
                                 minimum: Some(1),

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -48,6 +48,7 @@ pub const MAX_METADATA_KEY_LENGTH: usize = 32;
 pub const MAX_METADATA_VALUE_LENGTH: usize = 128;
 pub const MAX_METADATA_ENTRIES: usize = 20;
 pub const MAX_THUMBNAIL_STREAM_SIZE: usize = 20 * 1024 * 1024;
+pub const MAX_CONVERSATION_DESCRIPTION: usize = 256;
 
 pub(super) mod topics {
     use std::fmt::Display;
@@ -434,6 +435,7 @@ pub enum ConversationUpdateKind {
     RemoveRestricted { did: DID },
     ChangeName { name: Option<String> },
     ChangeSettings { settings: ConversationSettings },
+    ChangeDescription { description: Option<String> },
 }
 
 // Note that this are temporary

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -73,6 +73,10 @@ pub enum MessageEventKind {
         conversation_id: Uuid,
         name: String,
     },
+    ConversationDescriptionChanged {
+        conversation_id: Uuid,
+        description: Option<String>,
+    },
     RecipientAdded {
         conversation_id: Uuid,
         recipient: DID,
@@ -359,6 +363,7 @@ pub struct Conversation {
     modified: DateTime<Utc>,
     settings: ConversationSettings,
     recipients: Vec<DID>,
+    description: Option<String>,
 }
 
 impl core::hash::Hash for Conversation {
@@ -389,6 +394,7 @@ impl Default for Conversation {
             modified: timestamp,
             settings: ConversationSettings::default(),
             recipients,
+            description: None,
         }
     }
 }
@@ -432,6 +438,10 @@ impl Conversation {
     pub fn recipients(&self) -> Vec<DID> {
         self.recipients.clone()
     }
+
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
 }
 
 impl Conversation {
@@ -465,6 +475,10 @@ impl Conversation {
 
     pub fn set_recipients(&mut self, recipients: Vec<DID>) {
         self.recipients = recipients;
+    }
+
+    pub fn set_description(&mut self, description: impl Into<Option<String>>) {
+        self.description = description.into();
     }
 }
 
@@ -992,6 +1006,7 @@ pub trait RayGun:
     + RayGunGroupConversation
     + RayGunAttachment
     + RayGunEvents
+    + RayGunConversationInformation
     + Extension
     + Sync
     + Send
@@ -1204,4 +1219,14 @@ pub trait RayGunEvents: Sync + Send {
     async fn cancel_event(&mut self, _: Uuid, _: MessageEvent) -> Result<(), Error> {
         Err(Error::Unimplemented)
     }
+}
+
+#[async_trait::async_trait]
+pub trait RayGunConversationInformation: Sync + Send {
+    /// Set a description to a conversation
+    async fn set_conversation_description(
+        &mut self,
+        conversation_id: Uuid,
+        description: Option<&str>,
+    ) -> Result<(), Error>;
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add `RayGun::set_conversation_description`

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- A description length is restricted to 256 characters. 
- In a direct conversation, either participants can set the description while in group conversations, only the creator can set the description.