### PR TITLE
refactor: provide a reference from structs where possible

### DIFF
--- a/extensions/warp-ipfs/examples/identity-interface.rs
+++ b/extensions/warp-ipfs/examples/identity-interface.rs
@@ -210,7 +210,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did, .. } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             if !opt.autoaccept_friend {
@@ -222,7 +222,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::FriendRequestSent { to: did, .. } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> A request has been sent to {username}. Do \"request close {did}\" to if you wish to close the request")?;
@@ -230,7 +230,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::IncomingFriendRequestRejected { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> You've rejected {username} request")?;
@@ -238,7 +238,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::OutgoingFriendRequestRejected { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} rejected your request")?;
@@ -246,7 +246,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::IncomingFriendRequestClosed { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has retracted their request")?;
@@ -254,7 +254,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::OutgoingFriendRequestClosed { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
 
@@ -263,7 +263,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::FriendAdded { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> You are now friends with {username}")?;
@@ -271,7 +271,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::FriendRemoved { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has been removed from friends list")?;
@@ -279,7 +279,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::IdentityOnline { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has came online")?;
@@ -287,7 +287,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::IdentityOffline { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} went offline")?;
@@ -295,7 +295,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::Blocked { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} was blocked")?;
@@ -303,7 +303,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::Unblocked { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} was unblocked")?;
@@ -311,7 +311,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::UnblockedBy { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
 
@@ -320,7 +320,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::BlockedBy { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
 
@@ -329,7 +329,7 @@ async fn main() -> anyhow::Result<()> {
                         warp::multipass::MultiPassEventKind::IdentityUpdate { did } => {
                             let username = account
                                 .get_identity(Identifier::did_key(did.clone())).await
-                                .map(|ident| ident.username())
+                                .map(|ident| ident.username().to_owned())
                                 .unwrap_or_else(|_| did.to_string());
 
                             writeln!(stdout, "> {username} has been updated ")?;
@@ -368,7 +368,7 @@ async fn main() -> anyhow::Result<()> {
                             };
                             for friend in friends.iter() {
                                 let username = match account.get_identity(Identifier::did_key(friend.clone())).await {
-                                    Ok(ident) => ident.username(),
+                                    Ok(ident) => ident.username().to_owned(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -390,7 +390,7 @@ async fn main() -> anyhow::Result<()> {
                             };
                             for item in block_list.iter() {
                                 let username = match account.get_identity(Identifier::did_key(item.clone())).await {
-                                    Ok(ident) => ident.username(),
+                                    Ok(ident) => ident.username().to_owned(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -637,7 +637,7 @@ async fn main() -> anyhow::Result<()> {
                             for request in list.iter() {
                                 let identity = request.identity();
                                 let username = match account.get_identity(Identifier::did_key(identity.clone())).await {
-                                    Ok(ident) => ident.username(),
+                                    Ok(ident) => ident.username().to_owned(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -660,7 +660,7 @@ async fn main() -> anyhow::Result<()> {
                             for request in list.iter() {
                                 let identity = request.identity();
                                 let username = match account.get_identity(Identifier::did_key(identity.clone())).await {
-                                    Ok(ident) => ident.username(),
+                                    Ok(ident) => ident.username().to_owned(),
                                     Err(_) => String::from("N/A")
                                 };
                                 table.add_row(vec![
@@ -778,11 +778,11 @@ async fn main() -> anyhow::Result<()> {
                                     let meta = identity.metadata();
 
                                     table.add_row(vec![
-                                        identity.username(),
+                                        identity.username().to_owned(),
                                         identity.did_key().to_string(),
                                         created.to_string(),
                                         modified.to_string(),
-                                        identity.status_message().unwrap_or_default(),
+                                        identity.status_message().map(ToOwned::to_owned).unwrap_or_default(),
                                         (!profile_banner.data().is_empty()).to_string(),
                                         (!profile_picture.data().is_empty()).to_string(),
                                         platform.to_string(),
@@ -815,11 +815,11 @@ async fn main() -> anyhow::Result<()> {
                                         let meta = identity.metadata();
 
                                         table.add_row(vec![
-                                            identity.username(),
+                                            identity.username().to_string(),
                                             identity.did_key().to_string(),
                                             created.to_string(),
                                             modified.to_string(),
-                                            identity.status_message().unwrap_or_default(),
+                                            identity.status_message().map(ToOwned::to_owned).unwrap_or_default(),
                                             (!profile_banner.data().is_empty()).to_string(),
                                             (!profile_picture.data().is_empty()).to_string(),
                                             platform.to_string(),

--- a/extensions/warp-ipfs/examples/ipfs-friends.rs
+++ b/extensions/warp-ipfs/examples/ipfs-friends.rs
@@ -52,14 +52,14 @@ async fn main() -> anyhow::Result<()> {
             Some(ev) = subscribe_a.next() => {
                 match ev {
                     MultiPassEventKind::FriendRequestSent { .. } => sent = true,
-                    MultiPassEventKind::IdentityUpdate { did } if did == ident_b.did_key() => seen_b = true,
+                    MultiPassEventKind::IdentityUpdate { did } if did.eq(ident_b.did_key()) => seen_b = true,
                     _ => {}
                 }
             }
             Some(ev) = subscribe_b.next() => {
                 match ev {
                     MultiPassEventKind::FriendRequestReceived { .. } => received = true,
-                    MultiPassEventKind::IdentityUpdate { did } if did == ident_a.did_key() => seen_a = true,
+                    MultiPassEventKind::IdentityUpdate { did } if did.eq(ident_a.did_key()) => seen_a = true,
                     _ => {}
                 }
             }

--- a/extensions/warp-ipfs/examples/messenger.rs
+++ b/extensions/warp-ipfs/examples/messenger.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::env::temp_dir;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -273,7 +274,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::FriendRequestReceived { from: did, .. } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
                         if !opt.autoaccept_friend {
                             writeln!(stdout, "> Pending request from {username}. Do \"/accept-request {did}\" to accept.")?;
@@ -284,7 +285,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::FriendRequestSent { to: did, .. } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> A request has been sent to {username}. Do \"/close-request {did}\" to if you wish to close the request")?;
@@ -292,7 +293,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::IncomingFriendRequestRejected { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> You've rejected {username} request")?;
@@ -300,7 +301,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::OutgoingFriendRequestRejected { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} rejected your request")?;
@@ -308,7 +309,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::IncomingFriendRequestClosed { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} has retracted their request")?;
@@ -316,7 +317,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::OutgoingFriendRequestClosed { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> Request for {username} has been retracted")?;
@@ -324,7 +325,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::FriendAdded { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> You are now friends with {username}")?;
@@ -332,7 +333,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::FriendRemoved { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} has been removed from friends list")?;
@@ -340,7 +341,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::IdentityOnline { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} has came online")?;
@@ -348,7 +349,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::IdentityOffline { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} went offline")?;
@@ -356,7 +357,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::Blocked { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} was blocked")?;
@@ -364,14 +365,14 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::Unblocked { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
                         writeln!(stdout, "> {username} was unblocked")?;
                     },
                     warp::multipass::MultiPassEventKind::UnblockedBy { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} unblocked you")?;
@@ -379,7 +380,7 @@ async fn main() -> anyhow::Result<()> {
                     warp::multipass::MultiPassEventKind::BlockedBy { did } => {
                         let username = instance
                             .get_identity(Identifier::did_key(did.clone())).await
-                            .map(|ident| ident.username())
+                            .map(|ident| ident.username().to_owned())
                             .unwrap_or_else(|_| did.to_string());
 
                         writeln!(stdout, "> {username} blocked you")?;
@@ -516,7 +517,7 @@ async fn main() -> anyhow::Result<()> {
                                 }
                                 let created = convo.created();
                                 let modified = convo.modified();
-                                table.add_row(vec![convo.name().unwrap_or_default(), convo.id().to_string(), created.to_string(), modified.to_string(), recipients.join(",").to_string()]);
+                                table.add_row(vec![convo.name().map(ToOwned::to_owned).unwrap_or_default(), convo.id().to_string(), created.to_string(), modified.to_string(), recipients.join(",").to_string()]);
                             }
                             writeln!(stdout, "{table}")?;
                         },
@@ -530,7 +531,7 @@ async fn main() -> anyhow::Result<()> {
                                 Ok(conversation) => {
                                     let mut permissions = GroupPermissions::new();
                                     if open {
-                                        for did in conversation.recipients() {
+                                        for did in conversation.recipients().to_owned() {
                                             permissions.insert(did, vec![GroupPermission::AddParticipants, GroupPermission::SetGroupName].into_iter().collect());
                                         }
                                     }
@@ -967,11 +968,11 @@ async fn main() -> anyhow::Result<()> {
                                 let modified = identity.modified();
 
                                 table.add_row(vec![
-                                    identity.username(),
+                                    identity.username().to_owned(),
                                     identity.did_key().to_string(),
                                     created.to_string(),
                                     modified.to_string(),
-                                    identity.status_message().unwrap_or_default(),
+                                    identity.status_message().map(ToOwned::to_owned).unwrap_or_default(),
                                     (!profile_banner.data().is_empty()).to_string(),
                                     (!profile_picture.data().is_empty()).to_string(),
                                     platform.to_string(),
@@ -993,9 +994,10 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn get_username<M: MultiPass>(account: &M, did: DID) -> String {
+async fn get_username<M: MultiPass>(account: &M, did: impl Borrow<DID>) -> String {
+    let did = did.borrow();
     account
-        .get_identity(Identifier::did_key(did.clone()))
+        .get_identity(did)
         .await
         .map(|id| format!("{}#{}", id.username(), id.short_id()))
         .unwrap_or(did.to_string())

--- a/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
@@ -71,14 +71,14 @@ pub async fn run() -> Result<(), JsError> {
             Some(ev) = subscribe_a.next() => {
                 match ev {
                     MultiPassEventKind::FriendRequestSent { .. } => sent = true,
-                    MultiPassEventKind::IdentityUpdate { did } if did == ident_b.did_key() => seen_b = true,
+                    MultiPassEventKind::IdentityUpdate { did } if did.eq(ident_b.did_key()) => seen_b = true,
                     _ => {}
                 }
             }
             Some(ev) = subscribe_b.next() => {
                 match ev {
                     MultiPassEventKind::FriendRequestReceived { .. } => received = true,
-                    MultiPassEventKind::IdentityUpdate { did } if did == ident_a.did_key() => seen_a = true,
+                    MultiPassEventKind::IdentityUpdate { did } if did.eq(ident_a.did_key()) => seen_a = true,
                     _ => {}
                 }
             }

--- a/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
+++ b/extensions/warp-ipfs/examples/wasm-ipfs-friends/src/lib.rs
@@ -61,7 +61,7 @@ pub async fn run() -> Result<(), JsError> {
     ))?;
     body.append_p("")?;
 
-    account_a.send_request(&ident_b.did_key()).await?;
+    account_a.send_request(ident_b.did_key()).await?;
     let mut sent = false;
     let mut received = false;
     let mut seen_a = false;
@@ -111,10 +111,10 @@ pub async fn run() -> Result<(), JsError> {
     match coin {
         0 => {
             body.append_p(&format!("Denying {} friend request", username(&ident_a)))?;
-            account_b.deny_request(&ident_a.did_key()).await?;
+            account_b.deny_request(ident_a.did_key()).await?;
         }
         _ => {
-            account_b.accept_request(&ident_a.did_key()).await?;
+            account_b.accept_request(ident_a.did_key()).await?;
 
             body.append_p(&format!(
                 "{} accepted {} request",
@@ -141,8 +141,8 @@ pub async fn run() -> Result<(), JsError> {
             }
 
             if rand::random() {
-                account_a.remove_friend(&ident_b.did_key()).await?;
-                if account_a.has_friend(&ident_b.did_key()).await? {
+                account_a.remove_friend(ident_b.did_key()).await?;
+                if account_a.has_friend(ident_b.did_key()).await? {
                     body.append_p(&format!(
                         "{} is stuck with {} forever",
                         username(&ident_a),
@@ -156,8 +156,8 @@ pub async fn run() -> Result<(), JsError> {
                     ))?;
                 }
             } else {
-                account_b.remove_friend(&ident_a.did_key()).await?;
-                if account_b.has_friend(&ident_a.did_key()).await? {
+                account_b.remove_friend(ident_a.did_key()).await?;
+                if account_b.has_friend(ident_a.did_key()).await? {
                     body.append_p(&format!(
                         "{} is stuck with {} forever",
                         username(&ident_b),

--- a/extensions/warp-ipfs/src/store/conversation/message.rs
+++ b/extensions/warp-ipfs/src/store/conversation/message.rs
@@ -101,7 +101,7 @@ impl MessageDocument {
         let modified = message.modified();
         let replied = message.replied();
         let lines = message.lines();
-        let reactions = message.reactions();
+        let reactions = message.reactions().to_owned();
         let attachments = message.attachments();
 
         if attachments.len() > MAX_ATTACHMENT {
@@ -255,7 +255,7 @@ impl MessageDocument {
 
         if message.id() != self.id
             || message.conversation_id() != self.conversation_id
-            || message.sender() != sender
+            || message.sender() != &sender
         {
             tracing::error!(id = %self.conversation_id, message_id = %self.id, "Message does not exist, is invalid or has invalid sender");
             //TODO: Maybe remove message from this point?
@@ -275,7 +275,7 @@ impl MessageDocument {
             });
         }
 
-        self.reactions = reactions;
+        self.reactions = reactions.to_owned();
 
         if message.lines() != old_message.lines() {
             let lines = message.lines();

--- a/extensions/warp-ipfs/src/store/conversation/message.rs
+++ b/extensions/warp-ipfs/src/store/conversation/message.rs
@@ -153,7 +153,7 @@ impl MessageDocument {
 
         let data = match key {
             Either::Right(keystore) => {
-                let key = keystore.get_latest(keypair, &sender)?;
+                let key = keystore.get_latest(keypair, sender)?;
                 Cipher::direct_encrypt(&bytes, &key)?.into()
             }
             Either::Left(key) => ecdh_encrypt(keypair, Some(key), &bytes)?.into(),
@@ -161,7 +161,7 @@ impl MessageDocument {
 
         let message = Some(data);
 
-        let sender = DIDEd25519Reference::from_did(&sender);
+        let sender = DIDEd25519Reference::from_did(sender);
 
         let document = MessageDocument {
             id,

--- a/extensions/warp-ipfs/src/store/document/identity.rs
+++ b/extensions/warp-ipfs/src/store/document/identity.rs
@@ -62,10 +62,10 @@ pub struct IdentityMetadata {
 
 impl From<Identity> for IdentityDocument {
     fn from(identity: Identity) -> Self {
-        let username = identity.username();
-        let did = identity.did_key();
+        let username = identity.username().to_owned();
+        let did = identity.did_key().to_owned();
         let short_id = *identity.short_id();
-        let status_message = identity.status_message();
+        let status_message = identity.status_message().map(ToOwned::to_owned);
         let created = identity.created();
         let modified = identity.modified();
 

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -1281,7 +1281,7 @@ impl IdentityStore {
                 identity.verify()?;
 
                 if let Ok(own_id) = self.own_identity().await {
-                    if own_id.did_key() == identity.did {
+                    if own_id.did_key() == &identity.did {
                         tracing::warn!(did = %identity.did, "Cannot accept own identity");
                         return Ok(());
                     }
@@ -2253,7 +2253,7 @@ impl IdentityStore {
         let own_did = self
             .own_identity()
             .await
-            .map(|identity| identity.did_key())
+            .map(|identity| identity.did_key().to_owned())
             .map_err(|_| Error::OtherWithContext("Identity store may not be initialized".into()))?;
 
         if own_did.eq(did) {

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -3119,10 +3119,10 @@ async fn message_event(
                 });
             }
 
-            let sender = message.sender();
-
             *message.lines_mut() = lines;
             message.set_modified(modified);
+
+            let sender = message.sender().to_owned();
 
             message_document
                 .update(

--- a/extensions/warp-ipfs/tests/common.rs
+++ b/extensions/warp-ipfs/tests/common.rs
@@ -77,7 +77,7 @@ pub async fn create_account(
     let profile = instance.create_identity(username, passphrase).await?;
     let identity = profile.identity().clone();
 
-    Ok((instance, identity.did_key(), identity))
+    Ok((instance, identity.did_key().clone(), identity))
 }
 
 #[allow(dead_code)]

--- a/extensions/warp-ipfs/tests/group.rs
+++ b/extensions/warp-ipfs/tests/group.rs
@@ -56,7 +56,7 @@ mod test {
         .await?;
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), GroupPermissions::new(),);
+        assert_eq!(conversation.permissions(), &GroupPermissions::new(),);
         assert_eq!(conversation.recipients().len(), 1);
         assert!(conversation.recipients().contains(&did_a));
 
@@ -110,7 +110,7 @@ mod test {
         .await?;
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.name(), Some(name));
+        assert_eq!(conversation.name(), Some(name).as_deref());
 
         instance_a.update_conversation_name(id_a, "").await?;
 
@@ -193,7 +193,7 @@ mod test {
         assert_eq!(id_b, id_c);
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), GroupPermissions::new(),);
+        assert_eq!(conversation.permissions(), &GroupPermissions::new(),);
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -439,7 +439,7 @@ mod test {
         .await?;
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), permissions,);
+        assert_eq!(conversation.permissions(), &permissions,);
         assert_eq!(conversation.name().as_deref(), Some("test"));
         assert_eq!(conversation.recipients().len(), 4);
         assert!(conversation.recipients().contains(&did_a));
@@ -615,7 +615,7 @@ mod test {
         }
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), permissions,);
+        assert_eq!(conversation.permissions(), &permissions,);
         assert_eq!(conversation.recipients().len(), 4);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -765,7 +765,7 @@ mod test {
         .await?;
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), GroupPermissions::new(),);
+        assert_eq!(conversation.permissions(), &GroupPermissions::new(),);
         assert_eq!(conversation.recipients().len(), 4);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -1092,7 +1092,7 @@ mod test {
 
         let conversation = instance_a.get_conversation(id_a).await?;
 
-        assert_eq!(conversation.permissions(), GroupPermissions::new(),);
+        assert_eq!(conversation.permissions(), &GroupPermissions::new(),);
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
         assert!(!conversation.recipients().contains(&did_b));
@@ -1335,7 +1335,7 @@ mod test {
         assert_eq!(id_b, id_c);
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), GroupPermissions::new(),);
+        assert_eq!(conversation.permissions(), &GroupPermissions::new(),);
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));
@@ -1490,7 +1490,7 @@ mod test {
         assert_eq!(id_b, id_c);
 
         let conversation = instance_a.get_conversation(id_a).await?;
-        assert_eq!(conversation.permissions(), GroupPermissions::new(),);
+        assert_eq!(conversation.permissions(), &GroupPermissions::new(),);
         assert_eq!(conversation.recipients().len(), 3);
         assert!(conversation.recipients().contains(&did_a));
         assert!(conversation.recipients().contains(&did_b));

--- a/tools/inspect/src/main.rs
+++ b/tools/inspect/src/main.rs
@@ -131,7 +131,7 @@ async fn main() -> anyhow::Result<()> {
     table.set_header(vec!["ID", "Name", "Type", "Recipients", "# of Messages"]);
     for convo in conversations {
         let recipients = instance
-            .get_identity(Identifier::DIDList(convo.recipients()))
+            .get_identity(convo.recipients())
             .map(|id| format!("{}#{}", id.username(), id.short_id()))
             .collect::<Vec<_>>()
             .await;
@@ -140,7 +140,7 @@ async fn main() -> anyhow::Result<()> {
 
         table.add_row(vec![
             convo.id().to_string(),
-            convo.name().unwrap_or_default(),
+            convo.name().map(ToOwned::to_owned).unwrap_or_default(),
             convo.conversation_type().to_string(),
             recipients.join(", "),
             count.to_string(),

--- a/warp/src/multipass/identity.rs
+++ b/warp/src/multipass/identity.rs
@@ -274,20 +274,20 @@ impl Identity {
 }
 
 impl Identity {
-    pub fn username(&self) -> String {
-        self.username.clone()
+    pub fn username(&self) -> &str {
+        &self.username
     }
 
-    pub fn status_message(&self) -> Option<String> {
-        self.status_message.clone()
+    pub fn status_message(&self) -> Option<&str> {
+        self.status_message.as_deref()
     }
 
     pub fn short_id(&self) -> ShortId {
         self.short_id
     }
 
-    pub fn did_key(&self) -> DID {
-        self.did_key.clone()
+    pub fn did_key(&self) -> &DID {
+        &self.did_key
     }
 
     pub fn created(&self) -> DateTime<Utc> {

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -657,12 +657,12 @@ impl Conversation {
         self.id
     }
 
-    pub fn name(&self) -> Option<String> {
-        self.name.clone()
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
     }
 
-    pub fn creator(&self) -> Option<DID> {
-        self.creator.clone()
+    pub fn creator(&self) -> Option<&DID> {
+        self.creator.as_ref()
     }
 
     pub fn created(&self) -> DateTime<Utc> {
@@ -681,12 +681,12 @@ impl Conversation {
         self.conversation_type
     }
 
-    pub fn permissions(&self) -> GroupPermissions {
-        self.permissions.clone()
+    pub fn permissions(&self) -> &GroupPermissions {
+        &self.permissions
     }
 
-    pub fn recipients(&self) -> Vec<DID> {
-        self.recipients.clone()
+    pub fn recipients(&self) -> &[DID] {
+        &self.recipients
     }
 
     pub fn description(&self) -> Option<&str> {
@@ -817,8 +817,8 @@ impl MessageReference {
         self.conversation_id
     }
 
-    pub fn sender(&self) -> DID {
-        self.sender.clone()
+    pub fn sender(&self) -> &DID {
+        &self.sender
     }
 
     pub fn date(&self) -> DateTime<Utc> {
@@ -975,8 +975,8 @@ impl Message {
         self.conversation_id
     }
 
-    pub fn sender(&self) -> DID {
-        self.sender.clone()
+    pub fn sender(&self) -> &DID {
+        &self.sender
     }
 
     pub fn date(&self) -> DateTime<Utc> {
@@ -991,24 +991,24 @@ impl Message {
         self.pinned
     }
 
-    pub fn reactions(&self) -> IndexMap<String, Vec<DID>> {
-        self.reactions.clone()
+    pub fn reactions(&self) -> &IndexMap<String, Vec<DID>> {
+        &self.reactions
     }
 
     pub fn mentions(&self) -> &[DID] {
         &self.mentions
     }
 
-    pub fn lines(&self) -> Vec<String> {
-        self.lines.clone()
+    pub fn lines(&self) -> &[String] {
+        &self.lines
     }
 
-    pub fn attachments(&self) -> Vec<File> {
-        self.attachment.clone()
+    pub fn attachments(&self) -> &[File] {
+        &self.attachment
     }
 
-    pub fn metadata(&self) -> IndexMap<String, String> {
-        self.metadata.clone()
+    pub fn metadata(&self) -> &IndexMap<String, String> {
+        &self.metadata
     }
 
     pub fn replied(&self) -> Option<Uuid> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- provide a reference from structs where possible

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This would reduce needless cloning in `Identity`, and other structs, thus reducing allocation where possible
- May still require cloning the data where the content needs to be owned.
