### PR TITLE
chore: add boilerplate for community messaging methods

### DIFF
--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -1989,24 +1989,201 @@ impl RayGunCommunity for WarpIpfs {
             .revoke_community_channel_permission_for_all(community_id, channel_id, permission)
             .await
     }
+
+    async fn get_community_channel_message(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+    ) -> Result<Message, Error> {
+        self.messaging_store()?
+            .get_community_channel_message(community_id, channel_id, message_id)
+            .await
+    }
+    async fn get_community_channel_messages(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        options: MessageOptions,
+    ) -> Result<Messages, Error> {
+        self.messaging_store()?
+            .get_community_channel_messages(community_id, channel_id, options)
+            .await
+    }
+    async fn get_community_channel_message_count(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+    ) -> Result<usize, Error> {
+        self.messaging_store()?
+            .get_community_channel_message_count(community_id, channel_id)
+            .await
+    }
+    async fn get_community_channel_message_reference(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+    ) -> Result<MessageReference, Error> {
+        self.messaging_store()?
+            .get_community_channel_message_reference(community_id, channel_id, message_id)
+            .await
+    }
+    async fn get_community_channel_message_references(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        options: MessageOptions,
+    ) -> Result<BoxStream<'static, MessageReference>, Error> {
+        self.messaging_store()?
+            .get_community_channel_message_references(community_id, channel_id, options)
+            .await
+    }
+    async fn community_channel_message_status(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+    ) -> Result<MessageStatus, Error> {
+        self.messaging_store()?
+            .community_channel_message_status(community_id, channel_id, message_id)
+            .await
+    }
     async fn send_community_channel_message(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        message: &str,
-    ) -> Result<(), Error> {
+        message: Vec<String>,
+    ) -> Result<Uuid, Error> {
         self.messaging_store()?
             .send_community_channel_message(community_id, channel_id, message)
+            .await
+    }
+    async fn edit_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        message: Vec<String>,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .edit_community_channel_message(community_id, channel_id, message_id, message)
+            .await
+    }
+    async fn reply_to_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        message: Vec<String>,
+    ) -> Result<Uuid, Error> {
+        self.messaging_store()?
+            .reply_to_community_channel_message(community_id, channel_id, message_id, message)
             .await
     }
     async fn delete_community_channel_message(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        message_id: Uuid,
+        message_id: Option<Uuid>,
     ) -> Result<(), Error> {
         self.messaging_store()?
             .delete_community_channel_message(community_id, channel_id, message_id)
+            .await
+    }
+    async fn pin_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        state: PinState,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .pin_community_channel_message(community_id, channel_id, message_id, state)
+            .await
+    }
+    async fn react_to_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        state: ReactionState,
+        emoji: String,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .react_to_community_channel_message(community_id, channel_id, message_id, state, emoji)
+            .await
+    }
+    async fn send_community_channel_messsage_event(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        event: MessageEvent,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .send_community_channel_messsage_event(community_id, channel_id, event)
+            .await
+    }
+    async fn cancel_community_channel_messsage_event(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        event: MessageEvent,
+    ) -> Result<(), Error> {
+        self.messaging_store()?
+            .cancel_community_channel_messsage_event(community_id, channel_id, event)
+            .await
+    }
+    async fn attach_to_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Option<Uuid>,
+        locations: Vec<Location>,
+        message: Vec<String>,
+    ) -> Result<(Uuid, AttachmentEventStream), Error> {
+        self.messaging_store()?
+            .attach_to_community_channel_message(
+                community_id,
+                channel_id,
+                message_id,
+                locations,
+                message,
+            )
+            .await
+    }
+    async fn download_from_community_channel_message(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        file: String,
+        path: PathBuf,
+    ) -> Result<ConstellationProgressStream, Error> {
+        self.messaging_store()?
+            .download_from_community_channel_message(
+                community_id,
+                channel_id,
+                message_id,
+                file,
+                path,
+            )
+            .await
+    }
+    async fn download_stream_from_community_channel_message(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        file: &str,
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
+        self.messaging_store()?
+            .download_stream_from_community_channel_message(
+                community_id,
+                channel_id,
+                message_id,
+                file,
+            )
             .await
     }
 }

--- a/warp/src/raygun/community.rs
+++ b/warp/src/raygun/community.rs
@@ -1,12 +1,20 @@
+use std::path::PathBuf;
+
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
 use indexmap::{IndexMap, IndexSet};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::constellation::ConstellationProgressStream;
 use crate::crypto::DID;
 use crate::raygun::{Error, Location};
 
