### PR TITLE
chore: Restrict the number of reactions per message

### DIFF
--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -67,7 +67,7 @@ use crate::{
 
 use super::{
     document::root::RootDocumentMap, ds_key::DataStoreKey, PeerIdExt, MAX_CONVERSATION_DESCRIPTION,
-    MAX_MESSAGE_SIZE, SHUTTLE_TIMEOUT,
+    MAX_MESSAGE_SIZE, MAX_REACTIONS, SHUTTLE_TIMEOUT,
 };
 
 const CHAT_DIRECTORY: &str = "chat_media";
@@ -1986,6 +1986,15 @@ impl ConversationInner {
 
         match state {
             ReactionState::Add => {
+                if reactions.len() >= MAX_REACTIONS {
+                    return Err(Error::InvalidLength {
+                        context: "reactions".into(),
+                        current: reactions.len(),
+                        minimum: None,
+                        maximum: Some(MAX_REACTIONS),
+                    });
+                }
+
                 let entry = reactions.entry(emoji.clone()).or_default();
 
                 if entry.contains(&own_did) {
@@ -3797,6 +3806,15 @@ async fn message_event(
 
             match state {
                 ReactionState::Add => {
+                    if reactions.len() >= MAX_REACTIONS {
+                        return Err(Error::InvalidLength {
+                            context: "reactions".into(),
+                            current: reactions.len(),
+                            minimum: None,
+                            maximum: Some(MAX_REACTIONS),
+                        });
+                    }
+
                     let entry = reactions.entry(emoji.clone()).or_default();
 
                     if entry.contains(&reactor) {

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -49,6 +49,7 @@ pub const MAX_METADATA_VALUE_LENGTH: usize = 128;
 pub const MAX_METADATA_ENTRIES: usize = 20;
 pub const MAX_THUMBNAIL_STREAM_SIZE: usize = 20 * 1024 * 1024;
 pub const MAX_CONVERSATION_DESCRIPTION: usize = 256;
+pub const MAX_REACTIONS: usize = 30;
 
 pub(super) mod topics {
     use std::fmt::Display;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Restrict the number of reactions per message.

**Which issue(s) this PR fixes** 🔨
- Relates to #415
<!--AP-X-->

**Special notes for reviewers** 🗒️
- Each message will have no more than 30 reactions. The number of reactors (ie users) are not limited, however this may change in the future.
 
**Additional comments** 🎤
