### PR TITLE
feat: String based permission nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ tracing = { version = "0.1" }
 either = "1"
 void = "1"
 indexmap = { version = "2.4.0", features = ["serde"] }
+enum_macro = { path = "./tools/enum_macro" }
 
 # ipfs dependency
 rust-ipfs = "0.12.2"

--- a/extensions/warp-ipfs/src/lib.rs
+++ b/extensions/warp-ipfs/src/lib.rs
@@ -23,9 +23,7 @@ use std::time::Duration;
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::{Instrument, Span};
 use uuid::Uuid;
-use warp::raygun::community::{
-    CommunityChannelPermission, CommunityPermission, CommunityRole, RoleId,
-};
+use warp::raygun::community::{CommunityRole, RoleId};
 
 use crate::config::{Bootstrap, DiscoveryType};
 use crate::rt::{Executor, LocalExecutor};
@@ -1879,42 +1877,54 @@ impl RayGunCommunity for WarpIpfs {
             .edit_community_description(community_id, description)
             .await
     }
-    async fn grant_community_permission(
+    async fn grant_community_permission<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .grant_community_permission(community_id, permission, role_id)
+            .grant_community_permission(community_id, permission.to_string(), role_id)
             .await
     }
-    async fn revoke_community_permission(
+    async fn revoke_community_permission<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .revoke_community_permission(community_id, permission, role_id)
+            .revoke_community_permission(community_id, permission.to_string(), role_id)
             .await
     }
-    async fn grant_community_permission_for_all(
+    async fn grant_community_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .grant_community_permission_for_all(community_id, permission)
+            .grant_community_permission_for_all(community_id, permission.to_string())
             .await
     }