-use super::{ConversationImage, MessageEventStream};
+use super::{
+    AttachmentEventStream, ConversationImage, Message, MessageEvent, MessageEventStream,
+    MessageOptions, MessageReference, MessageStatus, Messages, PinState, ReactionState,
+};
 
 pub type RoleId = Uuid;
 pub type CommunityRoles = IndexMap<RoleId, CommunityRole>;
@@ -522,20 +530,182 @@ pub trait RayGunCommunity: Sync + Send {
     ) -> Result<(), Error> {
         Err(Error::Unimplemented)
     }
+
+    /// Retrieve all messages from a conversation
+    async fn get_community_channel_message(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+    ) -> Result<Message, Error> {
+        Err(Error::Unimplemented)
+    }
+    /// Retrieve all messages from a conversation
+    async fn get_community_channel_messages(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _options: MessageOptions,
+    ) -> Result<Messages, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Get a number of messages in a conversation
+    async fn get_community_channel_message_count(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+    ) -> Result<usize, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Retrieve a message reference from a conversation
+    async fn get_community_channel_message_reference(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+    ) -> Result<MessageReference, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Retrieve all message references from a conversation
+    async fn get_community_channel_message_references(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _options: MessageOptions,
+    ) -> Result<BoxStream<'static, MessageReference>, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Get a status of a message in a conversation
+    async fn community_channel_message_status(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+    ) -> Result<MessageStatus, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Sends a message to a conversation.
     async fn send_community_channel_message(
         &mut self,
         _community_id: Uuid,
         _channel_id: Uuid,
-        _message: &str,
-    ) -> Result<(), Error> {
+        _message: Vec<String>,
+    ) -> Result<Uuid, Error> {
         Err(Error::Unimplemented)
     }
-    async fn delete_community_channel_message(
+
+    /// Edit an existing message in a conversation.
+    async fn edit_community_channel_message(
         &mut self,
         _community_id: Uuid,
         _channel_id: Uuid,
         _message_id: Uuid,
+        _message: Vec<String>,
     ) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Reply to a message within a conversation
+    async fn reply_to_community_channel_message(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+        _message: Vec<String>,
+    ) -> Result<Uuid, Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Delete message from a conversation
+    async fn delete_community_channel_message(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Option<Uuid>,
+    ) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Pin a message within a conversation
+    async fn pin_community_channel_message(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+        _state: PinState,
+    ) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// React to a message
+    async fn react_to_community_channel_message(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+        _state: ReactionState,
+        _emoji: String,
+    ) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Send an event to a conversation
+    async fn send_community_channel_messsage_event(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _event: MessageEvent,
+    ) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+
+    /// Cancel event that was sent, if any.
+    async fn cancel_community_channel_messsage_event(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _event: MessageEvent,
+    ) -> Result<(), Error> {
+        Err(Error::Unimplemented)
+    }
+    /// Send files to a conversation.
+    /// If no files is provided in the array, it will throw an error
+    async fn attach_to_community_channel_message(
+        &mut self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Option<Uuid>,
+        _locations: Vec<Location>,
+        _message: Vec<String>,
+    ) -> Result<(Uuid, AttachmentEventStream), Error> {
+        Err(Error::Unimplemented)
+    }
+    /// Downloads a file that been attached to a message
+    /// Note: Must use the filename associated when downloading
+    async fn download_from_community_channel_message(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+        _file: String,
+        _path: PathBuf,
+    ) -> Result<ConstellationProgressStream, Error> {
+        Err(Error::Unimplemented)
+    }
+    /// Stream a file that been attached to a message
+    /// Note: Must use the filename associated when downloading
+    async fn download_stream_from_community_channel_message(
+        &self,
+        _community_id: Uuid,
+        _channel_id: Uuid,
+        _message_id: Uuid,
+        _file: &str,
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
         Err(Error::Unimplemented)
     }
 }

--- a/warp/src/warp.rs
+++ b/warp/src/warp.rs
@@ -875,24 +875,201 @@ where
             .revoke_community_channel_permission_for_all(community_id, channel_id, permission)
             .await
     }
