### PR TITLE
refactor: use specific types on `PayloadMessage` and send for intended recipient(s)

### DIFF
--- a/extensions/warp-ipfs/src/store/identity.rs
+++ b/extensions/warp-ipfs/src/store/identity.rs
@@ -41,7 +41,7 @@ use super::{
         cache::IdentityCache, identity::IdentityDocument, image_dag::get_image,
         root::RootDocumentMap, ResolvedRootDocument, RootDocument,
     },
-    ecdh_decrypt, ecdh_encrypt,
+    ecdh_encrypt,
     event_subscription::EventSubscription,
     payload::PayloadMessage,
     phonebook::PhoneBook,
@@ -530,12 +530,18 @@ impl IdentityStore {
 
                             tracing::info!("Received event from {in_did}");
 
-                            let event = match ecdh_decrypt(store.root_document().keypair(), Some(&in_did), &message.data).and_then(|bytes| {
-                                serde_json::from_slice::<IdentityEvent>(&bytes).map_err(Error::from)
-                            }) {
-                                Ok(e) => e,
+                            let payload: PayloadMessage<IdentityEvent> = match PayloadMessage::from_bytes(&message.data) {
+                                Ok(p) => p,
                                 Err(e) => {
-                                   tracing::error!("Failed to decrypt payload from {in_did}: {e}");
+                                    tracing::error!(error = %e, from = %in_did, "failed to process payload");
+                                    continue;
+                                }
+                            };
+
+                            let event = match payload.message(store.root_document().keypair()) {
+                                Ok(event) => event,
+                                Err(e) => {
+                                    tracing::error!("Failed to decrypt payload from {in_did}: {e}");
                                     continue;
                                 }
                             };
@@ -545,11 +551,9 @@ impl IdentityStore {
                             if let Err(e) = store.process_message(&in_did, event, false).await {
                                tracing::error!("Failed to process identity message from {in_did}: {e}");
                             }
-
-
                         }
                         Some(event) = friend_stream.next() => {
-                            let payload = match PayloadMessage::<Vec<u8>>::from_bytes(&event.data) {
+                            let payload = match PayloadMessage::<RequestResponsePayload>::from_bytes(&event.data) {
                                 Ok(p) => p,
                                 Err(_e) => {
                                     continue;
@@ -568,17 +572,8 @@ impl IdentityStore {
 
                             tracing::info!("Received event from {did}");
 
-                            let msg = match payload.message(None) {
+                            let data = match payload.message(store.root_document.keypair()) {
                                 Ok(m) => m,
-                                Err(_) => {
-                                    continue;
-                                }
-                            };
-
-                            let data = match ecdh_decrypt(store.root_document().keypair(), Some(&did), msg).and_then(|bytes| {
-                                serde_json::from_slice::<RequestResponsePayload>(&bytes).map_err(Error::from)
-                            }) {
-                                Ok(pl) => pl,
                                 Err(e) => {
                                     if let Some(tx) = signal {
                                         let _ = tx.send(Err(e));
@@ -920,9 +915,11 @@ impl IdentityStore {
 
         let event = IdentityEvent::Request { option };
 
-        let payload_bytes = serde_json::to_vec(&event)?;
+        let payload = PayloadBuilder::new(pk_did, event.clone())
+            .add_recipient(out_did)?
+            .await?;
 
-        let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
+        let bytes = payload.to_bytes()?;
 
         tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
@@ -949,8 +946,6 @@ impl IdentityStore {
         if !self.ipfs.is_connected(out_peer_id).await? {
             return Err(Error::IdentityDoesntExist);
         }
-
-        let pk_did = self.root_document.keypair();
 
         let mut identity = self.own_identity_document().await?;
 
@@ -980,9 +975,11 @@ impl IdentityStore {
             option: ResponseOption::Identity { identity: payload },
         };
 
-        let payload_bytes = serde_json::to_vec(&event)?;
+        let payload = PayloadBuilder::new(kp_did, event.clone())
+            .add_recipient(out_did)?
+            .await?;
 
-        let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
+        let bytes = payload.to_bytes()?;
 
         tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
@@ -1035,9 +1032,11 @@ impl IdentityStore {
             },
         };
 
-        let payload_bytes = serde_json::to_vec(&event)?;
+        let payload = PayloadBuilder::new(pk_did, event.clone())
+            .add_recipient(out_did)?
+            .await?;
 
-        let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
+        let bytes = payload.to_bytes()?;
 
         tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
@@ -1112,9 +1111,11 @@ impl IdentityStore {
             option: ResponseOption::Metadata { data: metadata },
         };
 
-        let payload_bytes = serde_json::to_vec(&event)?;
+        let payload = PayloadBuilder::new(pk_did, event.clone())
+            .add_recipient(out_did)?
+            .await?;
 
-        let bytes = ecdh_encrypt(pk_did, Some(out_did), payload_bytes)?;
+        let bytes = payload.to_bytes()?;
 
         tracing::info!(to = %out_did, event = ?event, payload_size = bytes.len(), "Sending event");
 
@@ -2960,10 +2961,10 @@ impl IdentityStore {
 
         let kp = self.root_document.keypair();
 
-        let payload_bytes = serde_json::to_vec(&payload)?;
-
-        let bytes = ecdh_encrypt(kp, Some(recipient), payload_bytes)?;
-        let message = PayloadBuilder::new(kp, bytes).build()?;
+        let message = PayloadBuilder::new(kp, payload.clone())
+            .add_recipient(recipient)?
+            .from_ipfs(&self.ipfs)
+            .await?;
 
         let message_bytes = message.to_bytes()?;
 

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -35,7 +35,7 @@ use super::{document::root::RootDocumentMap, ds_key::DataStoreKey, PeerIdExt};
 use crate::store::{
     conversation::ConversationDocument,
     discovery::Discovery,
-    ecdh_decrypt, ecdh_encrypt,
+    ecdh_encrypt,
     event_subscription::EventSubscription,
     files::FileStore,
     generate_shared_topic,
@@ -2053,7 +2053,7 @@ impl ConversationTask {
                     }
                 }
                 Some(message) = stream.next() => {
-                    let payload = match PayloadMessage::<Vec<u8>>::from_bytes(&message.data) {
+                    let payload = match PayloadMessage::<ConversationEvents>::from_bytes(&message.data) {
                         Ok(payload) => payload,
                         Err(e) => {
                             tracing::warn!("Failed to parse payload data: {e}");
@@ -2061,38 +2061,25 @@ impl ConversationTask {
                         }
                     };
 
-                    let sender = match payload.sender().to_did() {
+                    let sender_peer_id = payload.sender();
+
+                    let sender = match sender_peer_id.to_did() {
                         Ok(did) => did,
                         Err(e) => {
-                            tracing::warn!(sender = %payload.sender(), error = %e, "unable to convert to did");
+                            tracing::warn!(sender = %sender_peer_id, error = %e, "unable to convert to did");
                             continue;
                         }
                     };
 
-                    let msg = match payload.message(None) {
+                    let event = match payload.message(self.identity.root_document().keypair()) {
                         Ok(m) => m,
-                        Err(_) => {
+                        Err(e) => {
+                            tracing::error!(%sender, error = %e, "unable to obtain message from payload");
                             continue
                         }
                     };
 
-                    let data = match ecdh_decrypt(self.identity.root_document().keypair(), Some(&sender), msg) {
-                        Ok(d) => d,
-                        Err(e) => {
-                            tracing::warn!(%sender, error = %e, "failed to decrypt message");
-                            continue;
-                        }
-                    };
-
-                    let events = match serde_json::from_slice::<ConversationEvents>(&data) {
-                        Ok(ev) => ev,
-                        Err(e) => {
-                            tracing::warn!(%sender, error = %e, "failed to parse message");
-                            continue;
-                        }
-                    };
-
-                    if let Err(e) = process_conversation(&mut *self.inner.write().await, payload, events).await {
+                    if let Err(e) = process_conversation(&mut *self.inner.write().await, *sender_peer_id, event).await {
                         tracing::error!(%sender, error = %e, "error processing conversation");
                     }
                 }
@@ -2244,12 +2231,12 @@ impl ConversationInner {
         //     return Err(Error::ConversationLimitReached);
         // }
 
-        let conversation =
+        let mut conversation =
             ConversationDocument::new_direct(self.root.keypair(), [own_did.clone(), did.clone()])?;
 
         let convo_id = conversation.id();
 
-        self.set_document(conversation.clone()).await?;
+        self.set_document(&mut conversation).await?;
 
         self.create_conversation_task(convo_id).await?;
 
@@ -2259,11 +2246,12 @@ impl ConversationInner {
             recipient: own_did.clone(),
         };
 
-        let bytes = ecdh_encrypt(self.root.keypair(), Some(did), serde_json::to_vec(&event)?)?;
-
-        let payload = PayloadBuilder::new(self.root.keypair(), bytes)
+        let payload = PayloadBuilder::new(self.root.keypair(), event)
+            .add_recipient(did)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let payload_bytes = payload.to_bytes()?;
 
         let peers = self.ipfs.pubsub_peers(Some(did.messaging())).await?;
 
@@ -2271,14 +2259,14 @@ impl ConversationInner {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(did.messaging(), payload.to_bytes()?)
+                    .pubsub_publish(did.messaging(), payload_bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(conversation_id = %convo_id, "Unable to publish to topic. Queuing event");
             self.queue_event(
                 did.clone(),
-                Queue::direct(peer_id, did.messaging(), payload.message(None)?.to_vec()),
+                Queue::direct(peer_id, did.messaging(), payload_bytes.to_vec()),
             )
             .await;
         }
@@ -2367,30 +2355,31 @@ impl ConversationInner {
             .filter_map(|(a, b)| b.to_peer_id().map(|pk| (a, pk)).ok())
             .collect::<Vec<_>>();
 
-        let event = serde_json::to_vec(&ConversationEvents::NewGroupConversation {
+        let event = ConversationEvents::NewGroupConversation {
             conversation: conversation.clone(),
-        })?;
+        };
+
+        let payload = PayloadBuilder::new(self.root.keypair(), event)
+            .add_recipients(peer_id_list.iter().map(|(did, _)| did))?
+            .from_ipfs(&self.ipfs)
+            .await?;
+
+        let payload_bytes = payload.to_bytes()?;
 
         for (did, peer_id) in peer_id_list {
-            let bytes = ecdh_encrypt(self.root.keypair(), Some(&did), &event)?;
-
-            let payload = PayloadBuilder::new(self.root.keypair(), bytes)
-                .from_ipfs(&self.ipfs)
-                .await?;
-
             let peers = self.ipfs.pubsub_peers(Some(did.messaging())).await?;
             if !peers.contains(&peer_id)
                 || (peers.contains(&peer_id)
                     && self
                         .ipfs
-                        .pubsub_publish(did.messaging(), payload.to_bytes()?)
+                        .pubsub_publish(did.messaging(), payload_bytes.clone())
                         .await
                         .is_err())
             {
                 tracing::warn!("Unable to publish to topic. Queuing event");
                 self.queue_event(
                     did.clone(),
-                    Queue::direct(peer_id, did.messaging(), payload.message(None)?.to_vec()),
+                    Queue::direct(peer_id, did.messaging(), payload_bytes.to_vec()),
                 )
                 .await;
             }
@@ -2602,11 +2591,12 @@ impl ConversationInner {
 
         let keypair = self.root.keypair();
 
-        let bytes = ecdh_encrypt(keypair, Some(did), serde_json::to_vec(&request)?)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, request)
+            .add_recipient(did)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let payload_bytes = payload.to_bytes()?;
 
         let topic = conversation.exchange_topic(did);
 
@@ -2616,14 +2606,14 @@ impl ConversationInner {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(topic.clone(), payload.to_bytes()?)
+                    .pubsub_publish(topic.clone(), payload_bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(%conversation_id, "Unable to publish to topic");
             self.queue_event(
                 did.clone(),
-                Queue::direct(peer_id, topic.clone(), payload.message(None)?.to_vec()),
+                Queue::direct(peer_id, topic.clone(), payload_bytes.clone()),
             )
             .await;
         }
@@ -2725,19 +2715,19 @@ impl ConversationInner {
                     .filter_map(|(a, b)| b.to_peer_id().map(|pk| (a, pk)).ok())
                     .collect::<Vec<_>>();
 
-                let event = serde_json::to_vec(&ConversationEvents::DeleteConversation {
+                let event = ConversationEvents::DeleteConversation {
                     conversation_id: document_type.id(),
-                })?;
+                };
+
+                let payload = PayloadBuilder::new(self.root.keypair(), event)
+                    .add_recipients(peer_id_list.iter().map(|(did, _)| did))?
+                    .from_ipfs(&self.ipfs)
+                    .await?;
+
+                let payload_bytes = payload.to_bytes()?;
 
                 let main_timer = Instant::now();
                 for (recipient, peer_id) in peer_id_list {
-                    let keypair = self.root.keypair();
-                    let bytes = ecdh_encrypt(keypair, Some(&recipient), &event)?;
-
-                    let payload = PayloadBuilder::new(keypair, bytes)
-                        .from_ipfs(&self.ipfs)
-                        .await?;
-
                     let peers = self.ipfs.pubsub_peers(Some(recipient.messaging())).await?;
                     let timer = Instant::now();
                     let mut time = true;
@@ -2745,7 +2735,7 @@ impl ConversationInner {
                         || (peers.contains(&peer_id)
                             && self
                                 .ipfs
-                                .pubsub_publish(recipient.messaging(), payload.to_bytes()?)
+                                .pubsub_publish(recipient.messaging(), payload_bytes.clone())
                                 .await
                                 .is_err())
                     {
@@ -2756,11 +2746,7 @@ impl ConversationInner {
                         //      For now we will queue the message if we hit an error
                         self.queue_event(
                             recipient.clone(),
-                            Queue::direct(
-                                peer_id,
-                                recipient.messaging(),
-                                payload.message(None)?.to_vec(),
-                            ),
+                            Queue::direct(peer_id, recipient.messaging(), payload_bytes.clone()),
                         )
                         .await;
                         time = false;
@@ -2829,15 +2815,14 @@ impl ConversationInner {
         did_key: &DID,
         event: ConversationEvents,
     ) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
-
         let keypair = self.root.keypair();
 
-        let bytes = ecdh_encrypt(keypair, Some(did_key), &event)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, event)
+            .add_recipient(did_key)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let payload_bytes = payload.to_bytes()?;
 
         let peer_id = did_key.to_peer_id()?;
         let peers = self.ipfs.pubsub_peers(Some(did_key.messaging())).await?;
@@ -2848,18 +2833,14 @@ impl ConversationInner {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(did_key.messaging(), payload.to_bytes()?)
+                    .pubsub_publish(did_key.messaging(), payload_bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(%conversation_id, "Unable to publish to topic. Queuing event");
             self.queue_event(
                 did_key.clone(),
-                Queue::direct(
-                    peer_id,
-                    did_key.messaging(),
-                    payload.message(None)?.to_vec(),
-                ),
+                Queue::direct(peer_id, did_key.messaging(), payload_bytes.clone()),
             )
             .await;
             time = false;
@@ -3090,7 +3071,7 @@ impl ConversationInner {
 
 async fn process_conversation(
     this: &mut ConversationInner,
-    data: PayloadMessage<Vec<u8>>,
+    sender: PeerId,
     event: ConversationEvents,
 ) -> Result<(), Error> {
     match event {
@@ -3202,7 +3183,7 @@ async fn process_conversation(
                 return Err(anyhow::anyhow!("Conversation {conversation_id} doesnt exist").into());
             }
 
-            let sender = data.sender().to_did()?;
+            let sender = sender.to_did()?;
 
             match this.get(conversation_id).await {
                 Ok(conversation)
@@ -3265,7 +3246,7 @@ async fn process_conversation(
                 return Err(anyhow::anyhow!("Community {community_id} doesnt exist").into());
             }
 
-            let sender = data.sender().to_did()?;
+            let sender = sender.to_did()?;
 
             match this.get_community_document(community_id).await {
                 Ok(community) if community.owner.eq(&sender) => community,
@@ -3460,12 +3441,13 @@ async fn process_identity_events(
 struct Queue {
     peer: PeerId,
     topic: String,
-    data: Vec<u8>,
+    data: Bytes,
     sent: bool,
 }
 
 impl Queue {
-    pub fn direct(peer: PeerId, topic: String, data: Vec<u8>) -> Self {
+    pub fn direct(peer: PeerId, topic: String, data: impl Into<Bytes>) -> Self {
+        let data = data.into();
         Queue {
             peer,
             topic,
@@ -3478,7 +3460,6 @@ impl Queue {
 //TODO: Replace
 async fn _process_queue(this: &mut ConversationInner) {
     let mut changed = false;
-    let keypair = &this.root.keypair().clone();
     for (did, items) in this.queue.iter_mut() {
         let Ok(peer_id) = did.to_peer_id() else {
             continue;
@@ -3511,22 +3492,7 @@ async fn _process_queue(this: &mut ConversationInner) {
                 continue;
             }
 
-            let payload = match PayloadBuilder::<_>::new(keypair, data.clone())
-                .from_ipfs(&this.ipfs)
-                .await
-            {
-                Ok(p) => p,
-                Err(_e) => {
-                    // tracing::warn!(error = %_e, "unable to build payload")
-                    continue;
-                }
-            };
-
-            let Ok(bytes) = payload.to_bytes() else {
-                continue;
-            };
-
-            if let Err(e) = this.ipfs.pubsub_publish(topic.clone(), bytes).await {
+            if let Err(e) = this.ipfs.pubsub_publish(topic.clone(), data.clone()).await {
                 tracing::error!("Error publishing to topic: {e}");
                 continue;
             }

--- a/extensions/warp-ipfs/src/store/message/community_task.rs
+++ b/extensions/warp-ipfs/src/store/message/community_task.rs
@@ -31,11 +31,7 @@ use warp::raygun::{
     MessageReference, MessageStatus, MessageType, Messages, MessagesType, PinState,
     RayGunEventKind, ReactionState,
 };
-use warp::{
-    crypto::{cipher::Cipher, generate},
-    error::Error,
-    raygun::MessageEventKind,
-};
+use warp::{crypto::generate, error::Error, raygun::MessageEventKind};
 use web_time::Instant;
 
 use crate::store::community::{
@@ -326,7 +322,7 @@ pub struct CommunityTask {
     file: FileStore,
     identity: IdentityStore,
     discovery: Discovery,
-    pending_key_exchange: IndexMap<DID, Vec<(Vec<u8>, bool)>>,
+    pending_key_exchange: IndexMap<DID, Vec<(Bytes, bool)>>,
     document: CommunityDocument,
     keystore: Keystore,
 
@@ -1180,15 +1176,14 @@ impl CommunityTask {
         did_key: &DID,
         event: ConversationEvents,
     ) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
-
         let keypair = self.root.keypair();
 
-        let bytes = ecdh_encrypt(keypair, Some(did_key), &event)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, event)
+            .add_recipient(did_key)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let bytes = payload.to_bytes()?;
 
         let peer_id = did_key.to_peer_id()?;
         let peers = self.ipfs.pubsub_peers(Some(did_key.messaging())).await?;
@@ -1199,19 +1194,14 @@ impl CommunityTask {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(did_key.messaging(), payload.to_bytes()?)
+                    .pubsub_publish(did_key.messaging(), bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(id=%&self.community_id, "Unable to publish to topic. Queuing event");
             self.queue_event(
                 did_key.clone(),
-                QueueItem::direct(
-                    None,
-                    peer_id,
-                    did_key.messaging(),
-                    payload.message(None)?.to_vec(),
-                ),
+                QueueItem::direct(None, peer_id, did_key.messaging(), bytes.clone()),
             )
             .await;
             time = false;
@@ -1226,50 +1216,46 @@ impl CommunityTask {
     }
 
     async fn process_msg_event(&mut self, msg: Message) -> Result<(), Error> {
-        let data = PayloadMessage::<Vec<u8>>::from_bytes(&msg.data)?;
+        let data = PayloadMessage::<CommunityMessagingEvents>::from_bytes(&msg.data)?;
         let sender = data.sender().to_did()?;
 
         let keypair = self.root.keypair();
 
         let id = self.community_id;
 
-        let bytes = {
-            let key = match self.keystore.get_latest(keypair, &sender) {
-                Ok(key) => key,
-                Err(Error::PublicKeyDoesntExist) => {
-                    // If we are not able to get the latest key from the store, this is because we are still awaiting on the response from the key exchange
-                    // So what we should so instead is set aside the payload until we receive the key exchange then attempt to process it again
+        let event = match self.keystore.get_latest(keypair, &sender) {
+            Ok(key) => data.message_from_key(&key)?,
+            Err(Error::PublicKeyDoesntExist) => {
+                match data.message(keypair) {
+                    Ok(message) => message,
+                    _ => {
+                        // If we are not able to get the latest key from the store, this is because we are still awaiting on the response from the key exchange
+                        // So what we should so instead is set aside the payload until we receive the key exchange then attempt to process it again
 
-                    // Note: We can set aside the data without the payload being owned directly due to the data already been verified
-                    //       so we can own the data directly without worrying about the lifetime
-                    //       however, we may want to eventually validate the data to ensure it havent been tampered in some way
-                    //       while waiting for the response.
+                        // Note: We can set aside the data without the payload being owned directly due to the data already been verified
+                        //       so we can own the data directly without worrying about the lifetime
+                        //       however, we may want to eventually validate the data to ensure it havent been tampered in some way
+                        //       while waiting for the response.
+                        let bytes = data.to_bytes()?;
+                        self.pending_key_exchange
+                            .entry(sender)
+                            .or_default()
+                            .push((bytes, false));
 
-                    self.pending_key_exchange
-                        .entry(sender)
-                        .or_default()
-                        .push((data.message(None)?, false));
+                        // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
+                        // but for now we can leave this commented until the queue is removed and refactored.
+                        // _ = self.request_key(id, &data.sender()).await;
 
-                    // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
-                    // but for now we can leave this commented until the queue is removed and refactored.
-                    // _ = self.request_key(id, &data.sender()).await;
-
-                    // Note: We will mark this as `Ok` since this is pending request to be resolved
-                    return Ok(());
+                        // Note: We will mark this as `Ok` since this is pending request to be resolved
+                        return Ok(());
+                    }
                 }
-                Err(e) => {
-                    tracing::warn!(id = %id, sender = %data.sender(), error = %e, "Failed to obtain key");
-                    return Err(e);
-                }
-            };
-
-            Cipher::direct_decrypt(&data.message(None)?, &key)?
+            }
+            Err(e) => {
+                tracing::warn!(id = %id, sender = %data.sender(), error = %e, "Failed to obtain key");
+                return Err(e);
+            }
         };
-
-        let event = serde_json::from_slice::<CommunityMessagingEvents>(&bytes).map_err(|e| {
-            tracing::warn!(id = %id, sender = %data.sender(), error = %e, "Failed to deserialize message");
-            e
-        })?;
 
         message_event(self, &sender, event).await?;
 
@@ -1300,11 +1286,12 @@ impl CommunityTask {
 
         let keypair = self.root.keypair();
 
-        let bytes = ecdh_encrypt(keypair, Some(did), serde_json::to_vec(&request)?)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, request)
+            .add_recipient(did)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let bytes = payload.to_bytes()?;
 
         let topic = community.exchange_topic(did);
 
@@ -1314,19 +1301,14 @@ impl CommunityTask {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(topic.clone(), payload.to_bytes()?)
+                    .pubsub_publish(topic.clone(), bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(id = %self.community_id, "Unable to publish to topic");
             self.queue_event(
                 did.clone(),
-                QueueItem::direct(
-                    None,
-                    peer_id,
-                    topic.clone(),
-                    payload.message(None)?.to_vec(),
-                ),
+                QueueItem::direct(None, peer_id, topic.clone(), bytes),
             )
             .await;
         }
@@ -1337,13 +1319,13 @@ impl CommunityTask {
     }
 
     pub async fn send_message_event(&self, event: CommunityMessagingEvents) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
-
         let key = self.community_key(None)?;
 
-        let bytes = Cipher::direct_encrypt(&event, &key)?;
+        let recipients = self.document.participants();
 
-        let payload = PayloadBuilder::new(self.root.keypair(), bytes)
+        let payload = PayloadBuilder::new(self.root.keypair(), event)
+            .add_recipients(recipients)?
+            .set_key(key)
             .from_ipfs(&self.ipfs)
             .await?;
 
@@ -3667,15 +3649,21 @@ impl CommunityTask {
         queue: bool,
         exclude: Vec<DID>,
     ) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
         let keypair = self.root.keypair();
         let own_did = self.identity.did_key();
 
         let key = self.community_key(None)?;
 
-        let bytes = Cipher::direct_encrypt(&event, &key)?;
+        let recipients = self.document.participants();
 
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, event)
+            .add_recipients(
+                recipients
+                    .iter()
+                    .filter(|did| own_did.ne(did))
+                    .filter(|did| !exclude.contains(did)),
+            )?
+            .set_key(key)
             .from_ipfs(&self.ipfs)
             .await?;
 
@@ -3684,6 +3672,8 @@ impl CommunityTask {
         let mut can_publish = false;
 
         let recipients = self.document.participants().clone();
+
+        let bytes = payload.to_bytes()?;
 
         for recipient in recipients
             .iter()
@@ -3705,7 +3695,7 @@ impl CommunityTask {
                                 message_id,
                                 peer_id,
                                 self.document.topic(),
-                                payload.message(None)?.to_vec(),
+                                bytes.clone(),
                             ),
                         )
                         .await;
@@ -3715,7 +3705,6 @@ impl CommunityTask {
         }
 
         if can_publish {
-            let bytes = payload.to_bytes()?;
             tracing::trace!(id = %self.community_id, "Payload size: {} bytes", bytes.len());
             let timer = Instant::now();
             let mut time = true;
@@ -4522,13 +4511,11 @@ async fn process_request_response_event(
     let keypair = &this.root.keypair().clone();
     let own_did = this.identity.did_key();
 
-    let payload = PayloadMessage::<Vec<u8>>::from_bytes(&req.data)?;
+    let payload = PayloadMessage::<ConversationRequestResponse>::from_bytes(&req.data)?;
 
     let sender = payload.sender().to_did()?;
 
-    let data = ecdh_decrypt(keypair, Some(&sender), payload.message(None)?)?;
-
-    let event = serde_json::from_slice::<ConversationRequestResponse>(&data)?;
+    let event = payload.message(keypair)?;
 
     tracing::debug!(id=%this.community_id, ?event, "Event received");
     match event {
@@ -4568,9 +4555,8 @@ async fn process_request_response_event(
 
                 let topic = this.document.exchange_topic(&sender);
 
-                let bytes = ecdh_encrypt(keypair, Some(&sender), serde_json::to_vec(&response)?)?;
-
-                let payload = PayloadBuilder::new(keypair, bytes)
+                let payload = PayloadBuilder::new(keypair, response)
+                    .add_recipient(&sender)?
                     .from_ipfs(&this.ipfs)
                     .await?;
 
@@ -4588,7 +4574,7 @@ async fn process_request_response_event(
                     || (peers.contains(&peer_id)
                         && this
                             .ipfs
-                            .pubsub_publish(topic.clone(), bytes)
+                            .pubsub_publish(topic.clone(), bytes.clone())
                             .await
                             .is_err())
                 {
@@ -4596,12 +4582,7 @@ async fn process_request_response_event(
                     // TODO
                     this.queue_event(
                         sender.clone(),
-                        QueueItem::direct(
-                            None,
-                            peer_id,
-                            topic.clone(),
-                            payload.message(None)?.to_vec(),
-                        ),
+                        QueueItem::direct(None, peer_id, topic.clone(), bytes.clone()),
                     )
                     .await;
                 }
@@ -4671,8 +4652,8 @@ async fn process_pending_payload(this: &mut CommunityTask) {
         let event_fn = || {
             let keypair = root.keypair();
             let key = store.get_latest(keypair, &sender)?;
-            let data = Cipher::direct_decrypt(&data, &key)?;
-            let event = serde_json::from_slice(&data)?;
+            let payload = PayloadMessage::<_>::from_bytes(&data)?;
+            let event = payload.message_from_key(&key)?;
             Ok::<_, Error>(event)
         };
 
@@ -4691,14 +4672,12 @@ async fn process_pending_payload(this: &mut CommunityTask) {
 }
 
 async fn process_community_event(this: &mut CommunityTask, message: Message) -> Result<(), Error> {
-    let payload = PayloadMessage::<Vec<u8>>::from_bytes(&message.data)?;
+    let payload = PayloadMessage::<CommunityMessagingEvents>::from_bytes(&message.data)?;
     let sender = payload.sender().to_did()?;
 
     let key = this.community_key(Some(&sender))?;
 
-    let data = Cipher::direct_decrypt(&payload.message(None)?, &key)?;
-
-    let event = match serde_json::from_slice::<CommunityMessagingEvents>(&data)? {
+    let event = match payload.message_from_key(&key)? {
         event @ CommunityMessagingEvents::Event { .. } => event,
         _ => return Err(Error::Other),
     };
@@ -4739,12 +4718,13 @@ struct QueueItem {
     m_id: Option<Uuid>,
     peer: PeerId,
     topic: String,
-    data: Vec<u8>,
+    data: Bytes,
     sent: bool,
 }
 
 impl QueueItem {
-    pub fn direct(m_id: Option<Uuid>, peer: PeerId, topic: String, data: Vec<u8>) -> Self {
+    pub fn direct(m_id: Option<Uuid>, peer: PeerId, topic: String, data: impl Into<Bytes>) -> Self {
+        let data = data.into();
         QueueItem {
             m_id,
             peer,
@@ -4758,7 +4738,6 @@ impl QueueItem {
 //TODO: Replace
 async fn process_queue(this: &mut CommunityTask) {
     let mut changed = false;
-    let keypair = &this.root.keypair().clone();
     for (did, items) in this.queue.iter_mut() {
         let Ok(peer_id) = did.to_peer_id() else {
             continue;
@@ -4792,22 +4771,7 @@ async fn process_queue(this: &mut CommunityTask) {
                 continue;
             }
 
-            let payload = match PayloadBuilder::<_>::new(keypair, data.clone())
-                .from_ipfs(&this.ipfs)
-                .await
-            {
-                Ok(p) => p,
-                Err(_e) => {
-                    // tracing::warn!(error = %_e, "unable to build payload")
-                    continue;
-                }
-            };
-
-            let Ok(bytes) = payload.to_bytes() else {
-                continue;
-            };
-
-            if let Err(e) = this.ipfs.pubsub_publish(topic.clone(), bytes).await {
+            if let Err(e) = this.ipfs.pubsub_publish(topic.clone(), data.clone()).await {
                 tracing::error!("Error publishing to topic: {e}");
                 continue;
             }

--- a/extensions/warp-ipfs/src/store/message/community_task.rs
+++ b/extensions/warp-ipfs/src/store/message/community_task.rs
@@ -1226,30 +1226,32 @@ impl CommunityTask {
         let event = match self.keystore.get_latest(keypair, &sender) {
             Ok(key) => data.message_from_key(&key)?,
             Err(Error::PublicKeyDoesntExist) => {
-                match data.message(keypair) {
-                    Ok(message) => message,
-                    _ => {
-                        // If we are not able to get the latest key from the store, this is because we are still awaiting on the response from the key exchange
-                        // So what we should so instead is set aside the payload until we receive the key exchange then attempt to process it again
+                // match data.message(keypair) {
+                //     Ok(message) => {
+                //         message
+                //     }
+                //     _ => {
+                // If we are not able to get the latest key from the store, this is because we are still awaiting on the response from the key exchange
+                // So what we should so instead is set aside the payload until we receive the key exchange then attempt to process it again
 
-                        // Note: We can set aside the data without the payload being owned directly due to the data already been verified
-                        //       so we can own the data directly without worrying about the lifetime
-                        //       however, we may want to eventually validate the data to ensure it havent been tampered in some way
-                        //       while waiting for the response.
-                        let bytes = data.to_bytes()?;
-                        self.pending_key_exchange
-                            .entry(sender)
-                            .or_default()
-                            .push((bytes, false));
+                // Note: We can set aside the data without the payload being owned directly due to the data already been verified
+                //       so we can own the data directly without worrying about the lifetime
+                //       however, we may want to eventually validate the data to ensure it havent been tampered in some way
+                //       while waiting for the response.
+                let bytes = data.to_bytes()?;
+                self.pending_key_exchange
+                    .entry(sender)
+                    .or_default()
+                    .push((bytes, false));
 
-                        // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
-                        // but for now we can leave this commented until the queue is removed and refactored.
-                        // _ = self.request_key(id, &data.sender()).await;
+                // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
+                // but for now we can leave this commented until the queue is removed and refactored.
+                // _ = self.request_key(id, &data.sender()).await;
 
-                        // Note: We will mark this as `Ok` since this is pending request to be resolved
-                        return Ok(());
-                    }
-                }
+                // Note: We will mark this as `Ok` since this is pending request to be resolved
+                return Ok(());
+                //     }
+                // }
             }
             Err(e) => {
                 tracing::warn!(id = %id, sender = %data.sender(), error = %e, "Failed to obtain key");

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -28,7 +28,7 @@ use warp::raygun::{
     RayGunEventKind,
 };
 use warp::{
-    crypto::{cipher::Cipher, generate},
+    crypto::generate,
     error::Error,
     raygun::{
         ConversationType, GroupPermission, ImplGroupPermissions, MessageEventKind, PinState,
@@ -233,7 +233,7 @@ pub struct ConversationTask {
     file: FileStore,
     identity: IdentityStore,
     discovery: Discovery,
-    pending_key_exchange: IndexMap<DID, Vec<(Vec<u8>, bool)>>,
+    pending_key_exchange: IndexMap<DID, Vec<(Bytes, bool)>>,
     document: ConversationDocument,
     keystore: Keystore,
 
@@ -916,15 +916,14 @@ impl ConversationTask {
         did_key: &DID,
         event: ConversationEvents,
     ) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
-
         let keypair = self.root.keypair();
 
-        let bytes = ecdh_encrypt(keypair, Some(did_key), &event)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, event)
+            .add_recipient(did_key)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let bytes = payload.to_bytes()?;
 
         let peer_id = did_key.to_peer_id()?;
         let peers = self.ipfs.pubsub_peers(Some(did_key.messaging())).await?;
@@ -935,19 +934,14 @@ impl ConversationTask {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(did_key.messaging(), payload.to_bytes()?)
+                    .pubsub_publish(did_key.messaging(), bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(id=%&self.conversation_id, "Unable to publish to topic. Queuing event");
             self.queue_event(
                 did_key.clone(),
-                QueueItem::direct(
-                    None,
-                    peer_id,
-                    did_key.messaging(),
-                    payload.message(None)?.to_vec(),
-                ),
+                QueueItem::direct(None, peer_id, did_key.messaging(), bytes),
             )
             .await;
             time = false;
@@ -1043,7 +1037,7 @@ impl ConversationTask {
     }
 
     async fn process_msg_event(&mut self, msg: Message) -> Result<(), Error> {
-        let data = PayloadMessage::<Vec<u8>>::from_bytes(&msg.data)?;
+        let data = PayloadMessage::<MessagingEvents>::from_bytes(&msg.data)?;
         let sender = data.sender().to_did()?;
 
         let keypair = self.root.keypair();
@@ -1052,7 +1046,7 @@ impl ConversationTask {
 
         let id = self.conversation_id;
 
-        let bytes = match self.document.conversation_type() {
+        let event = match self.document.conversation_type() {
             ConversationType::Direct => {
                 let list = self.document.recipients();
 
@@ -1066,46 +1060,51 @@ impl ConversationTask {
                     return Err(Error::IdentityDoesntExist);
                 };
 
-                ecdh_decrypt(keypair, Some(member), data.message(None)?)?
+                if &sender != *member {
+                    return Err(Error::IdentityDoesntExist);
+                }
+
+                data.message(keypair)?
             }
             ConversationType::Group => {
-                let key = match self.keystore.get_latest(keypair, &sender) {
-                    Ok(key) => key,
+                let bytes = data.to_bytes()?;
+                match self.keystore.get_latest(keypair, &sender) {
+                    Ok(key) => data.message_from_key(&key)?,
                     Err(Error::PublicKeyDoesntExist) => {
-                        // If we are not able to get the latest key from the store, this is because we are still awaiting on the response from the key exchange
-                        // So what we should so instead is set aside the payload until we receive the key exchange then attempt to process it again
+                        // Lets first try to get the message from the payload. If we are not apart of the list of recipients, we will then
+                        // queue the payload itself.
+                        match data.message(keypair) {
+                            Ok(message) => message,
+                            _ => {
+                                // If we are not able to get the latest key from the store, this is because we are still awaiting on the response from the key exchange
+                                // So what we should so instead is set aside the payload until we receive the key exchange then attempt to process it again
 
-                        // Note: We can set aside the data without the payload being owned directly due to the data already been verified
-                        //       so we can own the data directly without worrying about the lifetime
-                        //       however, we may want to eventually validate the data to ensure it havent been tampered in some way
-                        //       while waiting for the response.
+                                // Note: We can set aside the data without the payload being owned directly due to the data already been verified
+                                //       so we can own the data directly without worrying about the lifetime
+                                //       however, we may want to eventually validate the data to ensure it havent been tampered in some way
+                                //       while waiting for the response.
 
-                        self.pending_key_exchange
-                            .entry(sender)
-                            .or_default()
-                            .push((data.message(None)?, false));
+                                self.pending_key_exchange
+                                    .entry(sender)
+                                    .or_default()
+                                    .push((bytes, false));
 
-                        // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
-                        // but for now we can leave this commented until the queue is removed and refactored.
-                        // _ = self.request_key(id, &data.sender()).await;
+                                // Maybe send a request? Although we could, we should check to determine if one was previously sent or queued first,
+                                // but for now we can leave this commented until the queue is removed and refactored.
+                                // _ = self.request_key(id, &data.sender()).await;
 
-                        // Note: We will mark this as `Ok` since this is pending request to be resolved
-                        return Ok(());
+                                // Note: We will mark this as `Ok` since this is pending request to be resolved
+                                return Ok(());
+                            }
+                        }
                     }
                     Err(e) => {
                         tracing::warn!(id = %id, sender = %data.sender(), error = %e, "Failed to obtain key");
                         return Err(e);
                     }
-                };
-
-                Cipher::direct_decrypt(&data.message(None)?, &key)?
+                }
             }
         };
-
-        let event = serde_json::from_slice::<MessagingEvents>(&bytes).map_err(|e| {
-            tracing::warn!(id = %id, sender = %data.sender(), error = %e, "Failed to deserialize message");
-            e
-        })?;
 
         message_event(self, &sender, event).await?;
 
@@ -1211,11 +1210,12 @@ impl ConversationTask {
 
         let keypair = self.root.keypair();
 
-        let bytes = ecdh_encrypt(keypair, Some(did), serde_json::to_vec(&request)?)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, request)
+            .add_recipient(did)?
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let bytes = payload.to_bytes()?;
 
         let topic = conversation.exchange_topic(did);
 
@@ -1225,14 +1225,14 @@ impl ConversationTask {
             || (peers.contains(&peer_id)
                 && self
                     .ipfs
-                    .pubsub_publish(topic.clone(), payload.to_bytes()?)
+                    .pubsub_publish(topic.clone(), bytes.clone())
                     .await
                     .is_err())
         {
             tracing::warn!(id = %self.conversation_id, "Unable to publish to topic");
             self.queue_event(
                 did.clone(),
-                QueueItem::direct(None, peer_id, topic.clone(), payload.message(None)?),
+                QueueItem::direct(None, peer_id, topic.clone(), bytes),
             )
             .await;
         }
@@ -1850,14 +1850,14 @@ impl ConversationTask {
     }
 
     pub async fn send_message_event(&self, event: MessagingEvents) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
-
         let key = self.conversation_key(None)?;
 
-        let bytes = Cipher::direct_encrypt(&event, &key)?;
+        let recipients = self.document.recipients();
 
-        let payload = PayloadBuilder::new(self.root.keypair(), bytes)
+        let payload = PayloadBuilder::new(self.root.keypair(), event)
+            .set_key(key)
             .from_ipfs(&self.ipfs)
+            .add_recipients(recipients)?
             .await?;
 
         let peers = self
@@ -2581,28 +2581,34 @@ impl ConversationTask {
         event: MessagingEvents,
         queue: bool,
     ) -> Result<(), Error> {
-        let event = serde_json::to_vec(&event)?;
         let keypair = self.root.keypair();
         let own_did = self.identity.did_key();
 
+        let recipients = self.document.recipients();
+
+        let participants = recipients
+            .iter()
+            .filter(|did| own_did.ne(did))
+            .collect::<Vec<_>>();
+
         let key = self.conversation_key(None)?;
 
-        let bytes = Cipher::direct_encrypt(&event, &key)?;
-
-        let payload = PayloadBuilder::new(keypair, bytes)
+        let payload = PayloadBuilder::new(keypair, event)
+            .add_recipients(participants)?
+            // Note: We should probably not use the conversation key here but have each payload message be encrypted with a unique key while the underlining message
+            //       could be encrypted with the conversation key
+            // TODO: Determine if we should use the conversation key at the payload level.
+            .set_key(key)
             .from_ipfs(&self.ipfs)
             .await?;
+
+        let payload_bytes = payload.to_bytes()?;
 
         let peers = self.ipfs.pubsub_peers(Some(self.document.topic())).await?;
 
         let mut can_publish = false;
 
-        for recipient in self
-            .document
-            .recipients()
-            .iter()
-            .filter(|did| own_did.ne(did))
-        {
+        for recipient in recipients.iter().filter(|did| own_did.ne(did)) {
             let peer_id = recipient.to_peer_id()?;
 
             // We want to confirm that there is atleast one peer subscribed before attempting to send a message
@@ -2618,7 +2624,7 @@ impl ConversationTask {
                                 message_id,
                                 peer_id,
                                 self.document.topic(),
-                                payload.message(None)?,
+                                payload_bytes.clone(),
                             ),
                         )
                         .await;
@@ -3340,13 +3346,11 @@ async fn process_request_response_event(
     let keypair = &this.root.keypair().clone();
     let own_did = this.identity.did_key();
 
-    let payload = PayloadMessage::<Vec<u8>>::from_bytes(&req.data)?;
+    let payload = PayloadMessage::<ConversationRequestResponse>::from_bytes(&req.data)?;
 
     let sender = payload.sender().to_did()?;
 
-    let data = ecdh_decrypt(keypair, Some(&sender), payload.message(None)?)?;
-
-    let event = serde_json::from_slice::<ConversationRequestResponse>(&data)?;
+    let event = payload.message(keypair)?;
 
     tracing::debug!(id=%this.conversation_id, ?event, "Event received");
     match event {
@@ -3391,9 +3395,8 @@ async fn process_request_response_event(
 
                 let topic = this.document.exchange_topic(&sender);
 
-                let bytes = ecdh_encrypt(keypair, Some(&sender), serde_json::to_vec(&response)?)?;
-
-                let payload = PayloadBuilder::new(keypair, bytes)
+                let payload = PayloadBuilder::new(keypair, response)
+                    .add_recipient(&sender)?
                     .from_ipfs(&this.ipfs)
                     .await?;
 
@@ -3411,7 +3414,7 @@ async fn process_request_response_event(
                     || (peers.contains(&peer_id)
                         && this
                             .ipfs
-                            .pubsub_publish(topic.clone(), bytes)
+                            .pubsub_publish(topic.clone(), bytes.clone())
                             .await
                             .is_err())
                 {
@@ -3419,7 +3422,7 @@ async fn process_request_response_event(
                     // TODO
                     this.queue_event(
                         sender.clone(),
-                        QueueItem::direct(None, peer_id, topic.clone(), payload.message(None)?),
+                        QueueItem::direct(None, peer_id, topic.clone(), bytes.clone()),
                     )
                     .await;
                 }
@@ -3495,8 +3498,8 @@ async fn process_pending_payload(this: &mut ConversationTask) {
         let event_fn = || {
             let keypair = root.keypair();
             let key = store.get_latest(keypair, &sender)?;
-            let data = Cipher::direct_decrypt(&data, &key)?;
-            let event = serde_json::from_slice(&data)?;
+            let payload = PayloadMessage::<MessagingEvents>::from_bytes(&data)?;
+            let event = payload.message_from_key(&key)?;
             Ok::<_, Error>(event)
         };
 
@@ -3518,14 +3521,12 @@ async fn process_conversation_event(
     this: &mut ConversationTask,
     message: Message,
 ) -> Result<(), Error> {
-    let payload = PayloadMessage::<Vec<u8>>::from_bytes(&message.data)?;
+    let payload = PayloadMessage::<MessagingEvents>::from_bytes(&message.data)?;
     let sender = payload.sender().to_did()?;
 
     let key = this.conversation_key(Some(&sender))?;
 
-    let data = Cipher::direct_decrypt(&payload.message(None)?, &key)?;
-
-    let event = match serde_json::from_slice::<MessagingEvents>(&data)? {
+    let event = match payload.message_from_key(&key)? {
         event @ MessagingEvents::Event { .. } => event,
         _ => return Err(Error::Other),
     };
@@ -3563,12 +3564,13 @@ struct QueueItem {
     m_id: Option<Uuid>,
     peer: PeerId,
     topic: String,
-    data: Vec<u8>,
+    data: Bytes,
     sent: bool,
 }
 
 impl QueueItem {
-    pub fn direct(m_id: Option<Uuid>, peer: PeerId, topic: String, data: Vec<u8>) -> Self {
+    pub fn direct(m_id: Option<Uuid>, peer: PeerId, topic: String, data: impl Into<Bytes>) -> Self {
+        let data = data.into();
         QueueItem {
             m_id,
             peer,
@@ -3582,7 +3584,6 @@ impl QueueItem {
 //TODO: Replace
 async fn process_queue(this: &mut ConversationTask) {
     let mut changed = false;
-    let keypair = &this.root.keypair().clone();
     for (did, items) in this.queue.iter_mut() {
         let Ok(peer_id) = did.to_peer_id() else {
             continue;
@@ -3616,22 +3617,7 @@ async fn process_queue(this: &mut ConversationTask) {
                 continue;
             }
 
-            let payload = match PayloadBuilder::<_>::new(keypair, data.clone())
-                .from_ipfs(&this.ipfs)
-                .await
-            {
-                Ok(p) => p,
-                Err(_e) => {
-                    // tracing::warn!(error = %_e, "unable to build payload")
-                    continue;
-                }
-            };
-
-            let Ok(bytes) = payload.to_bytes() else {
-                continue;
-            };
-
-            if let Err(e) = this.ipfs.pubsub_publish(topic.clone(), bytes).await {
+            if let Err(e) = this.ipfs.pubsub_publish(topic.clone(), data.clone()).await {
                 tracing::error!("Error publishing to topic: {e}");
                 continue;
             }

--- a/extensions/warp-ipfs/src/store/payload.rs
+++ b/extensions/warp-ipfs/src/store/payload.rs
@@ -219,7 +219,7 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
             co_signature: None,
         };
 
-        if !recipients.is_empty() {
+        if !recipients.is_empty() || key.is_some() {
             let keypair = cosigner.unwrap_or(keypair);
             let new_key = generate::<64>();
 
@@ -242,10 +242,6 @@ impl<M: Serialize + DeserializeOwned + Clone> PayloadMessage<M> {
                 };
 
                 new_map.insert(recipient, key_set);
-            }
-
-            if new_map.is_empty() {
-                return Err(Error::EmptyMessage); // TODO: error for arb message being empty
             }
 
             let sender = payload.sender();

--- a/extensions/warp-ipfs/src/store/queue.rs
+++ b/extensions/warp-ipfs/src/store/queue.rs
@@ -281,11 +281,11 @@ impl QueueEntry {
 
                         let res = async move {
                             let kp = &entry.keypair;
-                            let payload_bytes = serde_json::to_vec(&entry.item)?;
 
-                            let bytes = ecdh_encrypt(kp, Some(&recipient), payload_bytes)?;
-
-                            let message = PayloadBuilder::new(kp, bytes).build()?;
+                            let message = PayloadBuilder::new(kp, entry.item)
+                                .add_recipient(&recipient)?
+                                .from_ipfs(&entry.ipfs)
+                                .await?;
 
                             let message_bytes = message.to_bytes()?;
 

--- a/extensions/warp-ipfs/tests/common.rs
+++ b/extensions/warp-ipfs/tests/common.rs
@@ -65,7 +65,7 @@ pub async fn create_account(
     config.ipfs_setting_mut().relay_client.relay_address = vec![];
     config.ipfs_setting_mut().mdns.enable = false;
     config.store_setting_mut().announce_to_mesh = true;
-    config.store_setting_mut().auto_push = Some(Duration::from_secs(30));
+    config.store_setting_mut().auto_push = Some(Duration::from_secs(1));
 
     *config.bootstrap_mut() = Bootstrap::None;
 

--- a/extensions/warp-ipfs/tests/common.rs
+++ b/extensions/warp-ipfs/tests/common.rs
@@ -65,7 +65,7 @@ pub async fn create_account(
     config.ipfs_setting_mut().relay_client.relay_address = vec![];
     config.ipfs_setting_mut().mdns.enable = false;
     config.store_setting_mut().announce_to_mesh = true;
-    config.store_setting_mut().auto_push = Some(Duration::from_secs(1));
+    config.store_setting_mut().auto_push = Some(Duration::from_secs(30));
 
     *config.bootstrap_mut() = Bootstrap::None;
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use specific type instead of array of bytes in `PayloadMessage` (eg using `PayloadMessage<Message>` instead of `PayloadMessage<Vec<u8>>`)
- Change queue to store the bytes of the payload itself instead of recreating the payload when handling conversation messages.
- Set existing key to payload if exist and available. 

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️
- This does break the internal queue and how messages are sent through the network due to the format change.

**Additional comments** 🎤
- There has been instances where we would send an array of bytes, which were primarily data that were encrypted, however since `PayloadMessage` can internally encrypt the content, it makes no sense to encrypt then build the payload. Now we would directly add the message to the payload builder along with the intended list of recipients. with or without existing key as if a key was never generated (and shared), it would create one and use that for encrypting the message, otherwise the key that is set would be used instead.
- Communities may require extracting the key from the recipient list of the payload and putting that into the keystore **__IF__** it is meant to be used. Otherwise, we could continue to wait for the key exchange before processing the payload itself.
