### PR TITLE
feat(files): implement gif thumbnail generator

### DIFF
--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -213,11 +213,11 @@ impl ThumbnailGenerator {
                                 (true, format) => format,
                             };
                             if output_format == ImageFormat::Gif {
-                                let decoder = GifDecoder::new(cursor).map_err(|_| Error::Other)?;
+                                let decoder = GifDecoder::new(cursor).map_err(anyhow::Error::from)?;
                                 let frames = decoder
                                     .into_frames()
                                     .collect_frames()
-                                    .map_err(|_| Error::Other)?;
+                                    .map_err(anyhow::Error::from)?;
                                 let frames = frames.iter().map(|frame| {
                                     let buffer = frame.buffer().clone();
                                     let width = width.min(buffer.width());
@@ -232,8 +232,8 @@ impl ThumbnailGenerator {
                                     )
                                 });
                                 let mut encoder = GifEncoder::new(&mut t_buffer);
-                                let _ = encoder.set_repeat(Repeat::Infinite);
-                                let _ = encoder.encode_frames(frames);
+                                encoder.set_repeat(Repeat::Infinite).map_err(anyhow::Error::from)?;
+                                encoder.encode_frames(frames).map_err(anyhow::Error::from)?;
                             } else {
                                 let image = ImageReader::new(cursor)
                                     .with_guessed_format()?

--- a/extensions/warp-ipfs/src/thumbnail.rs
+++ b/extensions/warp-ipfs/src/thumbnail.rs
@@ -10,7 +10,7 @@ use std::{
     ffi::OsStr,
     fmt::Display,
     hash::Hash,
-    io::{BufRead, BufReader, Seek},
+    io::{BufRead, Seek},
     path::PathBuf,
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -107,7 +107,7 @@ impl ThumbnailGenerator {
                     FileType::Mime(media) => match media.ty().as_str() {
                         "image" => tokio::task::spawn_blocking(move || {
                             let format: ImageFormat = extension.try_into()?;
-                            let file = BufReader::new(std::fs::File::open(own_path)?);
+                            let file = io::BufReader::new(std::fs::File::open(own_path)?);
                             let output_format = match (output_exact, format) {
                                 (false, _) => ImageFormat::Jpeg,
                                 (true, format) => format,


### PR DESCRIPTION
**What this PR does** 📖

Currently if a gif file is uploaded to constellation it will generate a thumbnail for it normally but this way the thumbnail will only contain one frame of the gif. 
This PR makes it so instead for gifs it will create a proper gif thumbnail too.