### PR TITLE
refactor: Use indexmap to preserve insertion order

### DIFF
--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -1325,7 +1325,9 @@ impl MessageReferenceList {
             None => IndexMap::new(),
         };
 
-        if !list_refs.contains_key(&message.id.to_string()) {
+        let id = message.id.to_string();
+
+        if !list_refs.contains_key(&id) {
             let mut next_ref = match self.next {
                 Some(cid) => {
                     ipfs.get_dag(cid)
@@ -1342,9 +1344,11 @@ impl MessageReferenceList {
             return Ok(cid);
         }
 
-        let id = message.id.to_string();
+        let msg_ref = list_refs.get_mut(&id).expect("entry exist");
 
-        let msg_ref = list_refs.get_mut(&id).expect("message exist");
+        if msg_ref.is_none() {
+            return Err(Error::MessageNotFound);
+        }
 
         let cid = ipfs.dag().put().serialize(message).await?;
         msg_ref.replace(cid);

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -1410,8 +1410,10 @@ impl MessageReferenceList {
     pub async fn get(&self, ipfs: &Ipfs, message_id: Uuid) -> Result<MessageDocument, Error> {
         let cid = self.messages.ok_or(Error::MessageNotFound)?;
 
+        let path = IpfsPath::from(cid).sub_path(&message_id.to_string())?;
+
         if let Ok(message_document) = ipfs
-            .get_dag(IpfsPath::from(cid).sub_path(&message_id.to_string())?)
+            .get_dag(path)
             .timeout(Duration::from_secs(10))
             .deserialized()
             .await

--- a/extensions/warp-ipfs/src/store/conversation.rs
+++ b/extensions/warp-ipfs/src/store/conversation.rs
@@ -1539,4 +1539,19 @@ impl MessageReferenceList {
 
         Ok(())
     }
+
+    // Since we have `IndexMap<String, Option<Cid>>` where the value is an `Option`, it is possible that
+    // that there could be some fragmentation when it comes to removing messages. This function would consume
+    // the current `MessageReferenceList` and walk down the reference list via `MessageReferenceList::list`
+    // and pass on messages where map value is `Option::Some` into a new list reference. Once completed, return
+    // the new list
+    // TODO: Use in the near future under a schedule to shrink reference list
+    pub async fn shrink(self, ipfs: &Ipfs) -> Result<MessageReferenceList, Error> {
+        let mut new_list = MessageReferenceList::default();
+        let mut list = self.list(ipfs).await;
+        while let Some(message) = list.next().await {
+            new_list.insert(ipfs, message).await?;
+        }
+        Ok(new_list)
+    }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use IndexMap in place of BtreeMap for preserving insertion order 

**Which issue(s) this PR fixes** 🔨
<!--AP-X-->
- relates to #585 

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Currently, we use BTreeMap to handle the sorting of the items inserted into the reference list, however this does not truly preserve the order of insertion into the map as it is determined by key implementation of `Ord`. While this would still be cheaper than `HashMap`, the order is not guaranteed to be preserved in any manner. Instead, we switch to `IndexMap` to rely on the insertion order instead.
- In addition, we make the content id optional in the map so we can preserve the reference list itself when the message is removed to prevent insertion into that list if a slot is available for insertion. This would allow us to cleanup later on as a form of "defragmentation" so the reference list would be rewritten in a manner to remove entries that are marked `None` (symbolizing that the message has been removed).