+
+    async fn get_community_channel_message(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+    ) -> Result<Message, Error> {
+        self.raygun
+            .get_community_channel_message(community_id, channel_id, message_id)
+            .await
+    }
+    async fn get_community_channel_messages(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        options: MessageOptions,
+    ) -> Result<Messages, Error> {
+        self.raygun
+            .get_community_channel_messages(community_id, channel_id, options)
+            .await
+    }
+    async fn get_community_channel_message_count(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+    ) -> Result<usize, Error> {
+        self.raygun
+            .get_community_channel_message_count(community_id, channel_id)
+            .await
+    }
+    async fn get_community_channel_message_reference(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+    ) -> Result<MessageReference, Error> {
+        self.raygun
+            .get_community_channel_message_reference(community_id, channel_id, message_id)
+            .await
+    }
+    async fn get_community_channel_message_references(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        options: MessageOptions,
+    ) -> Result<BoxStream<'static, MessageReference>, Error> {
+        self.raygun
+            .get_community_channel_message_references(community_id, channel_id, options)
+            .await
+    }
+    async fn community_channel_message_status(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+    ) -> Result<MessageStatus, Error> {
+        self.raygun
+            .community_channel_message_status(community_id, channel_id, message_id)
+            .await
+    }
     async fn send_community_channel_message(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        message: &str,
-    ) -> Result<(), Error> {
+        message: Vec<String>,
+    ) -> Result<Uuid, Error> {
         self.raygun
             .send_community_channel_message(community_id, channel_id, message)
+            .await
+    }
+    async fn edit_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        message: Vec<String>,
+    ) -> Result<(), Error> {
+        self.raygun
+            .edit_community_channel_message(community_id, channel_id, message_id, message)
+            .await
+    }
+    async fn reply_to_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        message: Vec<String>,
+    ) -> Result<Uuid, Error> {
+        self.raygun
+            .reply_to_community_channel_message(community_id, channel_id, message_id, message)
             .await
     }
     async fn delete_community_channel_message(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        message_id: Uuid,
+        message_id: Option<Uuid>,
     ) -> Result<(), Error> {
         self.raygun
             .delete_community_channel_message(community_id, channel_id, message_id)
+            .await
+    }
+    async fn pin_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        state: PinState,
+    ) -> Result<(), Error> {
+        self.raygun
+            .pin_community_channel_message(community_id, channel_id, message_id, state)
+            .await
+    }
+    async fn react_to_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        state: ReactionState,
+        emoji: String,
+    ) -> Result<(), Error> {
+        self.raygun
+            .react_to_community_channel_message(community_id, channel_id, message_id, state, emoji)
+            .await
+    }
+    async fn send_community_channel_messsage_event(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        event: MessageEvent,
+    ) -> Result<(), Error> {
+        self.raygun
+            .send_community_channel_messsage_event(community_id, channel_id, event)
+            .await
+    }
+    async fn cancel_community_channel_messsage_event(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        event: MessageEvent,
+    ) -> Result<(), Error> {
+        self.raygun
+            .cancel_community_channel_messsage_event(community_id, channel_id, event)
+            .await
+    }
+    async fn attach_to_community_channel_message(
+        &mut self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Option<Uuid>,
+        locations: Vec<Location>,
+        message: Vec<String>,
+    ) -> Result<(Uuid, AttachmentEventStream), Error> {
+        self.raygun
+            .attach_to_community_channel_message(
+                community_id,
+                channel_id,
+                message_id,
+                locations,
+                message,
+            )
+            .await
+    }
+    async fn download_from_community_channel_message(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        file: String,
+        path: PathBuf,
+    ) -> Result<ConstellationProgressStream, Error> {
+        self.raygun
+            .download_from_community_channel_message(
+                community_id,
+                channel_id,
+                message_id,
+                file,
+                path,
+            )
+            .await
+    }
+    async fn download_stream_from_community_channel_message(
+        &self,
+        community_id: Uuid,
+        channel_id: Uuid,
+        message_id: Uuid,
+        file: &str,
+    ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Error> {
+        self.raygun
+            .download_stream_from_community_channel_message(
+                community_id,
+                channel_id,
+                message_id,
+                file,
+            )
             .await
     }
 }


### PR DESCRIPTION
**What this PR does** 📖

Adds all the boilerplate for the community messaging methods. Implementations to follow in multiple subsequent PRs. This should keep those PRs smaller and make them easier to review.

The methods are:

- get_community_channel_message
- get_community_channel_messages
- get_community_channel_message_count
- get_community_channel_message_reference
- get_community_channel_message_references
- community_channel_message_status
- send_community_channel_message
- edit_community_channel_message
- reply_to_community_channel_message
- delete_community_channel_message
- pin_community_channel_message
- react_to_community_channel_message
- send_community_channel_messsage_event
- cancel_community_channel_messsage_event
- attach_to_community_channel_message
- download_from_community_channel_message
- download_stream_from_community_channel_message

