### PR TITLE
feat: Reintroduce `FriendRequest`

### DIFF
--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -207,7 +207,7 @@ async fn main() -> anyhow::Result<()> {
             event = event_stream.next() => {
                 if let Some(event) = event {
                     match event {
-                        warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did } => {
+                        warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did, .. } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
                                 .map(|ident| ident.username())
@@ -219,7 +219,7 @@ async fn main() -> anyhow::Result<()> {
                                 account.accept_request(&did).await?;
                             }
                         },
-                        warp::multipass::MultiPassEventKind::FriendRequestSent { to: did } => {
+                        warp::multipass::MultiPassEventKind::FriendRequestSent { to: did, .. } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
                                 .map(|ident| ident.username())
@@ -635,13 +635,14 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
                             for request in list.iter() {
-                                 let username = match account.get_identity(Identifier::did_key(request.clone())).await {
+                                let identity = request.identity();
+                                let username = match account.get_identity(Identifier::did_key(identity.clone())).await {
                                     Ok(ident) => ident.username(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
                                     username.to_string(),
-                                    request.to_string()
+                                    identity.to_string(),
                                 ]);
                             }
                             writeln!(stdout, "{table}")?;
@@ -657,13 +658,14 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             };
                             for request in list.iter() {
-                                let username = match account.get_identity(Identifier::did_key(request.clone())).await {
+                                let identity = request.identity();
+                                let username = match account.get_identity(Identifier::did_key(identity.clone())).await {
                                     Ok(ident) => ident.username(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
                                     username.to_string(),
-                                    request.to_string()
+                                    identity.to_string()
                                 ]);
                             }
                             writeln!(stdout, "{table}")?;

--- a/extensions/warp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-ipfs/examples/ipfs-friends.rs
@@ -76,14 +76,16 @@ async fn main() -> anyhow::Result<()> {
     println!("{} Outgoing request:", username(&ident_a));
 
     for outgoing in account_a.list_outgoing_request().await? {
-        let ident = account_a.get_identity(Identifier::from(outgoing)).await?;
+        let identity = outgoing.identity();
+        let ident = account_a.get_identity(Identifier::from(identity)).await?;
         println!("To: {}", username(&ident));
         println!();
     }
 
     println!("{} Incoming request:", username(&ident_b));
     for incoming in account_b.list_incoming_request().await? {
-        let ident = account_b.get_identity(Identifier::from(incoming)).await?;
+        let identity = incoming.identity();
+        let ident = account_b.get_identity(Identifier::from(identity)).await?;
 
         println!("From: {}", username(&ident));
         println!();

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -268,7 +268,7 @@ async fn main() -> anyhow::Result<()> {
             biased;
             Some(event) = account_stream.next() => {
                 match event {
-                    warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did } => {
+                    warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did, .. } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
                             .map(|ident| ident.username())
@@ -279,7 +279,7 @@ async fn main() -> anyhow::Result<()> {
                             new_account.accept_request(&did).await?;
                         }
                     },
-                    warp::multipass::MultiPassEventKind::FriendRequestSent { to: did } => {
+                    warp::multipass::MultiPassEventKind::FriendRequestSent { to: did, .. } => {
                         let username = new_account
                             .get_identity(Identifier::did_key(did.clone())).await
                             .map(|ident| ident.username())

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -42,7 +42,8 @@ use warp::crypto::{KeyMaterial, DID};
 use warp::error::Error;
 use warp::module::Module;
 use warp::multipass::identity::{
-    Identifier, Identity, IdentityImage, IdentityProfile, IdentityUpdate, Relationship,
+    FriendRequest, Identifier, Identity, IdentityImage, IdentityProfile, IdentityUpdate,
+    Relationship,
 };
 use warp::multipass::{
     identity, Friends, GetIdentity, IdentityImportOption, IdentityInformation, ImportLocation,
@@ -1337,12 +1338,12 @@ impl Friends for WarpIpfs {
         store.close_request(pubkey).await
     }
 
-    async fn list_incoming_request(&self) -> Result<Vec<DID>, Error> {
+    async fn list_incoming_request(&self) -> Result<Vec<FriendRequest>, Error> {
         let store = self.identity_store(true).await?;
         store.list_incoming_request().await
     }
 
-    async fn list_outgoing_request(&self) -> Result<Vec<DID>, Error> {
+    async fn list_outgoing_request(&self) -> Result<Vec<FriendRequest>, Error> {
         let store = self.identity_store(true).await?;
         store.list_outgoing_request().await
     }

--- a/extensions/warp-ipfs/tests/friends.rs
+++ b/extensions/warp-ipfs/tests/friends.rs
@@ -33,7 +33,7 @@ mod test {
 
         crate::common::timeout(Duration::from_secs(60), async {
             let did = loop {
-                if let Some(MultiPassEventKind::FriendRequestReceived { from }) =
+                if let Some(MultiPassEventKind::FriendRequestReceived { from, .. }) =
                     subscribe_b.next().await
                 {
                     break from;
@@ -75,7 +75,7 @@ mod test {
 
         crate::common::timeout(Duration::from_secs(60), async {
             let did = loop {
-                if let Some(MultiPassEventKind::FriendRequestReceived { from }) =
+                if let Some(MultiPassEventKind::FriendRequestReceived { from, .. }) =
                     subscribe_b.next().await
                 {
                     break from;
@@ -138,7 +138,7 @@ mod test {
 
         crate::common::timeout(Duration::from_secs(60), async {
             let did = loop {
-                if let Some(MultiPassEventKind::FriendRequestReceived { from }) =
+                if let Some(MultiPassEventKind::FriendRequestReceived { from, .. }) =
                     subscribe_b.next().await
                 {
                     break from;
@@ -252,7 +252,7 @@ mod test {
 
         let list = account_b.list_incoming_request().await?;
 
-        assert!(list.contains(&did_a));
+        assert!(list.iter().any(|request| request.identity().eq(&did_a)));
 
         Ok(())
     }
@@ -283,8 +283,7 @@ mod test {
 
         let list = account_a.list_outgoing_request().await?;
 
-        assert!(list.contains(&did_b));
-
+        assert!(list.iter().any(|request| request.identity().eq(&did_b)));
         Ok(())
     }
 

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -132,6 +132,31 @@ pub struct Relationship {
     blocked_by: bool,
 }
 
+#[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct FriendRequest {
+    identity: DID,
+    date: DateTime<Utc>,
+}
+
+impl FriendRequest {
+    pub fn new(identity: DID, date: Option<DateTime<Utc>>) -> Self {
+        Self {
+            identity,
+            date: date.unwrap_or_else(Utc::now),
+        }
+    }
+}
+
+impl FriendRequest {
+    pub fn date(&self) -> DateTime<Utc> {
+        self.date
+    }
+
+    pub fn identity(&self) -> &DID {
+        &self.identity
+    }
+}
+
 impl Relationship {
     pub fn set_friends(&mut self, val: bool) {
         self.friends = val;

--- a/warp/src/multipass/mod.rs
+++ b/warp/src/multipass/mod.rs
@@ -1,20 +1,20 @@
 #![allow(clippy::result_large_err)]
 
+use chrono::{DateTime, Utc};
+use dyn_clone::DynClone;
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt};
+use serde::{Deserialize, Serialize};
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use dyn_clone::DynClone;
-use futures::stream::BoxStream;
-use futures::{Stream, StreamExt};
-use serde::{Deserialize, Serialize};
-
 use identity::Identity;
 
 use crate::crypto::DID;
 use crate::error::Error;
-use crate::multipass::identity::{Identifier, IdentityUpdate};
+use crate::multipass::identity::{FriendRequest, Identifier, IdentityUpdate};
 use crate::tesseract::Tesseract;
 use crate::{Extension, SingleHandle};
 
@@ -27,8 +27,8 @@ pub mod identity;
 #[serde(rename_all = "snake_case")]
 #[allow(clippy::large_enum_variant)]
 pub enum MultiPassEventKind {
-    FriendRequestReceived { from: DID },
-    FriendRequestSent { to: DID },
+    FriendRequestReceived { from: DID, date: DateTime<Utc> },
+    FriendRequestSent { to: DID, date: DateTime<Utc> },
     IncomingFriendRequestRejected { did: DID },
     OutgoingFriendRequestRejected { did: DID },
     IncomingFriendRequestClosed { did: DID },
@@ -156,7 +156,7 @@ pub trait Friends: Sync + Send {
     }
 
     /// List the incoming friend request
-    async fn list_incoming_request(&self) -> Result<Vec<DID>, Error> {
+    async fn list_incoming_request(&self) -> Result<Vec<FriendRequest>, Error> {
         Err(Error::Unimplemented)
     }
 
@@ -166,7 +166,7 @@ pub trait Friends: Sync + Send {
     }
 
     /// List the outgoing friend request
-    async fn list_outgoing_request(&self) -> Result<Vec<DID>, Error> {
+    async fn list_outgoing_request(&self) -> Result<Vec<FriendRequest>, Error> {
         Err(Error::Unimplemented)
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Reintroduce a minimal `FriendRequest` struct that only contains the public key and date
- Return `FriendRequest` for incoming and outgoing friend requests. 
- Add dates to incoming and outgoing friend request events.

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Unlike the previous implementation, this implementation will only be minimal, providing only the public key and the date of when the request was made and not containing any additional metadata.
- Blocked until #581 is resolved