### PR TITLE
chore: Set document internals first to reduce duplication

### DIFF
--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -3867,6 +3867,11 @@ async fn message_event(
             kind,
         } => {
             conversation.verify()?;
+            conversation.excluded = document.excluded;
+            conversation.messages = document.messages;
+            conversation.favorite = document.favorite;
+            conversation.archived = document.archived;
+
             match kind {
                 ConversationUpdateKind::AddParticipant { did } => {
                     if document.recipients.contains(&did) {
@@ -3877,10 +3882,6 @@ async fn message_event(
                         let _ = this.discovery.insert(&did).await.ok();
                     }
 
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = this.request_key(conversation_id, &did).await {
@@ -3901,14 +3902,10 @@ async fn message_event(
 
                     //Maybe remove participant from discovery?
 
-                    let can_emit = !document.excluded.contains_key(&did);
+                    let can_emit = !conversation.excluded.contains_key(&did);
 
-                    document.excluded.remove(&did);
+                    conversation.excluded.remove(&did);
 
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if can_emit {
@@ -3932,16 +3929,11 @@ async fn message_event(
                             maximum: Some(255),
                         });
                     }
-                    if let Some(current_name) = document.name() {
+                    if let Some(current_name) = document.name.as_ref() {
                         if current_name.eq(&name) {
                             return Ok(());
                         }
                     }
-
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = tx.send(MessageEventKind::ConversationNameUpdated {
@@ -3953,10 +3945,6 @@ async fn message_event(
                 }
 
                 ConversationUpdateKind::ChangeName { name: None } => {
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = tx.send(MessageEventKind::ConversationNameUpdated {
@@ -3968,19 +3956,11 @@ async fn message_event(
                 }
                 ConversationUpdateKind::AddRestricted { .. }
                 | ConversationUpdateKind::RemoveRestricted { .. } => {
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
                     //TODO: Maybe add a api event to emit for when blocked users are added/removed from the document
                     //      but for now, we can leave this as a silent update since the block list would be for internal handling for now
                 }
                 ConversationUpdateKind::ChangeSettings { settings } => {
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
 
                     if let Err(e) = tx.send(MessageEventKind::ConversationSettingsUpdated {
@@ -4007,10 +3987,6 @@ async fn message_event(
                         }
                     }
 
-                    conversation.excluded = document.excluded;
-                    conversation.messages = document.messages;
-                    conversation.favorite = document.favorite;
-                    conversation.archived = document.archived;
                     this.set_document(conversation).await?;
                     if let Err(e) = tx.send(MessageEventKind::ConversationDescriptionChanged {
                         conversation_id,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Reduce duplication when setting/restoring document internal metadata while processing events.

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
