### PR TITLE
feat: Replace `rt::spawn` with Executor trait

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -24,6 +24,7 @@ use tracing::{error, info, warn, Instrument, Span};
 use uuid::Uuid;
 
 use crate::config::{Bootstrap, DiscoveryType};
+use crate::rt::{Executor, LocalExecutor};
 use crate::store::discovery::Discovery;
 use crate::store::phonebook::PhoneBook;
 use crate::store::{ecdh_decrypt, PeerIdExt};
@@ -84,6 +85,7 @@ pub struct WarpIpfs {
     multipass_tx: EventSubscription<MultiPassEventKind>,
     raygun_tx: EventSubscription<RayGunEventKind>,
     constellation_tx: EventSubscription<ConstellationEventKind>,
+    executor: LocalExecutor,
 }
 
 pub type WarpIpfsInstance = Warp<WarpIpfs, WarpIpfs, WarpIpfs>;
@@ -181,11 +183,13 @@ impl WarpIpfs {
             multipass_tx,
             raygun_tx,
             constellation_tx,
+            executor: LocalExecutor,
         };
 
         if !identity.tesseract.is_unlock() {
             let inner = identity.clone();
-            crate::rt::spawn(async move {
+            let executor = inner.executor;
+            executor.dispatch(async move {
                 let mut stream = inner.tesseract.subscribe();
                 while let Some(event) = stream.next().await {
                     if matches!(event, TesseractEvent::Unlocked) {
@@ -509,7 +513,7 @@ impl WarpIpfs {
             };
 
             if self.inner.config.ipfs_setting().relay_client.background {
-                crate::rt::spawn(relay_connection_task);
+                self.executor.dispatch(relay_connection_task);
             } else {
                 relay_connection_task.await;
             }
@@ -545,7 +549,7 @@ impl WarpIpfs {
             }
 
             if !empty_bootstrap {
-                crate::rt::spawn({
+                self.executor.dispatch({
                     let ipfs = ipfs.clone();
                     async move {
                         loop {

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -70,25 +70,3 @@ impl Executor for LocalExecutor {
         }
     }
 }
-
-#[derive(Clone, Copy, Debug, Default, PartialOrd, PartialEq, Eq)]
-pub struct GlobalExecutor;
-
-impl GlobalExecutor {
-    #[allow(dead_code)]
-    pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        LocalExecutor::default().spawn(future)
-    }
-
-    pub fn dispatch<F>(future: F)
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        LocalExecutor::default().dispatch(future)
-    }
-}

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -77,6 +77,7 @@ impl<T> Future for JoinHandle<T> {
     }
 }
 
+#[derive(Clone)]
 pub struct AbortableJoinHandle<T> {
     handle: Arc<InnerJoinHandle<T>>,
 }

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -39,7 +39,7 @@ pub trait Executor: Clone {
         F::Output: Send + 'static;
 
     /// Spawns a new asynchronous task in the background without an handle.
-    /// Basically the same as [`Executor::spawn`]. 
+    /// Basically the same as [`Executor::spawn`].
     fn dispatch<F>(&self, future: F)
     where
         F: Future + Send + 'static,

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -1,66 +1,144 @@
+#[allow(dead_code)]
+use futures::future::{AbortHandle, Abortable, Aborted};
 use std::future::Future;
-#[cfg(target_arch = "wasm32")]
 use std::pin::Pin;
-#[cfg(target_arch = "wasm32")]
+use std::sync::Arc;
 use std::task::{Context, Poll};
 
-#[cfg(target_arch = "wasm32")]
-use futures::future::{AbortHandle, Abortable, Aborted};
-
-#[cfg(not(target_arch = "wasm32"))]
-pub use tokio::task::JoinHandle;
-
-#[cfg(target_arch = "wasm32")]
-pub struct JoinHandle<T> {
-    inner: Option<futures::channel::oneshot::Receiver<Result<T, Aborted>>>,
-    handle: AbortHandle,
+pub enum JoinHandle<T> {
+    #[cfg(not(target_arch = "wasm32"))]
+    TokioHandle(tokio::task::JoinHandle<T>),
+    #[allow(dead_code)]
+    CustomHandle {
+        inner: Option<futures::channel::oneshot::Receiver<Result<T, Aborted>>>,
+        handle: AbortHandle,
+    },
 }
 
-#[cfg(target_arch = "wasm32")]
 impl<T> JoinHandle<T> {
     #[allow(dead_code)]
-    pub fn abort(&mut self) {
-        self.handle.abort();
-        self.inner.take();
+    pub fn abort(&self) {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            JoinHandle::TokioHandle(handle) => handle.abort(),
+            JoinHandle::CustomHandle { handle, .. } => handle.abort(),
+        }
     }
 
     #[allow(dead_code)]
     pub fn is_finished(&self) -> bool {
-        self.handle.is_aborted() || self.inner.is_none()
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            JoinHandle::TokioHandle(handle) => handle.is_finished(),
+            JoinHandle::CustomHandle { handle, inner } => handle.is_aborted() || inner.is_none(),
+        }
     }
 }
 
-#[cfg(target_arch = "wasm32")]
 impl<T> Future for JoinHandle<T> {
     type Output = std::io::Result<T>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Some(this) = self.inner.as_mut() else {
-            unreachable!("cannot poll completed future");
-        };
+        match &mut *self {
+            #[cfg(not(target_arch = "wasm32"))]
+            JoinHandle::TokioHandle(handle) => {
+                let fut = futures::ready!(Pin::new(handle).poll(cx));
 
-        let fut = futures::ready!(Pin::new(this).poll(cx));
-        self.inner.take();
-
-        match fut {
-            Ok(Ok(val)) => Poll::Ready(Ok(val)),
-            Ok(Err(e)) => {
-                let e = std::io::Error::other(e);
-                Poll::Ready(Err(e))
+                match fut {
+                    Ok(val) => Poll::Ready(Ok(val)),
+                    Err(e) => {
+                        let e = std::io::Error::other(e);
+                        Poll::Ready(Err(e))
+                    }
+                }
             }
-            Err(e) => {
-                let e = std::io::Error::other(e);
-                Poll::Ready(Err(e))
+            JoinHandle::CustomHandle { inner, .. } => {
+                let Some(this) = inner.as_mut() else {
+                    unreachable!("cannot poll completed future");
+                };
+
+                let fut = futures::ready!(Pin::new(this).poll(cx));
+                inner.take();
+
+                match fut {
+                    Ok(Ok(val)) => Poll::Ready(Ok(val)),
+                    Ok(Err(e)) => {
+                        let e = std::io::Error::other(e);
+                        Poll::Ready(Err(e))
+                    }
+                    Err(e) => {
+                        let e = std::io::Error::other(e);
+                        Poll::Ready(Err(e))
+                    }
+                }
             }
         }
     }
 }
 
-pub trait Executor: Clone {
+pub struct AbortableJoinHandle<T> {
+    handle: Arc<InnerJoinHandle<T>>,
+}
+
+impl<T> From<JoinHandle<T>> for AbortableJoinHandle<T> {
+    fn from(handle: JoinHandle<T>) -> Self {
+        AbortableJoinHandle {
+            handle: Arc::new(InnerJoinHandle {
+                inner: parking_lot::Mutex::new(handle),
+            }),
+        }
+    }
+}
+
+impl<T> AbortableJoinHandle<T> {
+    #[allow(dead_code)]
+    pub fn abort(&self) {
+        self.handle.inner.lock().abort();
+    }
+
+    #[allow(dead_code)]
+    pub fn is_finished(&self) -> bool {
+        self.handle.inner.lock().is_finished()
+    }
+}
+
+struct InnerJoinHandle<T> {
+    pub inner: parking_lot::Mutex<JoinHandle<T>>,
+}
+
+impl<T> Drop for InnerJoinHandle<T> {
+    fn drop(&mut self) {
+        self.inner.lock().abort();
+    }
+}
+
+impl<T> Future for AbortableJoinHandle<T> {
+    type Output = std::io::Result<T>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let inner = &mut *self.handle.inner.lock();
+        Pin::new(inner).poll(cx).map_err(std::io::Error::other)
+    }
+}
+
+pub trait Executor {
     /// Spawns a new asynchronous task in the background, returning an Future ['JoinHandle'] for it.
     fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;
+
+    /// Spawns a new asynchronous task in the background, returning an abortable handle that will cancel the task
+    /// once the handle is dropped.
+    ///
+    /// Note: This function is used if the task is expected to run until the handle is dropped. It is recommended to use
+    /// [`Executor::spawn`] or [`Executor::dispatch`] otherwise.
+    fn spawn_abortable<F>(&self, future: F) -> AbortableJoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let handle = self.spawn(future);
+        handle.into()
+    }
 
     /// Spawns a new asynchronous task in the background without an handle.
     /// Basically the same as [`Executor::spawn`].
@@ -84,7 +162,8 @@ impl Executor for LocalExecutor {
     {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            tokio::task::spawn(future)
+            let handle = tokio::task::spawn(future);
+            JoinHandle::TokioHandle(handle)
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -97,10 +176,83 @@ impl Executor for LocalExecutor {
             };
 
             wasm_bindgen_futures::spawn_local(fut);
-            JoinHandle {
+            JoinHandle::CustomHandle {
                 inner: Some(rx),
                 handle: abort_handle,
             }
         }
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn default_abortable_task() {
+    let executor = LocalExecutor;
+
+    let (tx, rx) = futures::channel::oneshot::channel::<()>();
+
+    let handle = executor.spawn_abortable(async {
+        futures_timer::Delay::new(std::time::Duration::from_secs(5)).await;
+        _ = tx.send(());
+        unreachable!();
+    });
+
+    handle.abort();
+    drop(handle);
+    let result = rx.await;
+    assert_eq!(result.is_err(), true);
+}
+
+#[test]
+fn custom_abortable_task() {
+    use futures::future::Abortable;
+    struct FuturesExecutor {
+        pool: futures::executor::ThreadPool,
+    }
+
+    impl Default for FuturesExecutor {
+        fn default() -> Self {
+            Self {
+                pool: futures::executor::ThreadPool::new().unwrap(),
+            }
+        }
+    }
+
+    impl Executor for FuturesExecutor {
+        fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+        where
+            F: Future + Send + 'static,
+            F::Output: Send + 'static,
+        {
+            let (abort_handle, abort_registration) = AbortHandle::new_pair();
+            let future = Abortable::new(future, abort_registration);
+            let (tx, rx) = futures::channel::oneshot::channel();
+            let fut = async {
+                let val = future.await;
+                _ = tx.send(val);
+            };
+
+            self.pool.spawn_ok(fut);
+            JoinHandle::CustomHandle {
+                inner: Some(rx),
+                handle: abort_handle,
+            }
+        }
+    }
+
+    futures::executor::block_on(async move {
+        let executor = FuturesExecutor::default();
+
+        let (tx, rx) = futures::channel::oneshot::channel::<()>();
+
+        let handle = executor.spawn_abortable(async {
+            futures_timer::Delay::new(std::time::Duration::from_secs(5)).await;
+            let _ = tx.send(());
+            unreachable!();
+        });
+
+        handle.abort();
+        let result = rx.await;
+        assert_eq!(result.is_err(), true);
+    });
 }

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -4,25 +4,47 @@ use std::pin::Pin;
 #[cfg(target_arch = "wasm32")]
 use std::task::{Context, Poll};
 
+#[cfg(target_arch = "wasm32")]
+use futures::future::{AbortHandle, Abortable, Aborted};
+
 #[cfg(not(target_arch = "wasm32"))]
 pub use tokio::task::JoinHandle;
 
 #[cfg(target_arch = "wasm32")]
-pub struct JoinHandle<T>(Option<futures::channel::oneshot::Receiver<T>>);
+pub struct JoinHandle<T> {
+    inner: Option<Abortable<futures::channel::oneshot::Receiver<T>>>,
+    handle: AbortHandle,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<T> JoinHandle<T> {
+    pub fn abort(&mut self) {
+        self.handle.abort();
+        self.inner.take();
+    }
+
+    pub fn is_finished(&self) -> bool {
+        self.handle.is_aborted() || self.inner.is_none()
+    }
+}
 
 #[cfg(target_arch = "wasm32")]
 impl<T> Future for JoinHandle<T> {
     type Output = std::io::Result<T>;
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let Some(this) = self.0.as_mut() else {
+        let Some(this) = self.inner.as_mut() else {
             unreachable!("cannot poll completed future");
         };
 
         let fut = futures::ready!(Pin::new(this).poll(cx));
-        self.0.take();
+        self.inner.take();
 
         match fut {
-            Ok(val) => Poll::Ready(Ok(val)),
+            Ok(Ok(val)) => Poll::Ready(Ok(val)),
+            Ok(Err(e)) => {
+                let e = std::io::Error::other(e);
+                Poll::Ready(Err(e))
+            }
             Err(e) => {
                 let e = std::io::Error::other(e);
                 Poll::Ready(Err(e))
@@ -64,13 +86,20 @@ impl Executor for LocalExecutor {
         }
         #[cfg(target_arch = "wasm32")]
         {
+            let (abort_handle, abort_registration) = AbortHandle::new_pair();
             let (tx, rx) = futures::channel::oneshot::channel();
             let fut = async {
                 let val = future.await;
                 _ = tx.send(val);
             };
-            wasm_bindgen_futures::spawn_local(fut);
-            JoinHandle(Some(rx))
+
+            let abortable_task = Abortable::new(fut, abort_registration);
+
+            wasm_bindgen_futures::spawn_local(abortable_task);
+            JoinHandle {
+                inner: Some(rx),
+                handle: abort_handle,
+            }
         }
     }
 }

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -1,5 +1,7 @@
-#[allow(dead_code)]
-use futures::future::{AbortHandle, Abortable, Aborted};
+#[allow(unused_imports)]
+use futures::future::Abortable;
+
+use futures::future::{AbortHandle, Aborted};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -197,10 +199,9 @@ async fn default_abortable_task() {
         unreachable!();
     });
 
-    handle.abort();
     drop(handle);
     let result = rx.await;
-    assert_eq!(result.is_err(), true);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -251,8 +252,8 @@ fn custom_abortable_task() {
             unreachable!();
         });
 
-        handle.abort();
+        drop(handle);
         let result = rx.await;
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
     });
 }

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -32,10 +32,14 @@ impl<T> Future for JoinHandle<T> {
 }
 
 pub trait Executor: Clone {
+    /// Spawns a new asynchronous task in the background, returning an Future ['JoinHandle'] for it.
     fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static;
+
+    /// Spawns a new asynchronous task in the background without an handle.
+    /// Basically the same as [`Executor::spawn`]. 
     fn dispatch<F>(&self, future: F)
     where
         F: Future + Send + 'static,

--- a/extensions/warp-ipfs/src/rt.rs
+++ b/extensions/warp-ipfs/src/rt.rs
@@ -1,11 +1,94 @@
-#[cfg(not(target_arch = "wasm32"))]
-pub use tokio::task::spawn;
-
+use std::future::Future;
 #[cfg(target_arch = "wasm32")]
-pub use wasm_bindgen_futures::spawn_local as spawn;
+use std::pin::Pin;
+#[cfg(target_arch = "wasm32")]
+use std::task::{Context, Poll};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use tokio::task::JoinHandle;
 
 #[cfg(target_arch = "wasm32")]
-pub struct JoinHandle<T>(std::marker::PhantomData<T>);
+pub struct JoinHandle<T>(Option<futures::channel::oneshot::Receiver<T>>);
+
+#[cfg(target_arch = "wasm32")]
+impl<T> Future for JoinHandle<T> {
+    type Output = std::io::Result<T>;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Some(this) = self.0.as_mut() else {
+            unreachable!("cannot poll completed future");
+        };
+
+        let fut = futures::ready!(Pin::new(this).poll(cx));
+        self.0.take();
+
+        match fut {
+            Ok(val) => Poll::Ready(Ok(val)),
+            Err(e) => {
+                let e = std::io::Error::other(e);
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+}
+
+pub trait Executor: Clone {
+    fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static;
+    fn dispatch<F>(&self, future: F)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.spawn(future);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialOrd, PartialEq, Eq)]
+pub struct LocalExecutor;
+
+impl Executor for LocalExecutor {
+    fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            tokio::task::spawn(future)
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let (tx, rx) = futures::channel::oneshot::channel();
+            let fut = async {
+                let val = future.await;
+                _ = tx.send(val);
+            };
+            wasm_bindgen_futures::spawn_local(fut);
+            JoinHandle(Some(rx))
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialOrd, PartialEq, Eq)]
+pub struct GlobalExecutor;
+
+impl GlobalExecutor {
+    #[allow(dead_code)]
+    pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        LocalExecutor::default().spawn(future)
+    }
+
+    pub fn dispatch<F>(future: F)
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        LocalExecutor::default().dispatch(future)
+    }
+}

--- a/extensions/warp-ipfs/src/store/files.rs
+++ b/extensions/warp-ipfs/src/store/files.rs
@@ -31,7 +31,7 @@ use super::{
     document::root::RootDocumentMap, event_subscription::EventSubscription,
     MAX_THUMBNAIL_STREAM_SIZE,
 };
-use crate::rt::{GlobalExecutor, LocalExecutor};
+use crate::rt::{Executor, LocalExecutor};
 use crate::{
     config::{self, Config},
     thumbnail::ThumbnailGenerator,
@@ -97,7 +97,7 @@ impl FileStore {
 
         let span = span.clone();
 
-        GlobalExecutor::dispatch(async move {
+        LocalExecutor.dispatch(async move {
             tokio::select! {
                 _ = task.run().instrument(span) => {}
                 _ = token.cancelled() => {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Replace `rt::spawn` with trait to handle spawning task
- Add a `JoinHandle` to return results when awaiting on a value from a task

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- While previously, we were able to use `rt::spawn`, which was an alias between `tokio::spawn` on native and `wasm_bindgen_futures::spawn_local` for wasm32, we were not able to await the task for the latter since it does not return an handle. This PR introduces a trait with a basic interface that allows us to implement an executor to be able to spawn a task, with a function `Executor::spawn` returning a `JoinHandle<T>`, with wasm32 having a holder for a oneshot channel that is awaited on if the `JohnHandle` is awaited, or just spawning a task without returning anything with `Executor::dispatch`. 
- Additionally, this would allow us to make use of different executors internally when needed, mostly for tests.