### PR TITLE
refactor: Use `Bytes` in place of `Vec<u8>` where applicable

### DIFF
--- a/extensions/warp-ipfs/examples/ipfs-example.rs
+++ b/extensions/warp-ipfs/examples/ipfs-example.rs
@@ -11,7 +11,7 @@ async fn main() -> anyhow::Result<()> {
     account.create_identity(None, None).await?;
 
     filesystem
-        .put_buffer("readme.txt", (&b"Hello, World!"[..]).into())
+        .put_buffer("readme.txt", b"Hello, World!")
         .await?;
 
     let buffer = filesystem.get_buffer("readme.txt").await?;

--- a/extensions/warp-ipfs/examples/ipfs-example.rs
+++ b/extensions/warp-ipfs/examples/ipfs-example.rs
@@ -11,7 +11,7 @@ async fn main() -> anyhow::Result<()> {
     account.create_identity(None, None).await?;
 
     filesystem
-        .put_buffer("readme.txt", b"Hello, World!")
+        .put_buffer("readme.txt", (&b"Hello, World!"[..]).into())
         .await?;
 
     let buffer = filesystem.get_buffer("readme.txt").await?;

--- a/extensions/warp-ipfs/examples/wasm-ipfs-storage/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-storage/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn run() -> Result<(), JsError> {
 
     instance.create_identity(None, None).await?;
 
-    instance.put_buffer("image.png", IMAGE.into()).await?;
+    instance.put_buffer("image.png", IMAGE).await?;
 
     let data = instance.get_buffer("image.png").await?;
 

--- a/extensions/warp-ipfs/examples/wasm-ipfs-storage/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-storage/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn run() -> Result<(), JsError> {
 
     instance.create_identity(None, None).await?;
 
-    instance.put_buffer("image.png", IMAGE).await?;
+    instance.put_buffer("image.png", IMAGE.into()).await?;
 
     let data = instance.get_buffer("image.png").await?;
 
@@ -78,8 +78,9 @@ impl Body {
         Ok(())
     }
 
-    fn append_image(&self, mime: String, image: Vec<u8>) -> Result<(), JsError> {
+    fn append_image(&self, mime: String, image: impl Into<Vec<u8>>) -> Result<(), JsError> {
         use base64::prelude::*;
+        let image = image.into();
 
         let encoded_image = format!("data:{mime};base64, {}", BASE64_STANDARD.encode(image));
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1,10 +1,4 @@
-use std::any::Any;
-use std::collections::HashSet;
-use std::ffi::OsStr;
-use std::path::PathBuf;
-use std::sync::Arc;
-use std::time::Duration;
-
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::channel::mpsc::channel;
 use futures::future::BoxFuture;
@@ -18,6 +12,12 @@ use ipfs::{DhtMode, Ipfs, Keypair, Protocol, UninitializedIpfs};
 use parking_lot::RwLock;
 use rust_ipfs as ipfs;
 use rust_ipfs::p2p::UpgradeVersion;
+use std::any::Any;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::{error, info, warn, Instrument, Span};
@@ -1659,7 +1659,7 @@ impl RayGunAttachment for WarpIpfs {
         conversation_id: Uuid,
         message_id: Uuid,
         file: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         self.messaging_store()?
             .download_stream(conversation_id, message_id, file)
             .await
@@ -1778,11 +1778,11 @@ impl Constellation for WarpIpfs {
         self.file_store()?.get(name, path).await
     }
 
-    async fn put_buffer(&mut self, name: &str, buffer: &[u8]) -> Result<(), Error> {
+    async fn put_buffer(&mut self, name: &str, buffer: Bytes) -> Result<(), Error> {
         self.file_store()?.put_buffer(name, buffer).await
     }
 
-    async fn get_buffer(&self, name: &str) -> Result<Vec<u8>, Error> {
+    async fn get_buffer(&self, name: &str) -> Result<Bytes, Error> {
         self.file_store()?.get_buffer(name).await
     }
 
@@ -1791,7 +1791,7 @@ impl Constellation for WarpIpfs {
         &mut self,
         name: &str,
         total_size: Option<usize>,
-        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
+        stream: BoxStream<'static, std::io::Result<Bytes>>,
     ) -> Result<ConstellationProgressStream, Error> {
         self.file_store()?
             .put_stream(name, total_size, stream)
@@ -1802,7 +1802,7 @@ impl Constellation for WarpIpfs {
     async fn get_stream(
         &self,
         name: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         self.file_store()?.get_stream(name).await
     }
 

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1778,7 +1778,7 @@ impl Constellation for WarpIpfs {
         self.file_store()?.get(name, path).await
     }
 
-    async fn put_buffer(&mut self, name: &str, buffer: Bytes) -> Result<(), Error> {
+    async fn put_buffer(&mut self, name: &str, buffer: &[u8]) -> Result<(), Error> {
         self.file_store()?.put_buffer(name, buffer).await
     }
 

--- a/extensions/warp-ipfs/src/store/document/files.rs
+++ b/extensions/warp-ipfs/src/store/document/files.rs
@@ -121,7 +121,7 @@ impl DirectoryDocument {
                     .await
                     .unwrap_or_default();
 
-                directory.set_thumbnail(&data);
+                directory.set_thumbnail(data);
             }
         }
 
@@ -282,7 +282,7 @@ impl FileDocument {
                     .await
                     .unwrap_or_default();
 
-                file.set_thumbnail(&data);
+                file.set_thumbnail(data);
             }
         }
 

--- a/extensions/warp-ipfs/src/store/document/image_dag.rs
+++ b/extensions/warp-ipfs/src/store/document/image_dag.rs
@@ -106,7 +106,7 @@ pub async fn get_image(
 
     let mut id_img = IdentityImage::default();
 
-    id_img.set_data(image.into());
+    id_img.set_data(image);
     id_img.set_image_type(dag.mime);
 
     Ok(id_img)

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -195,7 +195,7 @@ impl FileStore {
     pub async fn put_buffer(
         &mut self,
         name: impl Into<String>,
-        buffer: impl Into<Bytes>,
+        buffer: &[u8],
     ) -> Result<(), Error> {
         let (tx, rx) = oneshot::channel();
         let _ = self
@@ -203,7 +203,7 @@ impl FileStore {
             .clone()
             .send(FileTaskCommand::PutBuffer {
                 name: name.into(),
-                buffer: buffer.into(),
+                buffer: Bytes::from(Vec::from(buffer)),
                 response: tx,
             })
             .await;

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -858,7 +858,7 @@ impl FileTask {
             })
             .await;
 
-            Ok(buffer.into())
+            Ok(buffer)
         }
         .boxed())
     }

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -1,9 +1,9 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::ffi::OsStr;
 
-use std::{collections::VecDeque, path::PathBuf, sync::Arc};
-
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 
 use futures::{
     channel::{mpsc, oneshot},
@@ -195,7 +195,7 @@ impl FileStore {
     pub async fn put_buffer(
         &mut self,
         name: impl Into<String>,
-        buffer: impl Into<Vec<u8>>,
+        buffer: impl Into<Bytes>,
     ) -> Result<(), Error> {
         let (tx, rx) = oneshot::channel();
         let _ = self
@@ -210,7 +210,7 @@ impl FileStore {
         rx.await.map_err(anyhow::Error::from)??.await
     }
 
-    pub async fn get_buffer(&self, name: impl Into<String>) -> Result<Vec<u8>, Error> {
+    pub async fn get_buffer(&self, name: impl Into<String>) -> Result<Bytes, Error> {
         let (tx, rx) = oneshot::channel();
         let _ = self
             .command_sender
@@ -228,7 +228,7 @@ impl FileStore {
         &mut self,
         name: impl Into<String>,
         total_size: impl Into<Option<usize>>,
-        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
+        stream: BoxStream<'static, std::io::Result<Bytes>>,
     ) -> Result<ConstellationProgressStream, Error> {
         let (tx, rx) = oneshot::channel();
         let _ = self
@@ -248,7 +248,7 @@ impl FileStore {
     pub async fn get_stream(
         &self,
         name: impl Into<String>,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         let (tx, rx) = oneshot::channel();
         let _ = self
             .command_sender
@@ -326,8 +326,8 @@ impl FileStore {
     }
 }
 
-type GetStream = BoxStream<'static, Result<Vec<u8>, std::io::Error>>;
-type GetBufferFutResult = BoxFuture<'static, Result<Vec<u8>, Error>>;
+type GetStream = BoxStream<'static, Result<Bytes, std::io::Error>>;
+type GetBufferFutResult = BoxFuture<'static, Result<Bytes, Error>>;
 enum FileTaskCommand {
     #[cfg(not(target_arch = "wasm32"))]
     Put {
@@ -337,13 +337,13 @@ enum FileTaskCommand {
     },
     PutBuffer {
         name: String,
-        buffer: Vec<u8>,
+        buffer: Bytes,
         response: oneshot::Sender<Result<BoxFuture<'static, Result<(), Error>>, Error>>,
     },
     PutStream {
         name: String,
         total_size: Option<usize>,
-        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
+        stream: BoxStream<'static, std::io::Result<Bytes>>,
         response: oneshot::Sender<Result<ConstellationProgressStream, Error>>,
     },
     #[cfg(not(target_arch = "wasm32"))]
@@ -643,7 +643,7 @@ impl FileTask {
 
             match thumbnail_store.get(ticket).await {
                 Ok((extension_type, path, thumbnail)) => {
-                    file.set_thumbnail(&thumbnail);
+                    file.set_thumbnail(thumbnail);
                     file.set_thumbnail_format(extension_type.into());
                     file.set_thumbnail_reference(&path.to_string());
                 }
@@ -735,7 +735,7 @@ impl FileTask {
     fn put_buffer(
         &self,
         name: String,
-        buffer: Vec<u8>,
+        buffer: Bytes,
     ) -> Result<BoxFuture<'static, Result<(), Error>>, Error> {
         let ipfs = self.ipfs.clone();
         let thumbnail_store = self.thumbnail_store.clone();
@@ -809,7 +809,7 @@ impl FileTask {
 
             match thumbnail_store.get(ticket).await {
                 Ok((extension_type, path, thumbnail)) => {
-                    file.set_thumbnail(&thumbnail);
+                    file.set_thumbnail(thumbnail);
                     file.set_thumbnail_format(extension_type.into());
                     file.set_thumbnail_reference(&path.to_string());
                 }
@@ -835,7 +835,7 @@ impl FileTask {
     fn get_buffer(
         &self,
         name: impl Into<String>,
-    ) -> Result<BoxFuture<'static, Result<Vec<u8>, Error>>, Error> {
+    ) -> Result<BoxFuture<'static, Result<Bytes, Error>>, Error> {
         let name = name.into();
         let ipfs = self.ipfs.clone();
         let current_directory = self.current_directory()?;
@@ -868,7 +868,7 @@ impl FileTask {
         &mut self,
         name: &str,
         total_size: Option<usize>,
-        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
+        stream: BoxStream<'static, std::io::Result<Bytes>>,
     ) -> Result<ConstellationProgressStream, Error> {
         let (name, dest_path) = split_file_from_path(name)?;
 
@@ -1022,7 +1022,7 @@ impl FileTask {
 
             match thumbnail_store.get(ticket).await {
                 Ok((extension_type, path, thumbnail)) => {
-                    file.set_thumbnail(&thumbnail);
+                    file.set_thumbnail(thumbnail);
                     file.set_thumbnail_format(extension_type.into());
                     file.set_thumbnail_reference(&path.to_string());
                 }
@@ -1060,7 +1060,7 @@ impl FileTask {
     fn get_stream(
         &self,
         name: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         let ipfs = self.ipfs.clone();
 
         let item = self.current_directory()?.get_item_by_path(name)?;
@@ -1072,7 +1072,6 @@ impl FileTask {
 
         let stream = ipfs
             .cat_unixfs(path)
-            .map_ok(|bytes| bytes.into())
             .map_err(std::io::Error::other)
             .try_finally(move || async move {
                 let _ = tx
@@ -1198,7 +1197,7 @@ impl FileTask {
                 .await;
 
             if let Ok((extension_type, path, thumbnail)) = thumbnail_store.get(id).await {
-                file.set_thumbnail(&thumbnail);
+                file.set_thumbnail(thumbnail);
                 file.set_thumbnail_format(extension_type.into());
                 file.set_thumbnail_reference(&path.to_string());
             }

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -5,6 +5,7 @@ use futures_timer::Delay;
 use tokio_stream::StreamMap;
 use tracing::info;
 
+use bytes::Bytes;
 use std::{
     collections::{hash_map::Entry as HashEntry, BTreeMap, HashMap, HashSet},
     ffi::OsStr,
@@ -13,7 +14,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-
 use web_time::Instant;
 
 use futures::{
@@ -72,7 +72,7 @@ use super::{
 
 const CHAT_DIRECTORY: &str = "chat_media";
 
-pub type DownloadStream = BoxStream<'static, Result<Vec<u8>, std::io::Error>>;
+pub type DownloadStream = BoxStream<'static, Result<Bytes, std::io::Error>>;
 
 enum MessagingCommand {
     Receiver {
@@ -2486,7 +2486,7 @@ impl ConversationInner {
         conversation_id: Uuid,
         message_id: Uuid,
         file: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         let conversation = self.get(conversation_id).await?;
 
         let members = conversation

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -333,7 +333,9 @@ mod test {
 
         //upload file to constellation to attach file from constellation
 
-        instance_a.put_buffer("image.png", PROFILE_IMAGE).await?;
+        instance_a
+            .put_buffer("image.png", PROFILE_IMAGE.into())
+            .await?;
 
         let (_, mut stream) = instance_a
             .attach(
@@ -467,7 +469,7 @@ mod test {
                 None,
                 vec![Location::Stream {
                     name: "image.png".into(),
-                    stream: futures::stream::iter(vec![Ok(PROFILE_IMAGE.to_vec())]).boxed(),
+                    stream: futures::stream::iter(vec![Ok(PROFILE_IMAGE.into())]).boxed(),
                     size: Some(PROFILE_IMAGE.len()),
                 }],
                 vec![],

--- a/extensions/warp-ipfs/tests/files.rs
+++ b/extensions/warp-ipfs/tests/files.rs
@@ -31,7 +31,7 @@ mod test {
     async fn upload_file() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        fs.put_buffer("image.png", PROFILE_IMAGE).await?;
+        fs.put_buffer("image.png", PROFILE_IMAGE.into()).await?;
 
         assert!(root_directory.has_item("image.png"));
         Ok(())
@@ -41,7 +41,7 @@ mod test {
     async fn upload_file_stream() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        let stream = stream::iter(vec![Ok(PROFILE_IMAGE.to_vec())]).boxed();
+        let stream = stream::iter(vec![Ok(PROFILE_IMAGE.into())]).boxed();
         let mut status = fs.put_stream("image.png", None, stream).await?;
         while let Some(progress) = status.next().await {
             match progress {
@@ -65,7 +65,7 @@ mod test {
     async fn get_file() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        fs.put_buffer("image.png", PROFILE_IMAGE).await?;
+        fs.put_buffer("image.png", PROFILE_IMAGE.into()).await?;
 
         assert!(root_directory.has_item("image.png"));
 
@@ -79,7 +79,7 @@ mod test {
     async fn get_file_stream() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        fs.put_buffer("image.png", PROFILE_IMAGE).await?;
+        fs.put_buffer("image.png", PROFILE_IMAGE.into()).await?;
 
         assert!(root_directory.has_item("image.png"));
 
@@ -94,7 +94,8 @@ mod test {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
         fs.create_directory("images", false).await?;
-        fs.put_buffer("/images/image.png", PROFILE_IMAGE).await?;
+        fs.put_buffer("/images/image.png", PROFILE_IMAGE.into())
+            .await?;
         let item = root_directory.get_item_by_path("/images/image.png")?;
         // Note: Checking the item name would be sure that the file was actually uploaded to the directory
         //       and not just be named after the directory
@@ -107,7 +108,7 @@ mod test {
     async fn rename_file_via_constellation() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        fs.put_buffer("image.png", PROFILE_IMAGE).await?;
+        fs.put_buffer("image.png", PROFILE_IMAGE.into()).await?;
 
         assert!(root_directory.has_item("image.png"));
 
@@ -137,7 +138,7 @@ mod test {
         let root_directory = fs.root_directory();
         fs.create_directory("/my/storage", true).await?;
 
-        fs.put_buffer("/my/storage/image.png", PROFILE_IMAGE)
+        fs.put_buffer("/my/storage/image.png", PROFILE_IMAGE.into())
             .await?;
 
         fs.rename("/my/storage/image.png", "item.png").await?;
@@ -152,7 +153,7 @@ mod test {
     async fn remove_file() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        fs.put_buffer("image.png", PROFILE_IMAGE).await?;
+        fs.put_buffer("image.png", PROFILE_IMAGE.into()).await?;
 
         assert!(root_directory.has_item("image.png"));
 
@@ -166,8 +167,9 @@ mod test {
     async fn check_thumbnail_of_file() -> anyhow::Result<()> {
         let (mut fs, _, _) = create_account(None, None, None).await?;
         let root_directory = fs.root_directory();
-        fs.put_buffer("image.png", PROFILE_IMAGE).await?;
-        fs.put_buffer("data.txt", &b"hello, world!"[..]).await?;
+        let data: &[u8] = b"hello, world!";
+        fs.put_buffer("image.png", PROFILE_IMAGE.into()).await?;
+        fs.put_buffer("data.txt", data.into()).await?;
 
         assert!(root_directory.has_item("image.png"));
         assert!(root_directory.has_item("data.txt"));

--- a/warp/Cargo.toml
+++ b/warp/Cargo.toml
@@ -51,6 +51,7 @@ bs58.workspace = true
 hex.workspace = true
 
 # Misc
+bytes.workspace = true
 dyn-clone.workspace = true
 uuid.workspace = true
 derive_more.workspace = true

--- a/warp/src/constellation/directory.rs
+++ b/warp/src/constellation/directory.rs
@@ -2,6 +2,7 @@
 use super::file::File;
 use super::item::{FormatType, Item};
 use crate::error::Error;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use derive_more::Display;
 use parking_lot::RwLock;
@@ -32,7 +33,7 @@ pub struct Directory {
     description: Arc<RwLock<String>>,
 
     /// Thumbnail of the `Directory`
-    thumbnail: Arc<RwLock<Vec<u8>>>,
+    thumbnail: Arc<RwLock<Bytes>>,
 
     /// Format of the thumbnail
     thumbnail_format: Arc<RwLock<FormatType>>,
@@ -592,8 +593,8 @@ impl Directory {
         self.thumbnail_format.read().clone()
     }
 
-    pub fn set_thumbnail(&self, desc: &[u8]) {
-        *self.thumbnail.write() = desc.to_vec();
+    pub fn set_thumbnail(&self, desc: impl Into<Bytes>) {
+        *self.thumbnail.write() = desc.into();
         self.signal();
     }
 

--- a/warp/src/constellation/file.rs
+++ b/warp/src/constellation/file.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::result_large_err)]
 use crate::error::Error;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use derive_more::Display;
 use mediatype;
@@ -50,7 +51,7 @@ pub struct File {
     /// Thumbnail of the `File`
     /// Note: This should be set if the file is an image, unless
     ///       one plans to add a generic thumbnail for the file
-    thumbnail: Arc<RwLock<Vec<u8>>>,
+    thumbnail: Arc<RwLock<Bytes>>,
 
     /// Format of the thumbnail
     thumbnail_format: Arc<RwLock<FormatType>>,
@@ -218,15 +219,15 @@ impl File {
     }
 
     /// Set the thumbnail to the file
-    pub fn set_thumbnail(&self, data: &[u8]) {
-        *self.thumbnail.write() = data.to_vec();
+    pub fn set_thumbnail(&self, data: impl Into<Bytes>) {
+        *self.thumbnail.write() = data.into();
         *self.modified.write() = Utc::now();
         self.signal();
     }
 
     /// Get the thumbnail from the file
     pub fn thumbnail(&self) -> Vec<u8> {
-        self.thumbnail.read().clone()
+        self.thumbnail.read().to_vec()
     }
 
     pub fn set_favorite(&self, fav: bool) {

--- a/warp/src/constellation/item.rs
+++ b/warp/src/constellation/item.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 use chrono::{DateTime, Utc};
 
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use uuid::Uuid;
@@ -233,7 +234,7 @@ impl Item {
     }
 
     /// Set thumbnail of `Item`
-    pub fn set_thumbnail(&self, data: &[u8]) {
+    pub fn set_thumbnail(&self, data: impl Into<Bytes>) {
         match self {
             Item::File(file) => file.set_thumbnail(data),
             Item::Directory(directory) => directory.set_thumbnail(data),

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use crate::error::Error;
 use crate::{Extension, SingleHandle};
 use anyhow::anyhow;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 
 use directory::Directory;
@@ -166,13 +167,12 @@ pub trait Constellation:
     }
 
     /// Used to upload file to the filesystem with data from buffer
-    #[allow(clippy::ptr_arg)]
-    async fn put_buffer(&mut self, _: &str, _: &[u8]) -> Result<(), Error> {
+    async fn put_buffer(&mut self, _: &str, _: Bytes) -> Result<(), Error> {
         Err(Error::Unimplemented)
     }
 
     /// Used to download data from the filesystem into a buffer
-    async fn get_buffer(&self, _: &str) -> Result<Vec<u8>, Error> {
+    async fn get_buffer(&self, _: &str) -> Result<Bytes, Error> {
         Err(Error::Unimplemented)
     }
 
@@ -181,7 +181,7 @@ pub trait Constellation:
         &mut self,
         _: &str,
         _: Option<usize>,
-        _: BoxStream<'static, std::io::Result<Vec<u8>>>,
+        _: BoxStream<'static, std::io::Result<Bytes>>,
     ) -> Result<ConstellationProgressStream, Error> {
         Err(Error::Unimplemented)
     }
@@ -190,7 +190,7 @@ pub trait Constellation:
     async fn get_stream(
         &self,
         _: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         Err(Error::Unimplemented)
     }
 

--- a/warp/src/constellation/mod.rs
+++ b/warp/src/constellation/mod.rs
@@ -167,7 +167,7 @@ pub trait Constellation:
     }
 
     /// Used to upload file to the filesystem with data from buffer
-    async fn put_buffer(&mut self, _: &str, _: Bytes) -> Result<(), Error> {
+    async fn put_buffer(&mut self, _: &str, _: &[u8]) -> Result<(), Error> {
         Err(Error::Unimplemented)
     }
 

--- a/warp/src/js_exports/constellation.rs
+++ b/warp/src/js_exports/constellation.rs
@@ -70,7 +70,7 @@ impl ConstellationBox {
 
     pub async fn put_buffer(&mut self, name: &str, buffer: &[u8]) -> Result<(), JsError> {
         self.inner
-            .put_buffer(name, buffer)
+            .put_buffer(name, bytes::Bytes::from(buffer.to_vec()))
             .await
             .map_err(|e| e.into())
     }
@@ -251,7 +251,7 @@ impl Directory {
         serde_wasm_bindgen::to_value(&self.inner.thumbnail_format()).unwrap()
     }
     pub fn set_thumbnail(&self, desc: &[u8]) {
-        self.inner.set_thumbnail(desc)
+        self.inner.set_thumbnail(desc.to_vec())
     }
     pub fn thumbnail(&self) -> Vec<u8> {
         self.inner.thumbnail()
@@ -335,7 +335,7 @@ impl File {
         serde_wasm_bindgen::to_value(&self.inner.thumbnail_format()).unwrap()
     }
     pub fn set_thumbnail(&self, data: &[u8]) {
-        self.inner.set_thumbnail(data)
+        self.inner.set_thumbnail(data.to_vec())
     }
     pub fn thumbnail(&self) -> Vec<u8> {
         self.inner.thumbnail()
@@ -479,7 +479,7 @@ impl Item {
         self.inner.set_description(desc)
     }
     pub fn set_thumbnail(&self, data: &[u8]) {
-        self.inner.set_thumbnail(data)
+        self.inner.set_thumbnail(data.to_vec())
     }
     pub fn set_thumbnail_format(&self, format: JsValue) {
         self.inner

--- a/warp/src/js_exports/constellation.rs
+++ b/warp/src/js_exports/constellation.rs
@@ -70,7 +70,7 @@ impl ConstellationBox {
 
     pub async fn put_buffer(&mut self, name: &str, buffer: &[u8]) -> Result<(), JsError> {
         self.inner
-            .put_buffer(name, bytes::Bytes::from(buffer.to_vec()))
+            .put_buffer(name, buffer)
             .await
             .map_err(|e| e.into())
     }

--- a/warp/src/js_exports/stream.rs
+++ b/warp/src/js_exports/stream.rs
@@ -59,7 +59,7 @@ impl From<wasm_streams::ReadableStream> for InnerStream {
 }
 
 impl Stream for InnerStream {
-    type Item = std::io::Result<Vec<u8>>;
+    type Item = std::io::Result<bytes::Bytes>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
         match futures::ready!(Pin::new(&mut this.inner).poll_next(cx)) {

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -1,15 +1,15 @@
 use crate::{constellation::file::FileType, crypto::DID, error::Error};
-use std::hash::Hasher;
-use std::{
-    fmt::{Debug, Display},
-    vec,
-};
-
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use derive_more::Display;
 use futures::stream::BoxStream;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::hash::Hasher;
+use std::{
+    fmt::{Debug, Display},
+    vec,
+};
 
 pub const SHORT_ID_SIZE: usize = 8;
 
@@ -98,13 +98,13 @@ impl IdentityProfile {
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Default, Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct IdentityImage {
-    data: Vec<u8>,
+    data: Bytes,
     image_type: FileType,
 }
 
 impl IdentityImage {
-    pub fn set_data(&mut self, data: Vec<u8>) {
-        self.data = data
+    pub fn set_data(&mut self, data: impl Into<Bytes>) {
+        self.data = data.into()
     }
 
     pub fn set_image_type(&mut self, image_type: FileType) {

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -10,6 +10,7 @@ use derive_more::Display;
 use dyn_clone::DynClone;
 use futures::stream::BoxStream;
 
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use core::ops::Range;
 use indexmap::IndexMap;
@@ -947,7 +948,7 @@ pub enum Location {
     Stream {
         name: String,
         size: Option<usize>,
-        stream: BoxStream<'static, std::io::Result<Vec<u8>>>,
+        stream: BoxStream<'static, std::io::Result<Bytes>>,
     },
 }
 
@@ -1208,7 +1209,7 @@ pub trait RayGunAttachment: Sync + Send {
         _: Uuid,
         _: Uuid,
         _: &str,
-    ) -> Result<BoxStream<'static, Result<Vec<u8>, std::io::Error>>, Error> {
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         Err(Error::Unimplemented)
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use `Bytes` in place of `Vec<u8>` where applicable 

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Using `Bytes` for handling large bytes of data makes it cheaper to handle, reduce allocations and give some additional optimizations, which would reduce memory footprint.
- While we are using `Bytes`, some parts may still resolve to `Vec<u8>`. 