### PR TITLE
fix: filter out and skip message if empty within attachment

### DIFF
--- a/extensions/warp-ipfs/src/store/message/attachment.rs
+++ b/extensions/warp-ipfs/src/store/message/attachment.rs
@@ -84,10 +84,6 @@ impl AttachmentStream {
     }
 
     pub fn set_lines(mut self, lines: Vec<String>) -> Result<Self, Error> {
-        if lines.is_empty() {
-            return Ok(self);
-        }
-
         let lines_value_length: usize = lines
             .iter()
             .filter(|s| !s.is_empty())
@@ -95,18 +91,8 @@ impl AttachmentStream {
             .map(|s| s.chars().count())
             .sum();
 
-        if lines_value_length < MIN_MESSAGE_SIZE {
-            tracing::error!(
-                current_size = lines_value_length,
-                min = MIN_MESSAGE_SIZE,
-                "length of message is invalid"
-            );
-            return Err(Error::InvalidLength {
-                context: "message".into(),
-                current: lines_value_length,
-                minimum: None,
-                maximum: Some(MIN_MESSAGE_SIZE),
-            });
+        if lines.is_empty() || lines_value_length < MIN_MESSAGE_SIZE {
+            return Ok(self);
         }
 
         if lines_value_length > MAX_MESSAGE_SIZE {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- filter out and ignore message in an attachment if its empty instead of returning an error.

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
