### PR TITLE
feat: Add recipients to PayloadMessage

### DIFF
--- a/extensions/warp-ipfs/src/shuttle/server.rs
+++ b/extensions/warp-ipfs/src/shuttle/server.rs
@@ -11,8 +11,6 @@ use rust_ipfs::{
 use std::{path::Path, time::Duration};
 use warp::error::{Error as WarpError, Error};
 
-use crate::rt::{AbortableJoinHandle, Executor, LocalExecutor};
-use crate::store::topics::IDENTITY_ANNOUNCEMENT;
 // use crate::shuttle::identity::protocol::RegisterError;
 use super::{
     identity::{
@@ -28,6 +26,8 @@ use super::{
     },
     subscription_stream::Subscriptions,
 };
+use crate::rt::{AbortableJoinHandle, Executor, LocalExecutor};
+use crate::store::topics::IDENTITY_ANNOUNCEMENT;
 use crate::store::{
     document::identity::IdentityDocument,
     payload::{PayloadBuilder, PayloadMessage},
@@ -285,7 +285,9 @@ impl ShuttleTask {
                         continue;
                     }
 
-                    let document = payload.message();
+                    let Ok(document) = payload.message(None) else {
+                        continue;
+                    };
 
                     if document.verify().is_err() {
                         continue;
@@ -338,7 +340,27 @@ impl ShuttleTask {
 
             tracing::info!(%sender_peer_id, "Processing Incoming Request");
             let sender = payload.sender();
-            match payload.message() {
+
+            let message = match payload.message(None) {
+                Ok(message) => message,
+                Err(_e) => {
+                    tracing::warn!(%sender, error = %_e, "could not parse payload");
+                    let payload = payload_message_construct(
+                        keypair,
+                        None,
+                        MessageResponse::Error("public key is invalid".into()),
+                    )
+                    .expect("Valid payload construction");
+
+                    let bytes = payload.to_bytes().expect("valid deserialization");
+                    _ = ipfs
+                        .send_response(sender_peer_id, id, (protocols::SHUTTLE_IDENTITY, bytes))
+                        .await;
+                    return;
+                }
+            };
+
+            match message {
                 identity::protocol::Request::Register(Register::IsRegistered) => {
                     let peer_id = payload.sender();
                     let Ok(did) = peer_id.to_did() else {
@@ -391,8 +413,6 @@ impl ShuttleTask {
                         .await;
                 }
                 identity::protocol::Request::Register(Register::RegisterIdentity { root_cid }) => {
-                    let root_cid = *root_cid;
-
                     tracing::debug!(%sender, %root_cid, "preloading root document");
                     if let Err(e) = ipfs.fetch(&root_cid).recursive().await {
                         tracing::warn!(%sender, %root_cid, error = %e, "unable to preload root document");
@@ -604,7 +624,7 @@ impl ShuttleTask {
                                 .await;
                         }
                         identity::protocol::Mailbox::Send { did: to, request } => {
-                            if !identity_storage.contains(to).await {
+                            if !identity_storage.contains(&to).await {
                                 tracing::warn!(%did, "Identity is not registered");
                                 let payload = payload_message_construct(
                                     keypair,
@@ -654,7 +674,7 @@ impl ShuttleTask {
                                 return;
                             }
 
-                            if let Err(e) = identity_storage.deliver_request(to, request).await {
+                            if let Err(e) = identity_storage.deliver_request(&to, &request).await {
                                 match e {
                                     WarpError::InvalidSignature => {
                                         tracing::warn!(%did, to = %to, "request could not be vertified");
@@ -751,7 +771,7 @@ impl ShuttleTask {
 
                     let keypair = ipfs.keypair();
                     tracing::debug!(%did, %package, "preloading root document");
-                    if let Err(e) = ipfs.fetch(package).recursive().await {
+                    if let Err(e) = ipfs.fetch(&package).recursive().await {
                         tracing::warn!(%did, %package, error = %e, "unable to preload root document");
                         return;
                     }
@@ -768,7 +788,7 @@ impl ShuttleTask {
                         }
                     };
 
-                    let path = IpfsPath::from(*package)
+                    let path = IpfsPath::from(package)
                         .sub_path("identity")
                         .expect("valid path");
 
@@ -786,7 +806,7 @@ impl ShuttleTask {
                     };
 
                     tracing::debug!(%did, %package, "root document preloaded");
-                    if let Err(e) = identity_storage.update_user_document(&did, *package).await {
+                    if let Err(e) = identity_storage.update_user_document(&did, package).await {
                         tracing::warn!(%did, %package, error = %e, "unable to store document");
                         return;
                     }
@@ -957,7 +977,26 @@ impl ShuttleTask {
             };
 
             tracing::info!(%peer_id, %did, "Processing Incoming Message Request");
-            match payload.message() {
+            let message = match payload.message(None) {
+                Ok(message) => message,
+                Err(_e) => {
+                    tracing::warn!(%peer_id, error = %_e, "could not parse payload");
+                    let payload = message::protocol::payload_message_construct(
+                        keypair,
+                        None,
+                        MessageResponse::Error("public key is invalid".into()),
+                    )
+                    .expect("Valid payload construction");
+
+                    let bytes = payload.to_bytes().expect("valid deserialization");
+                    _ = ipfs
+                        .send_response(sender_peer_id, id, (protocols::SHUTTLE_MESSAGE, bytes))
+                        .await;
+                    return;
+                }
+            };
+
+            match message {
                 message::protocol::Request::RegisterConversation(RegisterConversation {
                     ..
                 }) => todo!(),
@@ -968,11 +1007,6 @@ impl ShuttleTask {
                         recipients,
                         message_cid,
                     } => {
-                        let conversation_id = *conversation_id;
-                        let message_id = *message_id;
-                        let recipients = recipients.to_owned();
-                        let message_cid = *message_cid;
-
                         tracing::info!(%conversation_id, %message_id, %did, "inserting message into mailbox");
                         if let Err(e) = message_storage
                             .insert_or_update(
@@ -993,9 +1027,6 @@ impl ShuttleTask {
                         conversation_id,
                         message_id,
                     } => {
-                        let conversation_id = *conversation_id;
-                        let message_id = *message_id;
-
                         tracing::info!(%conversation_id, %message_id, %did, "marking message as delivered");
                         if let Err(e) = message_storage
                             .message_delivered(&did, conversation_id, message_id)
@@ -1010,9 +1041,6 @@ impl ShuttleTask {
                         conversation_id,
                         message_id,
                     } => {
-                        let conversation_id = *conversation_id;
-                        let message_id = *message_id;
-
                         tracing::info!(%conversation_id, %message_id, %did, "removing message from mailbox");
                         if let Err(e) = message_storage
                             .remove_message(&did, conversation_id, message_id)
@@ -1026,11 +1054,11 @@ impl ShuttleTask {
                 },
                 message::protocol::Request::FetchMailBox { conversation_id } => {
                     let message = match message_storage
-                        .get_unsent_messages(did, *conversation_id)
+                        .get_unsent_messages(did, conversation_id)
                         .await
                     {
                         Ok(content) => message::protocol::Response::Mailbox {
-                            conversation_id: *conversation_id,
+                            conversation_id,
                             content,
                         },
                         Err(e) => message::protocol::Response::Error(e.to_string()),

--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -749,7 +749,7 @@ impl IdentityStore {
                         from,
                         date: req.date(),
                     })
-                        .await;
+                    .await;
                 }
 
                 let payload =
@@ -774,7 +774,7 @@ impl IdentityStore {
                 self.emit_event(MultiPassEventKind::OutgoingFriendRequestRejected {
                     did: data.sender,
                 })
-                    .await;
+                .await;
             }
             Event::Remove => {
                 if self.is_friend(&data.sender).await? {
@@ -797,7 +797,7 @@ impl IdentityStore {
                 self.emit_event(MultiPassEventKind::IncomingFriendRequestClosed {
                     did: data.sender,
                 })
-                    .await;
+                .await;
             }
             Event::Block => {
                 let sender = data.sender;
@@ -806,12 +806,12 @@ impl IdentityStore {
                     self.emit_event(MultiPassEventKind::IncomingFriendRequestClosed {
                         did: sender.clone(),
                     })
-                        .await;
+                    .await;
                 } else if self.sent_friend_request_to(&sender).await? {
                     self.emit_event(MultiPassEventKind::OutgoingFriendRequestRejected {
                         did: sender.clone(),
                     })
-                        .await;
+                    .await;
                 }
 
                 let list = self.list_all_raw_request().await?;
@@ -868,7 +868,7 @@ impl IdentityStore {
         Ok(())
     }
 
-    async fn push_iter<I: IntoIterator<Item=DID>>(&self, list: I) {
+    async fn push_iter<I: IntoIterator<Item = DID>>(&self, list: I) {
         for did in list {
             if let Err(e) = self.push(&did).await {
                 tracing::error!("Error pushing identity to {did}: {e}");
@@ -1250,7 +1250,7 @@ impl IdentityStore {
                             self.emit_event(MultiPassEventKind::IdentityUpdate {
                                 did: document.did.clone(),
                             })
-                                .await;
+                            .await;
 
                             if !exclude_images {
                                 if document.metadata.arb_data != identity.metadata.arb_data
@@ -1541,7 +1541,7 @@ impl IdentityStore {
                                 ty,
                                 Some(MAX_IMAGE_SIZE),
                             )
-                                .await?;
+                            .await?;
 
                             debug_assert_eq!(added_cid, cid);
                             store
@@ -1747,7 +1747,7 @@ impl IdentityStore {
                     crate::shuttle::identity::protocol::Synchronized::Fetch,
                 ),
             )
-                .build()?;
+            .build()?;
 
             let bytes = payload.to_bytes().expect("valid deserialization");
 
@@ -1809,7 +1809,7 @@ impl IdentityStore {
                     crate::shuttle::identity::protocol::Synchronized::Store { package },
                 ),
             )
-                .build()?;
+            .build()?;
 
             let bytes = payload.to_bytes().expect("valid deserialization");
 
@@ -1865,7 +1865,7 @@ impl IdentityStore {
                     crate::shuttle::identity::protocol::Register::IsRegistered,
                 ),
             )
-                .build()?;
+            .build()?;
 
             let bytes = payload.to_bytes().expect("valid deserialization");
 
@@ -1925,7 +1925,7 @@ impl IdentityStore {
                     crate::shuttle::identity::protocol::Register::RegisterIdentity { root_cid },
                 ),
             )
-                .build()?;
+            .build()?;
 
             let bytes = payload.to_bytes().expect("valid deserialization");
 
@@ -1982,7 +1982,7 @@ impl IdentityStore {
                     crate::shuttle::identity::protocol::Mailbox::FetchAll,
                 ),
             )
-                .build()?;
+            .build()?;
 
             let bytes = payload.to_bytes().expect("valid deserialization");
 
@@ -2063,7 +2063,7 @@ impl IdentityStore {
                     },
                 ),
             )
-                .build()?;
+            .build()?;
 
             let bytes = payload.to_bytes().expect("valid deserialization");
 
@@ -2694,7 +2694,7 @@ impl IdentityStore {
                 self.emit_event(MultiPassEventKind::OutgoingFriendRequestClosed {
                     did: pubkey.clone(),
                 })
-                    .await;
+                .await;
 
                 return Ok(());
             }
@@ -2835,7 +2835,7 @@ impl IdentityStore {
         self.emit_event(MultiPassEventKind::FriendAdded {
             did: pubkey.clone(),
         })
-            .await;
+        .await;
 
         let _ = self.announce_identity_to_mesh().await;
 
@@ -2867,7 +2867,7 @@ impl IdentityStore {
         self.emit_event(MultiPassEventKind::FriendRemoved {
             did: pubkey.clone(),
         })
-            .await;
+        .await;
 
         Ok(())
     }
@@ -2990,12 +2990,12 @@ impl IdentityStore {
         let start = Instant::now();
         if !peers.contains(&remote_peer_id)
             || (peers.contains(&remote_peer_id)
-            && self
-            .ipfs
-            .pubsub_publish(recipient.inbox(), message_bytes)
-            .await
-            .is_err())
-            && queue_broadcast
+                && self
+                    .ipfs
+                    .pubsub_publish(recipient.inbox(), message_bytes)
+                    .await
+                    .is_err())
+                && queue_broadcast
         {
             self.queue.insert(recipient, payload.clone()).await;
             queued = true;
@@ -3030,19 +3030,19 @@ impl IdentityStore {
                     to: recipient.clone(),
                     date: outgoing_request_date.expect("date is valid"),
                 })
-                    .await;
+                .await;
             }
             Event::Retract => {
                 self.emit_event(MultiPassEventKind::OutgoingFriendRequestClosed {
                     did: recipient.clone(),
                 })
-                    .await;
+                .await;
             }
             Event::Reject => {
                 self.emit_event(MultiPassEventKind::IncomingFriendRequestRejected {
                     did: recipient.clone(),
                 })
-                    .await;
+                .await;
             }
             Event::Block => {
                 let _ = self.push(recipient).await;
@@ -3050,7 +3050,7 @@ impl IdentityStore {
                 self.emit_event(MultiPassEventKind::Blocked {
                     did: recipient.clone(),
                 })
-                    .await;
+                .await;
             }
             Event::Unblock => {
                 let _ = self.push(recipient).await;
@@ -3059,7 +3059,7 @@ impl IdentityStore {
                 self.emit_event(MultiPassEventKind::Unblocked {
                     did: recipient.clone(),
                 })
-                    .await;
+                .await;
             }
             _ => {}
         };

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -2069,7 +2069,14 @@ impl ConversationTask {
                         }
                     };
 
-                    let data = match ecdh_decrypt(self.identity.root_document().keypair(), Some(&sender), payload.message()) {
+                    let msg = match payload.message(None) {
+                        Ok(m) => m,
+                        Err(_) => {
+                            continue
+                        }
+                    };
+
+                    let data = match ecdh_decrypt(self.identity.root_document().keypair(), Some(&sender), msg) {
                         Ok(d) => d,
                         Err(e) => {
                             tracing::warn!(%sender, error = %e, "failed to decrypt message");
@@ -2271,7 +2278,7 @@ impl ConversationInner {
             tracing::warn!(conversation_id = %convo_id, "Unable to publish to topic. Queuing event");
             self.queue_event(
                 did.clone(),
-                Queue::direct(peer_id, did.messaging(), payload.message().to_vec()),
+                Queue::direct(peer_id, did.messaging(), payload.message(None)?.to_vec()),
             )
             .await;
         }
@@ -2383,7 +2390,7 @@ impl ConversationInner {
                 tracing::warn!("Unable to publish to topic. Queuing event");
                 self.queue_event(
                     did.clone(),
-                    Queue::direct(peer_id, did.messaging(), payload.message().to_vec()),
+                    Queue::direct(peer_id, did.messaging(), payload.message(None)?.to_vec()),
                 )
                 .await;
             }
@@ -2616,7 +2623,7 @@ impl ConversationInner {
             tracing::warn!(%conversation_id, "Unable to publish to topic");
             self.queue_event(
                 did.clone(),
-                Queue::direct(peer_id, topic.clone(), payload.message().to_vec()),
+                Queue::direct(peer_id, topic.clone(), payload.message(None)?.to_vec()),
             )
             .await;
         }
@@ -2662,7 +2669,7 @@ impl ConversationInner {
             tracing::warn!(%community_id, "Unable to publish to topic");
             self.queue_event(
                 did.clone(),
-                Queue::direct(peer_id, topic.clone(), payload.message().to_vec()),
+                Queue::direct(peer_id, topic.clone(), payload.message(None)?.to_vec()),
             )
             .await;
         }
@@ -2752,7 +2759,7 @@ impl ConversationInner {
                             Queue::direct(
                                 peer_id,
                                 recipient.messaging(),
-                                payload.message().to_vec(),
+                                payload.message(None)?.to_vec(),
                             ),
                         )
                         .await;
@@ -2848,7 +2855,11 @@ impl ConversationInner {
             tracing::warn!(%conversation_id, "Unable to publish to topic. Queuing event");
             self.queue_event(
                 did_key.clone(),
-                Queue::direct(peer_id, did_key.messaging(), payload.message().to_vec()),
+                Queue::direct(
+                    peer_id,
+                    did_key.messaging(),
+                    payload.message(None)?.to_vec(),
+                ),
             )
             .await;
             time = false;
@@ -3004,7 +3015,11 @@ impl ConversationInner {
                 //      For now we will queue the message if we hit an error
                 self.queue_event(
                     recipient.clone(),
-                    Queue::direct(peer_id, recipient.messaging(), payload.message().to_vec()),
+                    Queue::direct(
+                        peer_id,
+                        recipient.messaging(),
+                        payload.message(None)?.to_vec(),
+                    ),
                 )
                 .await;
                 time = false;

--- a/extensions/warp-ipfs/src/store/message/community_task.rs
+++ b/extensions/warp-ipfs/src/store/message/community_task.rs
@@ -1210,7 +1210,7 @@ impl CommunityTask {
                     None,
                     peer_id,
                     did_key.messaging(),
-                    payload.message().to_vec(),
+                    payload.message(None)?.to_vec(),
                 ),
             )
             .await;
@@ -1248,7 +1248,7 @@ impl CommunityTask {
                     self.pending_key_exchange
                         .entry(sender)
                         .or_default()
-                        .push((data.message().to_vec(), false));
+                        .push((data.message(None)?, false));
 
                     // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
                     // but for now we can leave this commented until the queue is removed and refactored.
@@ -1263,7 +1263,7 @@ impl CommunityTask {
                 }
             };
 
-            Cipher::direct_decrypt(data.message(), &key)?
+            Cipher::direct_decrypt(&data.message(None)?, &key)?
         };
 
         let event = serde_json::from_slice::<CommunityMessagingEvents>(&bytes).map_err(|e| {
@@ -1321,7 +1321,12 @@ impl CommunityTask {
             tracing::warn!(id = %self.community_id, "Unable to publish to topic");
             self.queue_event(
                 did.clone(),
-                QueueItem::direct(None, peer_id, topic.clone(), payload.message().to_vec()),
+                QueueItem::direct(
+                    None,
+                    peer_id,
+                    topic.clone(),
+                    payload.message(None)?.to_vec(),
+                ),
             )
             .await;
         }
@@ -3700,7 +3705,7 @@ impl CommunityTask {
                                 message_id,
                                 peer_id,
                                 self.document.topic(),
-                                payload.message().to_vec(),
+                                payload.message(None)?.to_vec(),
                             ),
                         )
                         .await;
@@ -4521,7 +4526,7 @@ async fn process_request_response_event(
 
     let sender = payload.sender().to_did()?;
 
-    let data = ecdh_decrypt(keypair, Some(&sender), payload.message())?;
+    let data = ecdh_decrypt(keypair, Some(&sender), payload.message(None)?)?;
 
     let event = serde_json::from_slice::<ConversationRequestResponse>(&data)?;
 
@@ -4591,7 +4596,12 @@ async fn process_request_response_event(
                     // TODO
                     this.queue_event(
                         sender.clone(),
-                        QueueItem::direct(None, peer_id, topic.clone(), payload.message().to_vec()),
+                        QueueItem::direct(
+                            None,
+                            peer_id,
+                            topic.clone(),
+                            payload.message(None)?.to_vec(),
+                        ),
                     )
                     .await;
                 }
@@ -4686,7 +4696,7 @@ async fn process_community_event(this: &mut CommunityTask, message: Message) -> 
 
     let key = this.community_key(Some(&sender))?;
 
-    let data = Cipher::direct_decrypt(payload.message(), &key)?;
+    let data = Cipher::direct_decrypt(&payload.message(None)?, &key)?;
 
     let event = match serde_json::from_slice::<CommunityMessagingEvents>(&data)? {
         event @ CommunityMessagingEvents::Event { .. } => event,

--- a/extensions/warp-ipfs/src/store/payload.rs
+++ b/extensions/warp-ipfs/src/store/payload.rs
@@ -181,6 +181,7 @@ where
 }
 
 impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
+    /// Creates a new payload
     pub fn new(
         keypair: &Keypair,
         cosigner: Option<&Keypair>,
@@ -264,12 +265,14 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
         Ok(payload)
     }
 
+    /// Returns the payload by deserializing the bytes of data, which is in cbor format.
     pub fn from_bytes(data: &[u8]) -> Result<Self, Error> {
         let payload: Self = cbor4ii::serde::from_slice(data).map_err(std::io::Error::other)?;
         payload.verify()?;
         Ok(payload)
     }
 
+    /// Returns a serialized bytes of the payload in cbor format
     pub fn to_bytes(&self) -> Result<Bytes, Error> {
         cbor4ii::serde::to_vec(Vec::new(), self)
             .map_err(std::io::Error::other)
@@ -277,6 +280,7 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
             .map(Bytes::from)
     }
 
+    /// Verify the message of the payload
     #[inline]
     pub fn verify(&self) -> Result<(), Error> {
         self.verify_original()?;
@@ -354,6 +358,7 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
         Ok(())
     }
 
+    /// Returns the original message from the payload. If the message is encrypted, a Keypair will need to be supplied
     pub fn message<'a, K: Into<Option<&'a Keypair>>>(&self, keypair: K) -> Result<M, Error> {
         self.verify()?;
 
@@ -388,26 +393,32 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
 }
 
 impl<M> PayloadMessage<M> {
+    /// Sender of the message. If the message is cosigned, it will used the cosigner PeerId,
+    /// otherwise the original sender PeerId
     #[inline]
     pub fn sender(&self) -> &PeerId {
         self.on_behalf.as_ref().unwrap_or(&self.sender)
     }
 
+    /// Original sender of the message
     #[inline]
     pub fn original_sender(&self) -> &PeerId {
         &self.sender
     }
 
+    /// Cosigner of the message, if any.
     #[inline]
     pub fn cosigner(&self) -> Option<&PeerId> {
         self.on_behalf.as_ref()
     }
 
+    /// Date of when the message was created and signed.
     #[inline]
     pub fn date(&self) -> DateTime<Utc> {
         self.date
     }
 
+    /// Addresses of the sender for content discovery
     #[inline]
     pub fn addresses(&self) -> &[Multiaddr] {
         &self.addresses

--- a/extensions/warp-ipfs/src/store/payload.rs
+++ b/extensions/warp-ipfs/src/store/payload.rs
@@ -77,11 +77,15 @@ impl<'a, M: Serialize + DeserializeOwned + Clone> PayloadBuilder<'a, M> {
         }
     }
 
+    /// Keypair of the cosigner. This will be used for the primary keypair which would be separate from the network
+    /// keypair from Ipfs, which would cosign the payload and act as the original sender
     pub fn cosign(mut self, keypair: &'a Keypair) -> Self {
         self.cosigner_keypair = Some(keypair);
         self
     }
 
+    /// Add address for reachability of the node for content discovery and establishing connections
+    /// if needed
     pub fn add_address(mut self, mut address: Multiaddr) -> Self {
         if address.is_empty() || self.addresses.len() > 32 {
             // we will only permit 32 address slot for content discovery
@@ -104,12 +108,15 @@ impl<'a, M: Serialize + DeserializeOwned + Clone> PayloadBuilder<'a, M> {
         self
     }
 
+    /// Add a recipient to the message, which would ensure that the message is decrypted for the intended
+    /// parties involved in the message.
     pub fn add_recipient(mut self, recipient: impl DidExt) -> Result<Self, Error> {
         let recipient = recipient.to_peer_id()?;
         self.recipients.insert(recipient);
         Ok(self)
     }
 
+    /// Provide an array of recipients.
     pub fn add_recipients<R: DidExt>(
         mut self,
         recipients: impl IntoIterator<Item = R>,
@@ -120,6 +127,7 @@ impl<'a, M: Serialize + DeserializeOwned + Clone> PayloadBuilder<'a, M> {
         Ok(self)
     }
 
+    /// Set custom encryption key.
     pub fn set_key(mut self, key: impl Into<Bytes>) -> Self {
         let key = key.into();
         self.key = Some(key);
@@ -134,11 +142,14 @@ impl<'a, M: Serialize + DeserializeOwned + Clone> PayloadBuilder<'a, M> {
         self
     }
 
+    /// Provide an Ipfs instance to obtain the external address of the local node
+    /// for reachability.
     pub fn from_ipfs(mut self, ipfs: &'a Ipfs) -> Self {
         self.ipfs.replace(ipfs);
         self
     }
 
+    /// Construct and build a `PayloadMessage`
     pub fn build(self) -> Result<PayloadMessage<M>, Error> {
         PayloadMessage::new(
             self.keypair,

--- a/extensions/warp-ipfs/src/store/payload.rs
+++ b/extensions/warp-ipfs/src/store/payload.rs
@@ -25,6 +25,7 @@ pub struct PayloadMessage<M> {
     date: DateTime<Utc>,
 
     /// bytes of the message serialized as cbor
+    #[serde(flatten)]
     message: PayloadSelectMessage<M>,
 
     /// recipients of the payload message, if any.
@@ -44,7 +45,7 @@ pub struct PayloadMessage<M> {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
-#[serde(rename_all = "lowercase")]
+#[serde(untagged)]
 enum PayloadSelectMessage<M> {
     Clear { message: M },
     Encrypted { bytes: Bytes },

--- a/extensions/warp-ipfs/src/store/payload.rs
+++ b/extensions/warp-ipfs/src/store/payload.rs
@@ -331,7 +331,7 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
     }
 
     pub fn message<'a, K: Into<Option<&'a Keypair>>>(&self, keypair: K) -> Result<M, Error> {
-        // self.verify()?;
+        self.verify()?;
 
         match &self.message {
             PayloadSelectMessage::Clear { message } => Ok(message.clone()),

--- a/extensions/warp-ipfs/src/store/payload.rs
+++ b/extensions/warp-ipfs/src/store/payload.rs
@@ -352,7 +352,7 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
 
                 let raw_key = ecdh_decrypt(keypair, Some(&sender_did), encrypted_key)?;
 
-                let message_bytes = Cipher::direct_decrypt(&message, &raw_key)?;
+                let message_bytes = Cipher::direct_decrypt(message, &raw_key)?;
 
                 let message =
                     cbor4ii::serde::from_slice(&message_bytes).map_err(std::io::Error::other)?;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add recipients to PayloadMessage, which would internally trigger the method to encrypt the message itself.
- Change `PayloadMessage::message` to accept an optional keypair, which would attempt to retrieve the corresponding key and decrypt the message if it is intended for the recipient. 
- Add a function to add a pre-generated encryption key. If one is not supplied, a random key will be created.

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Previously, this container would only contain the message of what was sent, however there may be times where this payload may be intended for specific peers. The original way would be to encrypt the message and send the bytes as apart of the message of the payload, however we lose out on the type long term since it would only be arb bytes (eg `Vec<u8>`). To get around this, we would retain the type as apart of `PayloadMessage`, but instead of storing the message directly apart of the payload, it would either be stored directly or as bytes if encrypted. When calling `PayloadMessage::message`, we can supply an optional key pair, in which would attempt to decrypt the message if it is encrypted, otherwise it would provide a copy of the message if it is not encrypted.
- In a separate PR, we can begin to use the intended types directly in the payload instead of encrypting them and providing the bytes.