### PR TITLE
feat: update group permissions

### DIFF
--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -472,7 +472,7 @@ async fn main() -> anyhow::Result<()> {
                             let mut permissions = GroupPermissions::new();
                             if open {
                                 for did in &did_keys {
-                                    permissions.insert(did.clone(), GroupPermission::VALUES.into_iter().collect());
+                                    permissions.insert(did.clone(), GroupPermission::values());
                                 }
                             }
                             if let Err(e) = instance.create_group_conversation(

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -472,7 +472,7 @@ async fn main() -> anyhow::Result<()> {
                             let mut permissions = GroupPermissions::new();
                             if open {
                                 for did in &did_keys {
-                                    permissions.insert(did.clone(), GroupPermission::values());
+                                    permissions.insert(did.clone(), GroupPermission::values().into_iter().collect());
                                 }
                             }
                             if let Err(e) = instance.create_group_conversation(
@@ -531,7 +531,7 @@ async fn main() -> anyhow::Result<()> {
                                     let mut permissions = GroupPermissions::new();
                                     if open {
                                         for did in conversation.recipients() {
-                                            permissions.insert(did, GroupPermission::VALUES.into_iter().collect());
+                                            permissions.insert(did, GroupPermission::values().into_iter().collect());
                                         }
                                     }
                                     if let Err(e) = instance.update_conversation_permissions(topic, permissions).await {

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -528,7 +528,7 @@ async fn main() -> anyhow::Result<()> {
                                 Ok(conversation) => {
                                     let mut permissions = GroupPermissions::new();
                                     if open {
-                                        for did in conversation.recipients()).to_owned() {
+                                        for did in conversation.recipients().to_owned() {
                                             permissions.insert(did, GroupPermission::values().into_iter().collect());
                                         }
                                     }

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -472,7 +472,7 @@ async fn main() -> anyhow::Result<()> {
                             let mut permissions = GroupPermissions::new();
                             if open {
                                 for did in &did_keys {
-                                    permissions.insert(did.clone(), vec![GroupPermission::AddParticipants, GroupPermission::SetGroupName].into_iter().collect());
+                                    permissions.insert(did.clone(), GroupPermission::VALUES.into_iter().collect());
                                 }
                             }
                             if let Err(e) = instance.create_group_conversation(
@@ -531,7 +531,7 @@ async fn main() -> anyhow::Result<()> {
                                     let mut permissions = GroupPermissions::new();
                                     if open {
                                         for did in conversation.recipients() {
-                                            permissions.insert(did, vec![GroupPermission::AddParticipants, GroupPermission::SetGroupName].into_iter().collect());
+                                            permissions.insert(did, GroupPermission::VALUES.into_iter().collect());
                                         }
                                     }
                                     if let Err(e) = instance.update_conversation_permissions(topic, permissions).await {

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -2177,7 +2177,7 @@ impl ConversationTask {
             if !&self
                 .document
                 .permissions
-                .has_permission(&own_did, GroupPermission::EditGroupVisual)
+                .has_permission(&own_did, GroupPermission::EditGroupImages)
                 && own_did.ne(creator)
             {
                 return Err(Error::Unauthorized);
@@ -2319,7 +2319,7 @@ impl ConversationTask {
             if !&self
                 .document
                 .permissions
-                .has_permission(&own_did, GroupPermission::EditGroupVisual)
+                .has_permission(&own_did, GroupPermission::EditGroupImages)
                 && own_did.ne(creator)
             {
                 return Err(Error::Unauthorized);
@@ -3523,7 +3523,7 @@ async fn message_event(
                         && !this
                             .document
                             .permissions
-                            .has_permission(sender, GroupPermission::EditGroupVisual)
+                            .has_permission(sender, GroupPermission::EditGroupImages)
                     {
                         return Err(Error::Unauthorized);
                     }
@@ -3543,7 +3543,7 @@ async fn message_event(
                         && !this
                             .document
                             .permissions
-                            .has_permission(sender, GroupPermission::EditGroupVisual)
+                            .has_permission(sender, GroupPermission::EditGroupImages)
                     {
                         return Err(Error::Unauthorized);
                     }

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -2179,7 +2179,7 @@ impl ConversationTask {
             if !&self
                 .document
                 .permissions
-                .has_permission(&own_did, GroupPermission::EditGroupInfo)
+                .has_permission(&own_did, GroupPermission::EditGroupVisual)
                 && own_did.ne(creator)
             {
                 return Err(Error::Unauthorized);
@@ -2321,7 +2321,7 @@ impl ConversationTask {
             if !&self
                 .document
                 .permissions
-                .has_permission(&own_did, GroupPermission::EditGroupInfo)
+                .has_permission(&own_did, GroupPermission::EditGroupVisual)
                 && own_did.ne(creator)
             {
                 return Err(Error::Unauthorized);
@@ -3525,7 +3525,7 @@ async fn message_event(
                         && !this
                             .document
                             .permissions
-                            .has_permission(sender, GroupPermission::EditGroupInfo)
+                            .has_permission(sender, GroupPermission::EditGroupVisual)
                     {
                         return Err(Error::Unauthorized);
                     }
@@ -3545,7 +3545,7 @@ async fn message_event(
                         && !this
                             .document
                             .permissions
-                            .has_permission(sender, GroupPermission::EditGroupInfo)
+                            .has_permission(sender, GroupPermission::EditGroupVisual)
                     {
                         return Err(Error::Unauthorized);
                     }

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -2171,7 +2171,6 @@ impl ConversationTask {
             ConversationImageType::Banner => MAX_CONVERSATION_BANNER_SIZE,
             ConversationImageType::Icon => MAX_CONVERSATION_ICON_SIZE,
         };
-        
         if self.document.conversation_type() == ConversationType::Group {
             let Some(creator) = self.document.creator.as_ref() else {
                 return Err(Error::InvalidConversation);

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -1941,10 +1941,11 @@ impl ConversationTask {
 
         let own_did = &self.identity.did_key();
 
-        if creator.ne(own_did) && !self
-            .document
-            .permissions
-            .has_permission(own_did, GroupPermission::RemoveParticipants)
+        if creator.ne(own_did)
+            && !self
+                .document
+                .permissions
+                .has_permission(own_did, GroupPermission::RemoveParticipants)
         {
             return Err(Error::Unauthorized);
         }
@@ -2181,10 +2182,11 @@ impl ConversationTask {
 
         let own_did = &self.identity.did_key();
 
-        if creator.ne(own_did) && !&self
-            .document
-            .permissions
-            .has_permission(own_did, GroupPermission::EditGroupInfo)
+        if creator.ne(own_did)
+            && !&self
+                .document
+                .permissions
+                .has_permission(own_did, GroupPermission::EditGroupInfo)
         {
             return Err(Error::Unauthorized);
         }
@@ -2327,10 +2329,11 @@ impl ConversationTask {
 
         let own_did = &self.identity.did_key();
 
-        if creator.ne(own_did) && !&self
-            .document
-            .permissions
-            .has_permission(own_did, GroupPermission::EditGroupInfo)
+        if creator.ne(own_did)
+            && !&self
+                .document
+                .permissions
+                .has_permission(own_did, GroupPermission::EditGroupInfo)
         {
             return Err(Error::Unauthorized);
         }
@@ -2378,9 +2381,9 @@ impl ConversationTask {
             let Some(creator) = self.document.creator.as_ref() else {
                 return Err(Error::InvalidConversation);
             };
-    
+
             let own_did = self.identity.did_key();
-    
+
             if !&self
                 .document
                 .permissions

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -8,7 +8,8 @@ mod test {
         constellation::Progression,
         multipass::MultiPassEventKind,
         raygun::{
-            AttachmentKind, ConversationType, GroupPermission, GroupPermissions, Location, MessageEvent, MessageEventKind, MessageType, PinState, RayGunEventKind, ReactionState
+            AttachmentKind, ConversationType, GroupPermission, GroupPermissions, Location,
+            MessageEvent, MessageEventKind, MessageType, PinState, RayGunEventKind, ReactionState,
         },
     };
 
@@ -987,8 +988,13 @@ mod test {
         let mut chat_subscribe_b = instance_b.raygun_subscribe().await?;
 
         let mut perms = GroupPermissions::new();
-        perms.insert(did_b.clone(), [GroupPermission::EditGroupInfo].into_iter().collect());
-        instance_a.create_group_conversation(None, vec![did_b.clone()], perms).await?;
+        perms.insert(
+            did_b.clone(),
+            [GroupPermission::EditGroupInfo].into_iter().collect(),
+        );
+        instance_a
+            .create_group_conversation(None, vec![did_b.clone()], perms)
+            .await?;
 
         let id_a = crate::common::timeout(Duration::from_secs(60), async {
             loop {
@@ -1454,8 +1460,13 @@ mod test {
         let mut chat_subscribe_b = instance_b.raygun_subscribe().await?;
 
         let mut perms = GroupPermissions::new();
-        perms.insert(did_b.clone(), [GroupPermission::EditGroupInfo].into_iter().collect());
-        instance_a.create_group_conversation(None, vec![did_b.clone()], perms).await?;
+        perms.insert(
+            did_b.clone(),
+            [GroupPermission::EditGroupInfo].into_iter().collect(),
+        );
+        instance_a
+            .create_group_conversation(None, vec![did_b.clone()], perms)
+            .await?;
 
         let conversation_id = crate::common::timeout(Duration::from_secs(60), async {
             let mut id_a = None;
@@ -1603,8 +1614,13 @@ mod test {
         let mut chat_subscribe_b = instance_b.raygun_subscribe().await?;
 
         let mut perms = GroupPermissions::new();
-        perms.insert(did_b.clone(), [GroupPermission::EditGroupInfo].into_iter().collect());
-        instance_a.create_group_conversation(None, vec![did_b.clone()], perms).await?;
+        perms.insert(
+            did_b.clone(),
+            [GroupPermission::EditGroupInfo].into_iter().collect(),
+        );
+        instance_a
+            .create_group_conversation(None, vec![did_b.clone()], perms)
+            .await?;
 
         let conversation_id = crate::common::timeout(Duration::from_secs(60), async {
             let mut id_a = None;
@@ -1672,7 +1688,6 @@ mod test {
 
 
         }).await??;
-
 
         instance_b
             .update_conversation_banner(

--- a/extensions/warp-ipfs/tests/direct.rs
+++ b/extensions/warp-ipfs/tests/direct.rs
@@ -8,8 +8,7 @@ mod test {
         constellation::Progression,
         multipass::MultiPassEventKind,
         raygun::{
-            AttachmentKind, ConversationType, Location, MessageEvent, MessageEventKind,
-            MessageType, PinState, RayGunEventKind, ReactionState,
+            AttachmentKind, ConversationType, GroupPermission, GroupPermissions, Location, MessageEvent, MessageEventKind, MessageType, PinState, RayGunEventKind, ReactionState
         },
     };
 
@@ -987,7 +986,9 @@ mod test {
         let mut chat_subscribe_a = instance_a.raygun_subscribe().await?;
         let mut chat_subscribe_b = instance_b.raygun_subscribe().await?;
 
-        instance_a.create_conversation(&did_b).await?;
+        let mut perms = GroupPermissions::new();
+        perms.insert(did_b.clone(), [GroupPermission::EditGroupInfo].into_iter().collect());
+        instance_a.create_group_conversation(None, vec![did_b.clone()], perms).await?;
 
         let id_a = crate::common::timeout(Duration::from_secs(60), async {
             loop {
@@ -1452,7 +1453,9 @@ mod test {
         let mut chat_subscribe_a = instance_a.raygun_subscribe().await?;
         let mut chat_subscribe_b = instance_b.raygun_subscribe().await?;
 
-        instance_a.create_conversation(&did_b).await?;
+        let mut perms = GroupPermissions::new();
+        perms.insert(did_b.clone(), [GroupPermission::EditGroupInfo].into_iter().collect());
+        instance_a.create_group_conversation(None, vec![did_b.clone()], perms).await?;
 
         let conversation_id = crate::common::timeout(Duration::from_secs(60), async {
             let mut id_a = None;
@@ -1475,7 +1478,7 @@ mod test {
         }).await?;
 
         let conversation = instance_a.get_conversation(conversation_id).await?;
-        assert_eq!(conversation.conversation_type(), ConversationType::Direct);
+        assert_eq!(conversation.conversation_type(), ConversationType::Group);
         assert_eq!(conversation.recipients().len(), 2);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -1494,7 +1497,6 @@ mod test {
                 },
             )
             .await?;
-
         crate::common::timeout(Duration::from_secs(60), async {
             let mut a_updated = false;
             let mut b_updated = false;
@@ -1509,6 +1511,42 @@ mod test {
                     Some(MessageEventKind::ConversationUpdatedIcon { .. }) = conversation_stream_b.next() => {
                         b_updated = true;
                         let image = instance_b.conversation_icon(conversation_id).await?;
+                        assert_eq!(image.data(), PROFILE_IMAGE);
+                    }
+                }
+
+                if a_updated && b_updated {
+                    break Ok::<_, anyhow::Error>(())
+                }
+            }
+
+        }).await??;
+
+        instance_b
+            .update_conversation_icon(
+                conversation_id,
+                Location::Stream {
+                    name: "".into(),
+                    size: Some(PROFILE_IMAGE.len()),
+                    stream: futures::stream::once(async { Ok(PROFILE_IMAGE.to_vec().into()) })
+                        .boxed(),
+                },
+            )
+            .await?;
+        crate::common::timeout(Duration::from_secs(60), async {
+            let mut a_updated = false;
+            let mut b_updated = false;
+
+            loop {
+                tokio::select! {
+                    Some(MessageEventKind::ConversationUpdatedIcon { .. }) = conversation_stream_a.next() => {
+                        b_updated = true;
+                        let image = instance_b.conversation_icon(conversation_id).await?;
+                        assert_eq!(image.data(), PROFILE_IMAGE);
+                    },
+                    Some(MessageEventKind::ConversationUpdatedIcon { .. }) = conversation_stream_b.next() => {
+                        a_updated = true;
+                        let image = instance_a.conversation_icon(conversation_id).await?;
                         assert_eq!(image.data(), PROFILE_IMAGE);
                     }
                 }
@@ -1564,7 +1602,9 @@ mod test {
         let mut chat_subscribe_a = instance_a.raygun_subscribe().await?;
         let mut chat_subscribe_b = instance_b.raygun_subscribe().await?;
 
-        instance_a.create_conversation(&did_b).await?;
+        let mut perms = GroupPermissions::new();
+        perms.insert(did_b.clone(), [GroupPermission::EditGroupInfo].into_iter().collect());
+        instance_a.create_group_conversation(None, vec![did_b.clone()], perms).await?;
 
         let conversation_id = crate::common::timeout(Duration::from_secs(60), async {
             let mut id_a = None;
@@ -1587,7 +1627,7 @@ mod test {
         }).await?;
 
         let conversation = instance_a.get_conversation(conversation_id).await?;
-        assert_eq!(conversation.conversation_type(), ConversationType::Direct);
+        assert_eq!(conversation.conversation_type(), ConversationType::Group);
         assert_eq!(conversation.recipients().len(), 2);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -1621,6 +1661,45 @@ mod test {
                     Some(MessageEventKind::ConversationUpdatedBanner { .. }) = conversation_stream_b.next() => {
                         b_updated = true;
                         let image = instance_b.conversation_banner(conversation_id).await?;
+                        assert_eq!(image.data(), PROFILE_IMAGE);
+                    }
+                }
+
+                if a_updated && b_updated {
+                    break Ok::<_, anyhow::Error>(())
+                }
+            }
+
+
+        }).await??;
+
+
+        instance_b
+            .update_conversation_banner(
+                conversation_id,
+                Location::Stream {
+                    name: "".into(),
+                    size: Some(PROFILE_IMAGE.len()),
+                    stream: futures::stream::once(async { Ok(PROFILE_IMAGE.to_vec().into()) })
+                        .boxed(),
+                },
+            )
+            .await?;
+
+        crate::common::timeout(Duration::from_secs(60), async {
+            let mut a_updated = false;
+            let mut b_updated = false;
+
+            loop {
+                tokio::select! {
+                    Some(MessageEventKind::ConversationUpdatedBanner { .. }) = conversation_stream_a.next() => {
+                        b_updated = true;
+                        let image = instance_b.conversation_banner(conversation_id).await?;
+                        assert_eq!(image.data(), PROFILE_IMAGE);
+                    },
+                    Some(MessageEventKind::ConversationUpdatedBanner { .. }) = conversation_stream_b.next() => {
+                        a_updated = true;
+                        let image = instance_a.conversation_banner(conversation_id).await?;
                         assert_eq!(image.data(), PROFILE_IMAGE);
                     }
                 }

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -317,11 +317,11 @@ mod test {
         let mut permissions = GroupPermissions::new();
         permissions.insert(
             did_b.clone(),
-            vec![GroupPermission::SetGroupName].into_iter().collect(),
+            vec![GroupPermission::EditGroupInfo].into_iter().collect(),
         );
         permissions.insert(
             did_c.clone(),
-            vec![GroupPermission::SetGroupName].into_iter().collect(),
+            vec![GroupPermission::EditGroupInfo].into_iter().collect(),
         );
 
         instance_a
@@ -601,8 +601,8 @@ mod test {
 
         let ret = instance_b.update_conversation_name(id_b, "test").await;
 
-        if permissions[&did_b].contains(&GroupPermission::SetGroupName)
-            && permissions[&did_c].contains(&GroupPermission::SetGroupName)
+        if permissions[&did_b].contains(&GroupPermission::EditGroupInfo)
+            && permissions[&did_c].contains(&GroupPermission::EditGroupInfo)
         {
             // Non-owner should be able to change the name.
             ret?;

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -891,6 +891,7 @@ impl GroupPermission {
             Self::AddParticipants,
             Self::RemoveParticipants,
             Self::EditGroupInfo,
+            Self::EditGroupVisual,
         ]
     }
 }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -752,7 +752,9 @@ pub enum GroupPermission {
 }
 
 impl GroupPermission {
-    pub const VALUES: [Self; 3] = [Self::AddParticipants, Self::RemoveParticipants, Self::EditGroupInfo];
+    pub fn values() -> Vec<GroupPermission> {
+        vec![Self::AddParticipants, Self::RemoveParticipants, Self::EditGroupInfo]
+    }
 }
 
 #[derive(Default, Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, Display)]

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -753,7 +753,11 @@ pub enum GroupPermission {
 
 impl GroupPermission {
     pub fn values() -> Vec<GroupPermission> {
-        vec![Self::AddParticipants, Self::RemoveParticipants, Self::EditGroupInfo]
+        vec![
+            Self::AddParticipants,
+            Self::RemoveParticipants,
+            Self::EditGroupInfo,
+        ]
     }
 }
 

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -882,7 +882,7 @@ pub enum GroupPermission {
     AddParticipants,
     RemoveParticipants,
     EditGroupInfo,
-    EditGroupVisual,
+    EditGroupImages,
 }
 
 impl GroupPermission {
@@ -891,7 +891,7 @@ impl GroupPermission {
             Self::AddParticipants,
             Self::RemoveParticipants,
             Self::EditGroupInfo,
-            Self::EditGroupVisual,
+            Self::EditGroupImages,
         ]
     }
 }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -749,6 +749,7 @@ pub enum GroupPermission {
     AddParticipants,
     RemoveParticipants,
     EditGroupInfo,
+    EditGroupVisual
 }
 
 impl GroupPermission {

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -749,7 +749,7 @@ pub enum GroupPermission {
     AddParticipants,
     RemoveParticipants,
     EditGroupInfo,
-    EditGroupVisual
+    EditGroupVisual,
 }
 
 impl GroupPermission {

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -747,7 +747,12 @@ impl Conversation {
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Hash)]
 pub enum GroupPermission {
     AddParticipants,
-    SetGroupName,
+    RemoveParticipants,
+    EditGroupInfo,
+}
+
+impl GroupPermission {
+    pub const VALUES: [Self; 3] = [Self::AddParticipants, Self::RemoveParticipants, Self::EditGroupInfo];
 }
 
 #[derive(Default, Clone, Copy, Deserialize, Serialize, Debug, PartialEq, Eq, Display)]


### PR DESCRIPTION
**What this PR does** 📖

- Renamed SetGroupName to EditGroupInfo
- Added RemoveParticipants permission. If someone has this they can remove a user from a group
- EditGroupInfo now allows: Renaming group name + description, changing group icon and banner
- Changed no permission error from PublicKeyInvalid to Unauthorized

- Updates the tests which only used direct conversation instead of group
