### PR TITLE
feat: log to console wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ wasm-streams = "0.4"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.4"
 send_wrapper = "0.6.0"
+tracing-wasm = "0.2.0"
 
 # Blink related crates
 # av-data is needed to use libaom. need to ensure that Warp and libaom use the same version of av-data

--- a/warp/Cargo.toml
+++ b/warp/Cargo.toml
@@ -73,6 +73,7 @@ console_error_panic_hook.workspace = true
 wasm-streams.workspace = true
 wasm-bindgen-futures.workspace = true
 serde-wasm-bindgen.workspace = true
+tracing-wasm.workspace = true
 
 [features]
 default = []

--- a/warp/src/js_exports/mod.rs
+++ b/warp/src/js_exports/mod.rs
@@ -19,6 +19,11 @@ pub fn initialize() {
 }
 
 #[wasm_bindgen]
+pub fn trace() {
+    tracing_wasm::set_as_global_default();
+}
+
+#[wasm_bindgen]
 pub struct WarpInstance {
     multipass: MultiPassBox,
     raygun: RayGunBox,


### PR DESCRIPTION
**What this PR does** 📖

Adds option to print the warp logs to console on wasm. Requires calling the exported `trace` function so this is not on by default