### PR TITLE
chore: replace CancellationToken with AbortableJoinHandle

### DIFF
--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -29,7 +29,6 @@ use ipld_core::cid::Cid;
 use rust_ipfs::{Ipfs, PeerId};
 
 use serde::{Deserialize, Serialize};
-use tokio_util::sync::{CancellationToken, DropGuard};
 use uuid::Uuid;
 
 use super::{document::root::RootDocumentMap, ds_key::DataStoreKey, PeerIdExt};
@@ -79,7 +78,7 @@ pub type DownloadStream = BoxStream<'static, Result<Bytes, std::io::Error>>;
 #[derive(Clone)]
 pub struct MessageStore {
     inner: Arc<tokio::sync::RwLock<ConversationInner>>,
-    _task_cancellation: Arc<DropGuard>,
+    _handle: AbortableJoinHandle<()>,
 }
 
 impl MessageStore {
@@ -93,9 +92,6 @@ impl MessageStore {
     ) -> Self {
         let executor = LocalExecutor;
         tracing::info!("Initializing MessageStore");
-
-        let token = CancellationToken::new();
-        let drop_guard = token.clone().drop_guard();
 
         let root = identity.root_document().clone();
 
@@ -127,19 +123,9 @@ impl MessageStore {
             identity: identity.clone(),
         };
 
-        executor.dispatch({
-            async move {
-                tokio::select! {
-                    _ = token.cancelled() => {}
-                    _ = task.run() => {}
-                }
-            }
-        });
+        let _handle = executor.spawn_abortable(task.run());
 
-        Self {
-            inner,
-            _task_cancellation: Arc::new(drop_guard),
-        }
+        Self { inner, _handle }
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- replace CancellationToken with AbortableJoinHandle to allow task to abort when dropped.

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