-    async fn revoke_community_permission_for_all(
+    async fn revoke_community_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .revoke_community_permission_for_all(community_id, permission)
+            .revoke_community_permission_for_all(community_id, permission.to_string())
             .await
     }
     async fn remove_community_member(
@@ -1947,46 +1957,76 @@ impl RayGunCommunity for WarpIpfs {
             .edit_community_channel_description(community_id, channel_id, description)
             .await
     }
-    async fn grant_community_channel_permission(
+    async fn grant_community_channel_permission<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .grant_community_channel_permission(community_id, channel_id, permission, role_id)
+            .grant_community_channel_permission(
+                community_id,
+                channel_id,
+                permission.to_string(),
+                role_id,
+            )
             .await
     }
-    async fn revoke_community_channel_permission(
+    async fn revoke_community_channel_permission<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .revoke_community_channel_permission(community_id, channel_id, permission, role_id)
+            .revoke_community_channel_permission(
+                community_id,
+                channel_id,
+                permission.to_string(),
+                role_id,
+            )
             .await
     }
-    async fn grant_community_channel_permission_for_all(
+    async fn grant_community_channel_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .grant_community_channel_permission_for_all(community_id, channel_id, permission)
+            .grant_community_channel_permission_for_all(
+                community_id,
+                channel_id,
+                permission.to_string(),
+            )
             .await
     }
-    async fn revoke_community_channel_permission_for_all(
+    async fn revoke_community_channel_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.messaging_store()?
-            .revoke_community_channel_permission_for_all(community_id, channel_id, permission)
+            .revoke_community_channel_permission_for_all(
+                community_id,
+                channel_id,
+                permission.to_string(),
+            )
             .await
     }
 

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -55,8 +55,7 @@ use crate::rt::{AbortableJoinHandle, Executor, LocalExecutor};
 use crate::store::community::CommunityDocument;
 use chrono::{DateTime, Utc};
 use warp::raygun::community::{
-    Community, CommunityChannel, CommunityChannelPermission, CommunityChannelType, CommunityInvite,
-    CommunityPermission, CommunityRole, RoleId,
+    Community, CommunityChannel, CommunityChannelType, CommunityInvite, CommunityRole, RoleId,
 };
 use warp::raygun::{ConversationImage, GroupPermissionOpt, Message};
 use warp::{
@@ -1371,7 +1370,7 @@ impl MessageStore {
     pub async fn grant_community_permission(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
         role_id: RoleId,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
@@ -1394,7 +1393,7 @@ impl MessageStore {
     pub async fn revoke_community_permission(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
         role_id: RoleId,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
@@ -1417,7 +1416,7 @@ impl MessageStore {
     pub async fn grant_community_permission_for_all(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
         let community_meta = inner
@@ -1438,7 +1437,7 @@ impl MessageStore {
     pub async fn revoke_community_permission_for_all(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
         let community_meta = inner
@@ -1528,7 +1527,7 @@ impl MessageStore {
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
         role_id: RoleId,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
@@ -1553,7 +1552,7 @@ impl MessageStore {
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
         role_id: RoleId,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
@@ -1578,7 +1577,7 @@ impl MessageStore {
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
         let community_meta = inner
@@ -1603,7 +1602,7 @@ impl MessageStore {
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
     ) -> Result<(), Error> {
         let inner = &*self.inner.read().await;
         let community_meta = inner

--- a/extensions/warp-ipfs/src/store/mod.rs
+++ b/extensions/warp-ipfs/src/store/mod.rs
@@ -30,10 +30,7 @@ use warp::{
     },
     error::Error,
     multipass::identity::IdentityStatus,
-    raygun::{
-        community::{CommunityChannelPermission, CommunityPermission, RoleId},
-        GroupPermissions, MessageEvent, PinState, ReactionState,
-    },
+    raygun::{community::RoleId, GroupPermissions, MessageEvent, PinState, ReactionState},
 };
 
 use conversation::{message::MessageDocument, ConversationDocument};
@@ -504,18 +501,18 @@ pub enum CommunityUpdateKind {
         description: Option<String>,
     },
     GrantCommunityPermission {
-        permission: CommunityPermission,
+        permission: String,
         role_id: RoleId,
     },
     RevokeCommunityPermission {
-        permission: CommunityPermission,
+        permission: String,
         role_id: RoleId,
     },
     GrantCommunityPermissionForAll {
-        permission: CommunityPermission,
+        permission: String,
     },
     RevokeCommunityPermissionForAll {
-        permission: CommunityPermission,
+        permission: String,
     },
     RemoveCommunityMember {
         member: DID,
@@ -530,21 +527,21 @@ pub enum CommunityUpdateKind {
     },
     GrantCommunityChannelPermission {
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
         role_id: RoleId,
     },
     RevokeCommunityChannelPermission {
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
         role_id: RoleId,
     },
     GrantCommunityChannelPermissionForAll {
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
     },
     RevokeCommunityChannelPermissionForAll {
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
     },
 }
 

--- a/extensions/warp-ipfs/tests/community.rs
+++ b/extensions/warp-ipfs/tests/community.rs
@@ -1558,7 +1558,7 @@ mod test {
         let community = instance_a.get_community(community.id()).await?;
         assert!(community
             .permissions()
-            .get(&CommunityPermission::EditName)
+            .get(&CommunityPermission::EditName.to_string())
             .unwrap()
             .contains(&role.id()));
         Ok(())
@@ -2107,7 +2107,7 @@ mod test {
             .await?;
         assert!(channel
             .permissions()
-            .get(&CommunityChannelPermission::ViewChannel)
+            .get(&CommunityChannelPermission::ViewChannel.to_string())
             .is_none());
         Ok(())
     }

--- a/tools/enum_macro/Cargo.toml
+++ b/tools/enum_macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "enum_macro"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+syn = { version = "2.0.87", features = ["derive"] }
+quote = "1.0.37"
+proc-macro2 = "1.0.89"
+
+[lib]
+proc-macro = true

--- a/tools/enum_macro/src/lib.rs
+++ b/tools/enum_macro/src/lib.rs
@@ -1,0 +1,116 @@
+extern crate proc_macro2;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput};
+
+///
+/// Implements Display for enum values with formatting and snake_case conversion
+/// This is used for CommunityPermissions
+/// E.g.
+/// ```rust
+/// #[derive(EnumFormatting)]
+/// pub enum SomeEnum {
+///     #[permission(formatting="prefix.{}")]
+///     SomeValue1,
+///     SomeValue2
+/// }
+///
+/// assert_eq!(SomeEnum::SomeValue1.to_string(), "prefix.some_value_1")
+/// assert_eq!(SomeEnum::SomeValue2.to_string(), "some_value_2")
+/// ```
+#[proc_macro_derive(EnumFormatting, attributes(permission))]
+pub fn permission_node(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    if let Data::Enum(enum_data) = &input.data {
+        let mut variants = vec![];
+        for variant in &enum_data.variants {
+            let mut format = None;
+            if let Some(attr) = variant
+                .attrs
+                .iter()
+                .find(|attr| attr.path().is_ident("permission"))
+            {
+                if let syn::Meta::List(l) = &attr.meta {
+                    if let Err(err) = l.parse_nested_meta(|meta| {
+                        if meta.path.is_ident("formatting") {
+                            let exp: syn::Expr = meta.value()?.parse()?;
+                            if let syn::Expr::Lit(v) = exp {
+                                if let syn::Lit::Str(s) = v.lit {
+                                    format = Some(s.value());
+                                }
+                            }
+                            return Ok(());
+                        }
+                        Err(meta.error("Unrecognized attribute"))
+                    }) {
+                        panic!("{:?}", err);
+                    }
+                }
+            }
+            let format = format.unwrap_or("{}".into());
+
+            let variant_name = &variant.ident;
+
+            variants.push(quote! {
+                #name::#variant_name => {
+                    let mut snake = String::new();
+                    for (i, ch) in stringify!(#variant_name).char_indices() {
+                        if i > 0 && ch.is_uppercase() {
+                            snake.push('_');
+                        }
+                        snake.push(ch.to_ascii_lowercase());
+                    }
+                    format!(#format, snake)
+                },
+            });
+        }
+
+        let expanded = quote! {
+            impl std::fmt::Display for #name {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    let result = match self {
+                        #(#variants)*
+                    };
+                    f.write_str(&format!("{}", result))
+                }
+            }
+        };
+
+        TokenStream::from(expanded)
+    } else {
+        panic!("Only Enums are supported");
+    }
+}
+
+///
+/// Implements #values() for enum values that returns all defined values in the enum
+/// E.g.
+/// ```rust
+/// #[derive(EnumValues, PartialEq)]
+/// pub enum SomeEnum {
+///     SomeValue1,
+///     SomeValue2
+/// }
+///
+/// assert_eq!([SomeEnum::SomeValue1, SomeEnum::SomeValue2], SomeEnum::values())
+/// ```
+#[proc_macro_derive(EnumValues)]
+pub fn enum_values(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+    if let Data::Enum(enum_data) = input.data {
+        let variants: Vec<_> = enum_data.variants.into_iter().map(|v| v.ident).collect();
+        let expanded = quote! {
+            impl #name {
+                pub fn values() -> &'static[#name] {
+                    &[ #(#name::#variants),* ]
+                }
+            }
+        };
+        TokenStream::from(expanded)
+    } else {
+        panic!("Only Enums are supported");
+    }
+}

--- a/tools/enum_macro/src/lib.rs
+++ b/tools/enum_macro/src/lib.rs
@@ -4,11 +4,11 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, Data, DeriveInput};
 
-///
 /// Implements Display for enum values with formatting and snake_case conversion
 /// This is used for CommunityPermissions
 /// E.g.
-/// ```rust
+/// ```
+/// use enum_macro::EnumFormatting;
 /// #[derive(EnumFormatting)]
 /// pub enum SomeEnum {
 ///     #[permission(formatting="prefix.{}")]
@@ -16,8 +16,8 @@ use syn::{parse_macro_input, Data, DeriveInput};
 ///     SomeValue2
 /// }
 ///
-/// assert_eq!(SomeEnum::SomeValue1.to_string(), "prefix.some_value_1")
-/// assert_eq!(SomeEnum::SomeValue2.to_string(), "some_value_2")
+/// assert_eq!(SomeEnum::SomeValue1.to_string(), "prefix.some_value1");
+/// assert_eq!(SomeEnum::SomeValue2.to_string(), "some_value2");
 /// ```
 #[proc_macro_derive(EnumFormatting, attributes(permission))]
 pub fn permission_node(input: TokenStream) -> TokenStream {
@@ -84,17 +84,17 @@ pub fn permission_node(input: TokenStream) -> TokenStream {
     }
 }
 
-///
 /// Implements #values() for enum values that returns all defined values in the enum
 /// E.g.
-/// ```rust
-/// #[derive(EnumValues, PartialEq)]
+/// ```
+/// use enum_macro::EnumValues;
+/// #[derive(EnumValues, PartialEq, Debug)]
 /// pub enum SomeEnum {
 ///     SomeValue1,
 ///     SomeValue2
 /// }
 ///
-/// assert_eq!([SomeEnum::SomeValue1, SomeEnum::SomeValue2], SomeEnum::values())
+/// assert_eq!([SomeEnum::SomeValue1, SomeEnum::SomeValue2], SomeEnum::values());
 /// ```
 #[proc_macro_derive(EnumValues)]
 pub fn enum_values(input: TokenStream) -> TokenStream {

--- a/warp/Cargo.toml
+++ b/warp/Cargo.toml
@@ -60,6 +60,7 @@ tracing = { workspace = true }
 mediatype.workspace = true
 send_wrapper.workspace = true
 indexmap.workspace = true
+enum_macro.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true }

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -8,10 +8,7 @@ use crate::error::Error;
 use crate::raygun::community::RayGunCommunity;
 use crate::{Extension, SingleHandle};
 
-use community::{
-    CommunityChannel, CommunityChannelPermission, CommunityInvite, CommunityPermission,
-    CommunityRole, RoleId,
-};
+use community::{CommunityChannel, CommunityInvite, CommunityRole, RoleId};
 use derive_more::Display;
 use futures::stream::BoxStream;
 
@@ -190,21 +187,21 @@ pub enum MessageEventKind {
     },
     GrantedCommunityPermission {
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
         role_id: RoleId,
     },
     RevokedCommunityPermission {
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
         role_id: RoleId,
     },
     GrantedCommunityPermissionForAll {
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
     },
     RevokedCommunityPermissionForAll {
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: String,
     },
     RemovedCommunityMember {
         community_id: Uuid,
@@ -223,24 +220,24 @@ pub enum MessageEventKind {
     GrantedCommunityChannelPermission {
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
         role_id: RoleId,
     },
     RevokedCommunityChannelPermission {
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
         role_id: RoleId,
     },
     GrantedCommunityChannelPermissionForAll {
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
     },
     RevokedCommunityChannelPermissionForAll {
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: String,
     },
 }
 

--- a/warp/src/warp.rs
+++ b/warp/src/warp.rs
@@ -15,9 +15,7 @@ use crate::multipass::{
     Friends, GetIdentity, IdentityImportOption, IdentityInformation, ImportLocation, LocalIdentity,
     MultiPass, MultiPassEvent, MultiPassEventStream, MultiPassImportExport,
 };
-use crate::raygun::community::{
-    CommunityChannelPermission, CommunityPermission, CommunityRole, RoleId,
-};
+use crate::raygun::community::{CommunityRole, RoleId};
 use crate::raygun::{
     community::{
         Community, CommunityChannel, CommunityChannelType, CommunityInvite, RayGunCommunity,
@@ -765,40 +763,52 @@ where
             .edit_community_description(community_id, description)
             .await
     }
-    async fn grant_community_permission(
+    async fn grant_community_permission<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .grant_community_permission(community_id, permission, role_id)
             .await
     }
-    async fn revoke_community_permission(
+    async fn revoke_community_permission<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .revoke_community_permission(community_id, permission, role_id)
             .await
     }
-    async fn grant_community_permission_for_all(
+    async fn grant_community_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .grant_community_permission_for_all(community_id, permission)
             .await
     }
-    async fn revoke_community_permission_for_all(
+    async fn revoke_community_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
-        permission: CommunityPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .revoke_community_permission_for_all(community_id, permission)
             .await
@@ -833,44 +843,56 @@ where
             .edit_community_channel_description(community_id, channel_id, description)
             .await
     }
-    async fn grant_community_channel_permission(
+    async fn grant_community_channel_permission<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .grant_community_channel_permission(community_id, channel_id, permission, role_id)
             .await
     }
-    async fn revoke_community_channel_permission(
+    async fn revoke_community_channel_permission<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
+        permission: T,
         role_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .revoke_community_channel_permission(community_id, channel_id, permission, role_id)
             .await
     }
-    async fn grant_community_channel_permission_for_all(
+    async fn grant_community_channel_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .grant_community_channel_permission_for_all(community_id, channel_id, permission)
             .await
     }
-    async fn revoke_community_channel_permission_for_all(
+    async fn revoke_community_channel_permission_for_all<T>(
         &mut self,
         community_id: Uuid,
         channel_id: Uuid,
-        permission: CommunityChannelPermission,
-    ) -> Result<(), Error> {
+        permission: T,
+    ) -> Result<(), Error>
+    where
+        T: ToString + Send,
+    {
         self.raygun
             .revoke_community_channel_permission_for_all(community_id, channel_id, permission)
             .await


### PR DESCRIPTION
**What this PR does** 📖

Rewrites the community permission system to use string based permissions instead of enums. String based permission have the form `some.permission` and have the advantage that they easily expandable and also allows hierarchy checking.

A permission `some.permission` will check under the hood if the user has the node
`some.permission` and `some` with the deeper one taking priority. If `some.permission` is defined it will use that permission. Otherwise it will check `some`.

The builtin permissions are still in an enum to allow ease of usage. The API to check a permission accepts anything that is representable as a String.


