### PR TITLE
feat: Add MessageDocumentBuilder

### DIFF
--- a/extensions/warp-ipfs/src/store/conversation/message.rs
+++ b/extensions/warp-ipfs/src/store/conversation/message.rs
@@ -1,3 +1,4 @@
+use crate::store::document::files::FileDocument;
 use crate::store::document::FileAttachmentDocument;
 use crate::store::keystore::Keystore;
 use crate::store::{
@@ -8,10 +9,11 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use either::Either;
 use futures::stream::{FuturesUnordered, StreamExt};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use rust_ipfs::{Ipfs, Keypair};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::future::IntoFuture;
+use std::hash::{Hash, Hasher};
 use uuid::Uuid;
 use warp::crypto::cipher::Cipher;
 use warp::crypto::hash::sha256_iter;
@@ -26,7 +28,7 @@ pub enum MessageVersion {
     V0,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MessageDocument {
     pub id: Uuid,
     pub message_type: MessageType,
@@ -35,9 +37,9 @@ pub struct MessageDocument {
     pub sender: DIDEd25519Reference,
     pub date: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    pub reactions: IndexMap<String, Vec<DID>>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub attachments: Vec<FileAttachmentDocument>,
+    pub reactions: IndexMap<String, IndexSet<DID>>,
+    #[serde(default, skip_serializing_if = "IndexSet::is_empty")]
+    pub attachments: IndexSet<FileAttachmentDocument>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub modified: Option<DateTime<Utc>>,
     #[serde(default)]
@@ -48,6 +50,83 @@ pub struct MessageDocument {
     pub message: Option<Bytes>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub signature: Option<MessageSignature>,
+}
+
+impl MessageDocument {
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    pub fn message_type(&self) -> MessageType {
+        self.message_type
+    }
+
+    pub fn conversation_id(&self) -> Uuid {
+        self.conversation_id
+    }
+
+    pub fn version(&self) -> MessageVersion {
+        self.version
+    }
+
+    pub fn sender(&self) -> DID {
+        self.sender.to_did()
+    }
+
+    pub fn date(&self) -> DateTime<Utc> {
+        self.date
+    }
+
+    pub fn reactions(&self) -> &IndexMap<String, IndexSet<DID>> {
+        &self.reactions
+    }
+
+    pub fn modified(&self) -> Option<DateTime<Utc>> {
+        self.modified
+    }
+
+    pub fn pinned(&self) -> bool {
+        self.pinned
+    }
+
+    pub fn replied(&self) -> Option<Uuid> {
+        self.replied
+    }
+}
+
+impl PartialEq for MessageDocument {
+    fn eq(&self, other: &Self) -> bool {
+        self.id.eq(&other.id) && self.conversation_id.eq(&other.conversation_id)
+    }
+}
+
+impl Eq for MessageDocument {}
+
+impl Hash for MessageDocument {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.conversation_id.hash(state);
+    }
+}
+
+impl MessageDocument {
+    pub fn empty() -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            message_type: MessageType::Message,
+            conversation_id: Uuid::nil(),
+            version: MessageVersion::V0,
+            sender: DIDEd25519Reference([0; 32]),
+            date: Utc::now(),
+            reactions: IndexMap::new(),
+            attachments: IndexSet::new(),
+            modified: None,
+            pinned: false,
+            replied: None,
+            message: None,
+            signature: None,
+        }
+    }
 }
 
 impl From<MessageDocument> for MessageReference {
@@ -85,49 +164,81 @@ impl Ord for MessageDocument {
     }
 }
 
-impl MessageDocument {
-    pub fn new(
-        keypair: &Keypair,
-        message: Message,
-        key: Either<&DID, &Keystore>,
-    ) -> Result<Self, Error> {
-        let id = message.id();
-        let message_type = message.message_type();
-        let conversation_id = message.conversation_id();
-        let date = message.date();
-        let sender = message.sender();
-        let pinned = message.pinned();
-        let modified = message.modified();
-        let replied = message.replied();
-        let lines = message.lines();
-        let reactions = message.reactions().to_owned();
-        let attachments = message.attachments();
+pub struct MessageDocumentBuilder<'a> {
+    keypair: &'a Keypair,
+    keystore: Either<&'a DID, &'a Keystore>,
+    message_document: MessageDocument,
+}
 
-        if attachments.len() > MAX_ATTACHMENT {
+impl<'a> MessageDocumentBuilder<'a> {
+    pub fn new(keypair: &'a Keypair, keystore: Either<&'a DID, &'a Keystore>) -> Self {
+        Self {
+            keypair,
+            keystore,
+            message_document: MessageDocument::empty(),
+        }
+    }
+
+    pub fn set_message_id(mut self, id: Uuid) -> Self {
+        self.message_document.id = id;
+        self
+    }
+
+    pub fn set_conversation_id(mut self, id: Uuid) -> Self {
+        self.message_document.conversation_id = id;
+        self
+    }
+
+    pub fn set_message_type(mut self, message_type: MessageType) -> Self {
+        self.message_document.message_type = message_type;
+        self
+    }
+
+    pub fn set_sender(mut self, sender: DID) -> Self {
+        self.message_document.sender = DIDEd25519Reference::from_did(&sender);
+        self
+    }
+
+    pub fn set_pin(mut self, pinned: bool) -> Self {
+        self.message_document.pinned = pinned;
+        self
+    }
+
+    pub fn set_replied(mut self, replied: impl Into<Option<Uuid>>) -> Self {
+        self.message_document.replied = replied.into();
+        self
+    }
+
+    pub fn set_date(mut self, date: DateTime<Utc>) -> Self {
+        self.message_document.date = date;
+        self
+    }
+
+    pub fn set_modified(mut self, modified: DateTime<Utc>) -> Self {
+        self.message_document.modified = Some(modified);
+        self
+    }
+
+    pub fn add_attachment(mut self, attachment: impl Into<FileDocument>) -> Result<Self, Error> {
+        let amount = self.message_document.attachments.len();
+        if amount > MAX_ATTACHMENT {
             return Err(Error::InvalidLength {
                 context: "attachments".into(),
-                current: attachments.len(),
+                current: amount,
                 minimum: None,
                 maximum: Some(MAX_ATTACHMENT),
             });
         }
+        let attachment = FileAttachmentDocument::new(attachment)?;
+        self.message_document.attachments.insert(attachment);
+        Ok(self)
+    }
 
-        if reactions.len() > MAX_REACTIONS {
-            return Err(Error::InvalidLength {
-                context: "reactions".into(),
-                current: reactions.len(),
-                minimum: None,
-                maximum: Some(MAX_REACTIONS),
-            });
-        }
+    pub fn set_message(mut self, message: Vec<String>) -> Result<Self, Error> {
+        let sender = self.message_document.sender.to_did();
 
-        let attachments = attachments
-            .iter()
-            .filter_map(|file| FileAttachmentDocument::new(file).ok())
-            .collect::<Vec<_>>();
-
-        if !lines.is_empty() {
-            let lines_value_length: usize = lines
+        if !message.is_empty() {
+            let lines_value_length: usize = message
                 .iter()
                 .filter(|s| !s.is_empty())
                 .map(|s| s.trim())
@@ -144,49 +255,373 @@ impl MessageDocument {
             }
         }
 
-        let bytes = serde_json::to_vec(&lines)?;
+        let bytes = serde_json::to_vec(&message)?;
 
-        let data = match key {
+        let data = match self.keystore {
             Either::Right(keystore) => {
-                let key = keystore.get_latest(keypair, sender)?;
+                let key = keystore.get_latest(self.keypair, &sender)?;
+                Cipher::direct_encrypt(&bytes, &key)?.into()
+            }
+            Either::Left(key) => ecdh_encrypt(self.keypair, Some(key), &bytes)?.into(),
+        };
+
+        self.message_document.message = Some(data);
+        Ok(self)
+    }
+
+    pub fn build(self) -> Result<MessageDocument, Error> {
+        self.message_document.sign(self.keypair)
+    }
+}
+
+impl MessageDocument {
+    // pub fn new(
+    //     keypair: &Keypair,
+    //     message: Message,
+    //     key: Either<&DID, &Keystore>,
+    // ) -> Result<Self, Error> {
+    //     let id = message.id();
+    //     let message_type = message.message_type();
+    //     let conversation_id = message.conversation_id();
+    //     let date = message.date();
+    //     let sender = message.sender();
+    //     let pinned = message.pinned();
+    //     let modified = message.modified();
+    //     let replied = message.replied();
+    //     let lines = message.lines();
+    //     let reactions = message.reactions().to_owned();
+    //     let attachments = message.attachments();
+    //
+    //     if attachments.len() > MAX_ATTACHMENT {
+    //         return Err(Error::InvalidLength {
+    //             context: "attachments".into(),
+    //             current: attachments.len(),
+    //             minimum: None,
+    //             maximum: Some(MAX_ATTACHMENT),
+    //         });
+    //     }
+    //
+    //     if reactions.len() > MAX_REACTIONS {
+    //         return Err(Error::InvalidLength {
+    //             context: "reactions".into(),
+    //             current: reactions.len(),
+    //             minimum: None,
+    //             maximum: Some(MAX_REACTIONS),
+    //         });
+    //     }
+    //
+    //     let attachments = attachments
+    //         .iter()
+    //         .filter_map(|file| FileAttachmentDocument::new(file).ok())
+    //         .collect::<Vec<_>>();
+    //
+    //     if !lines.is_empty() {
+    //         let lines_value_length: usize = lines
+    //             .iter()
+    //             .filter(|s| !s.is_empty())
+    //             .map(|s| s.trim())
+    //             .map(|s| s.chars().count())
+    //             .sum();
+    //
+    //         if lines_value_length > MAX_MESSAGE_SIZE {
+    //             return Err(Error::InvalidLength {
+    //                 context: "message".into(),
+    //                 current: lines_value_length,
+    //                 minimum: None,
+    //                 maximum: Some(MAX_MESSAGE_SIZE),
+    //             });
+    //         }
+    //     }
+    //
+    //     let bytes = serde_json::to_vec(&lines)?;
+    //
+    //     let data = match key {
+    //         Either::Right(keystore) => {
+    //             let key = keystore.get_latest(keypair, sender)?;
+    //             Cipher::direct_encrypt(&bytes, &key)?.into()
+    //         }
+    //         Either::Left(key) => ecdh_encrypt(keypair, Some(key), &bytes)?.into(),
+    //     };
+    //
+    //     let message = Some(data);
+    //
+    //     let sender = DIDEd25519Reference::from_did(sender);
+    //
+    //     let document = MessageDocument {
+    //         id,
+    //         message_type,
+    //         sender,
+    //         conversation_id,
+    //         version: MessageVersion::default(),
+    //         date,
+    //         reactions,
+    //         attachments,
+    //         message,
+    //         pinned,
+    //         modified,
+    //         replied,
+    //         signature: None,
+    //     };
+    //
+    //     document.sign(keypair)
+    // }
+
+    pub fn set_message_type(mut self, message_type: MessageType) -> Self {
+        self.message_type = message_type;
+        self
+    }
+
+    pub fn set_sender(mut self, sender: DID) -> Self {
+        self.sender = DIDEd25519Reference::from_did(&sender);
+        self
+    }
+
+    pub fn set_pin(mut self, pinned: bool) -> Self {
+        self.pinned = pinned;
+        self
+    }
+
+    pub fn set_replied(mut self, replied: Uuid) -> Self {
+        self.replied = Some(replied);
+        self
+    }
+
+    pub fn set_modified(mut self, modified: DateTime<Utc>) -> Self {
+        self.modified = Some(modified);
+        self
+    }
+
+    pub fn add_attachment(mut self, attachment: impl Into<FileDocument>) -> Result<Self, Error> {
+        let amount = self.attachments.len();
+        if amount > MAX_ATTACHMENT {
+            return Err(Error::InvalidLength {
+                context: "attachments".into(),
+                current: amount,
+                minimum: None,
+                maximum: Some(MAX_ATTACHMENT),
+            });
+        }
+        let attachment = FileAttachmentDocument::new(attachment)?;
+        self.attachments.insert(attachment);
+        Ok(self)
+    }
+
+    pub fn remove_attachment(mut self, file_id: Uuid) -> Self {
+        self.attachments
+            .retain(|attachment| attachment.id != file_id);
+        self
+    }
+
+    pub fn add_reaction(mut self, emoji: impl Into<String>, reactor: DID) -> Result<Self, Error> {
+        let emoji = emoji.into();
+        let size = self.reactions.len();
+        match self.reactions.entry(emoji) {
+            indexmap::map::Entry::Occupied(mut entry) => {
+                let list = entry.get_mut();
+                if list.contains(&reactor) {
+                    return Err(Error::ReactionExist);
+                }
+                list.insert(reactor);
+            }
+            indexmap::map::Entry::Vacant(entry) => {
+                if size > MAX_REACTIONS {
+                    return Err(Error::InvalidLength {
+                        context: "reactions".into(),
+                        current: size,
+                        minimum: None,
+                        maximum: Some(MAX_REACTIONS),
+                    });
+                }
+                let list = IndexSet::from_iter([reactor]);
+                entry.insert(list);
+            }
+        }
+
+        Ok(self)
+    }
+
+    pub fn remove_reaction(
+        mut self,
+        emoji: impl Into<String>,
+        reactor: DID,
+    ) -> Result<Self, Error> {
+        let emoji = emoji.into();
+        if !self.reactions.contains_key(&emoji) {
+            return Err(Error::ReactionDoesntExist);
+        }
+
+        if let indexmap::map::Entry::Occupied(mut entry) = self.reactions.entry(emoji) {
+            let list = entry.get_mut();
+            if !list.contains(&reactor) {
+                return Err(Error::ReactionDoesntExist);
+            }
+            list.shift_remove(&reactor);
+            if entry.get().is_empty() {
+                entry.shift_remove();
+            }
+        }
+        Ok(self)
+    }
+
+    pub fn set_message(
+        mut self,
+        keypair: &Keypair,
+        keystore: Either<&DID, &Keystore>,
+        message: &[String],
+    ) -> Result<Self, Error> {
+        let sender = self.sender.to_did();
+
+        if !message.is_empty() {
+            let lines_value_length: usize = message
+                .iter()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.trim())
+                .map(|s| s.chars().count())
+                .sum();
+
+            if lines_value_length > MAX_MESSAGE_SIZE {
+                return Err(Error::InvalidLength {
+                    context: "message".into(),
+                    current: lines_value_length,
+                    minimum: None,
+                    maximum: Some(MAX_MESSAGE_SIZE),
+                });
+            }
+        }
+
+        let bytes = serde_json::to_vec(message)?;
+
+        let data = match keystore {
+            Either::Right(keystore) => {
+                let key = keystore.get_latest(keypair, &sender)?;
                 Cipher::direct_encrypt(&bytes, &key)?.into()
             }
             Either::Left(key) => ecdh_encrypt(keypair, Some(key), &bytes)?.into(),
         };
 
-        let message = Some(data);
-
-        let sender = DIDEd25519Reference::from_did(sender);
-
-        let document = MessageDocument {
-            id,
-            message_type,
-            sender,
-            conversation_id,
-            version: MessageVersion::default(),
-            date,
-            reactions,
-            attachments,
-            message,
-            pinned,
-            modified,
-            replied,
-            signature: None,
-        };
-
-        document.sign(keypair)
+        self.message = Some(data);
+        self.sign(keypair)
     }
 
-    pub fn verify(&self) -> bool {
+    pub fn set_message_with_nonce(
+        mut self,
+        keypair: &Keypair,
+        keystore: Either<&DID, &Keystore>,
+        modified: DateTime<Utc>,
+        message: Vec<String>,
+        signature: Option<Vec<u8>>,
+        nonce: Option<&[u8]>,
+    ) -> Result<Self, Error> {
+        let own_did = keypair.to_did()?;
+        let sender = self.sender.to_did();
+
+        self.modified = Some(modified);
+
+        //
+        // if !message.is_empty() {
+        //     let lines_value_length: usize = message
+        //         .iter()
+        //         .filter(|s| !s.is_empty())
+        //         .map(|s| s.trim())
+        //         .map(|s| s.chars().count())
+        //         .sum();
+        //
+        //     if lines_value_length > MAX_MESSAGE_SIZE {
+        //         return Err(Error::InvalidLength {
+        //             context: "message".into(),
+        //             current: lines_value_length,
+        //             minimum: None,
+        //             maximum: Some(MAX_MESSAGE_SIZE),
+        //         });
+        //     }
+        // }
+        //
+        // let bytes = serde_json::to_vec(&message)?;
+        //
+        // let data = match keystore {
+        //     Either::Right(keystore) => {
+        //         let key = keystore.get_latest(keypair, &sender)?;
+        //         Cipher::direct_encrypt(&bytes, &key)?.into()
+        //     }
+        //     Either::Left(key) => ecdh_encrypt(keypair, Some(key), &bytes)?.into(),
+        // };
+        //
+        // self.message = Some(data);
+
+        if !message.is_empty() {
+            let lines_value_length: usize = message
+                .iter()
+                .filter(|s| !s.is_empty())
+                .map(|s| s.trim())
+                .map(|s| s.chars().count())
+                .sum();
+
+            if lines_value_length > MAX_MESSAGE_SIZE {
+                return Err(Error::InvalidLength {
+                    context: "message".into(),
+                    current: lines_value_length,
+                    minimum: None,
+                    maximum: Some(MAX_MESSAGE_SIZE),
+                });
+            }
+        }
+
+        let current_nonce = self.nonce_from_message()?;
+
+        if matches!(nonce, Some(nonce) if nonce.eq(current_nonce)) {
+            // Since the nonce from the current message matches the new one sent,
+            // we would consider this as an invalid message as a nonce should
+            // NOT be reused
+            // TODO: Maybe track previous nonces?
+            return Err(Error::InvalidMessage);
+        }
+
+        let bytes = serde_json::to_vec(&message)?;
+
+        let data = match (keystore, nonce) {
+            (Either::Right(keystore), Some(nonce)) => {
+                let key = keystore.get_latest(keypair, &sender)?;
+                Cipher::direct_encrypt_with_nonce(&bytes, &key, nonce)?
+            }
+            (Either::Left(key), Some(nonce)) => {
+                ecdh_encrypt_with_nonce(keypair, Some(key), &bytes, nonce)?
+            }
+            (Either::Right(keystore), None) => {
+                let key = keystore.get_latest(keypair, &sender)?;
+                Cipher::direct_encrypt(&bytes, &key)?
+            }
+            (Either::Left(key), None) => ecdh_encrypt(keypair, Some(key), &bytes)?,
+        };
+
+        self.message = (!data.is_empty()).then_some(data.into());
+
+        match (sender.eq(&own_did), signature) {
+            (true, None) => {
+                self = self.sign(keypair)?;
+            }
+            (false, None) | (true, Some(_)) => return Err(Error::InvalidMessage),
+            (false, Some(sig)) => {
+                let new_signature = MessageSignature::try_from(sig)?;
+                self.signature.replace(new_signature);
+                self.verify()?;
+            }
+        };
+
+        Ok(self)
+    }
+}
+
+impl MessageDocument {
+    pub fn verify(&self) -> Result<(), Error> {
         let Some(signature) = self.signature else {
-            return false;
+            return Err(Error::InvalidSignature);
         };
 
         let sender = self.sender.to_did();
         let Ok(sender_pk) = sender.to_public_key() else {
             // Note: Although unlikely, we will return false instead of refactoring this function to return an error
             //       since an invalid public key also signals a invalid message.
-            return false;
+            return Err(Error::PublicKeyInvalid);
         };
 
         let attachments_hash = sha256_iter(
@@ -215,7 +650,29 @@ impl MessageDocument {
             ),
         };
 
-        sender_pk.verify(&hash, signature.as_ref())
+        if !sender_pk.verify(&hash, signature.as_ref()) {
+            return Err(Error::InvalidMessage);
+        }
+
+        if self.reactions.len() > MAX_REACTIONS {
+            return Err(Error::InvalidLength {
+                context: "reactions".into(),
+                current: self.reactions.len(),
+                minimum: None,
+                maximum: Some(MAX_REACTIONS),
+            });
+        }
+
+        if self.attachments.len() > MAX_ATTACHMENT {
+            return Err(Error::InvalidLength {
+                context: "attachments".into(),
+                current: self.attachments.len(),
+                minimum: None,
+                maximum: Some(MAX_ATTACHMENT),
+            });
+        }
+
+        Ok(())
     }
 
     pub fn raw_encrypted_message(&self) -> Result<&Bytes, Error> {
@@ -229,179 +686,22 @@ impl MessageDocument {
         Ok(nonce)
     }
 
-    pub fn attachments(&self) -> &[FileAttachmentDocument] {
-        &self.attachments
+    pub fn attachments(&self) -> impl Iterator<Item = &FileAttachmentDocument> {
+        self.attachments.iter()
     }
 
-    pub async fn update(
-        &mut self,
-        ipfs: &Ipfs,
-        keypair: &Keypair,
-        message: Message,
-        signature: Option<Vec<u8>>,
-        key: Either<&DID, &Keystore>,
-        nonce: Option<&[u8]>,
-    ) -> Result<(), Error> {
-        let did = &keypair.to_did()?;
-        tracing::info!(id = %self.conversation_id, message_id = %self.id, "Updating message");
-        let old_message = self.resolve(ipfs, keypair, true, key).await?;
-
-        let sender = self.sender.to_did();
-
-        if message.id() != self.id
-            || message.conversation_id() != self.conversation_id
-            || message.sender() != &sender
-        {
-            tracing::error!(id = %self.conversation_id, message_id = %self.id, "Message does not exist, is invalid or has invalid sender");
-            //TODO: Maybe remove message from this point?
-            return Err(Error::InvalidMessage);
-        }
-
-        self.pinned = message.pinned();
-        self.modified = message.modified();
-
-        let reactions = message.reactions();
-        if reactions.len() > MAX_REACTIONS {
-            return Err(Error::InvalidLength {
-                context: "reactions".into(),
-                current: reactions.len(),
-                minimum: None,
-                maximum: Some(MAX_REACTIONS),
-            });
-        }
-
-        self.reactions = reactions.to_owned();
-
-        if message.lines() != old_message.lines() {
-            let lines = message.lines();
-            if !lines.is_empty() {
-                let lines_value_length: usize = lines
-                    .iter()
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.trim())
-                    .map(|s| s.chars().count())
-                    .sum();
-
-                if lines_value_length > MAX_MESSAGE_SIZE {
-                    return Err(Error::InvalidLength {
-                        context: "message".into(),
-                        current: lines_value_length,
-                        minimum: None,
-                        maximum: Some(MAX_MESSAGE_SIZE),
-                    });
-                }
-            }
-
-            let current_nonce = self.nonce_from_message()?;
-
-            if matches!(nonce, Some(nonce) if nonce.eq(current_nonce)) {
-                // Since the nonce from the current message matches the new one sent,
-                // we would consider this as an invalid message as a nonce should
-                // NOT be reused
-                // TODO: Maybe track previous nonces?
-                return Err(Error::InvalidMessage);
-            }
-
-            let bytes = serde_json::to_vec(&lines)?;
-
-            let data = match (key, nonce) {
-                (Either::Right(keystore), Some(nonce)) => {
-                    let key = keystore.get_latest(keypair, &sender)?;
-                    Cipher::direct_encrypt_with_nonce(&bytes, &key, nonce)?
-                }
-                (Either::Left(key), Some(nonce)) => {
-                    ecdh_encrypt_with_nonce(keypair, Some(key), &bytes, nonce)?
-                }
-                (Either::Right(keystore), None) => {
-                    let key = keystore.get_latest(keypair, &sender)?;
-                    Cipher::direct_encrypt(&bytes, &key)?
-                }
-                (Either::Left(key), None) => ecdh_encrypt(keypair, Some(key), &bytes)?,
-            };
-
-            self.message = (!data.is_empty()).then_some(data.into());
-
-            match (sender.eq(did), signature) {
-                (true, None) => {
-                    let new_documeent = self.clone();
-                    *self = new_documeent.sign(keypair)?;
-                }
-                (false, None) | (true, Some(_)) => return Err(Error::InvalidMessage),
-                (false, Some(sig)) => {
-                    let new_signature = MessageSignature::try_from(sig)?;
-                    self.signature.replace(new_signature);
-                    if !self.verify() {
-                        return Err(Error::InvalidSignature);
-                    }
-                }
-            };
-        }
-
-        tracing::info!(id = %self.conversation_id, message_id = %self.id, "Message is updated");
-        Ok(())
-    }
-
-    pub async fn resolve(
+    pub fn message(
         &self,
-        ipfs: &Ipfs,
         keypair: &Keypair,
-        local: bool,
-        key: Either<&DID, &Keystore>,
-    ) -> Result<Message, Error> {
-        if !self.verify() {
-            return Err(Error::InvalidMessage);
-        }
+        keystore: Either<&DID, &Keystore>,
+    ) -> Result<Vec<String>, Error> {
         let message_cipher = self.message.as_ref().ok_or(Error::MessageNotFound)?;
-        let mut message = Message::default();
-        message.set_id(self.id);
-        message.set_message_type(self.message_type);
-        message.set_conversation_id(self.conversation_id);
-        message.set_sender(self.sender.to_did());
-        message.set_date(self.date);
-        if let Some(date) = self.modified {
-            message.set_modified(date);
-        }
-        message.set_pinned(self.pinned);
-        message.set_replied(self.replied);
 
-        let attachments = self.attachments();
-
-        if self.attachments.len() > MAX_ATTACHMENT {
-            return Err(Error::InvalidLength {
-                context: "attachments".into(),
-                current: attachments.len(),
-                minimum: None,
-                maximum: Some(MAX_ATTACHMENT),
-            });
-        }
-
-        let files = FuturesUnordered::from_iter(
-            attachments
-                .iter()
-                .map(|document| document.resolve_to_file(ipfs, local).into_future()),
-        )
-        .filter_map(|result| async move { result.ok() })
-        .collect::<Vec<_>>()
-        .await;
-
-        message.set_attachment(files);
-
-        if self.reactions.len() > MAX_REACTIONS {
-            return Err(Error::InvalidLength {
-                context: "reactions".into(),
-                current: self.reactions.len(),
-                minimum: None,
-                maximum: Some(MAX_REACTIONS),
-            });
-        }
-
-        message.set_reactions(self.reactions.clone());
-
-        let sender = self.sender.to_did();
-
-        let data = match key {
+        let data = match keystore {
             Either::Left(exchange) => ecdh_decrypt(keypair, Some(exchange), message_cipher)?,
-            Either::Right(keystore) => keystore.try_decrypt(keypair, &sender, message_cipher)?,
+            Either::Right(keystore) => {
+                keystore.try_decrypt(keypair, &self.sender(), message_cipher)?
+            }
         };
 
         let lines: Vec<String> = serde_json::from_slice(&data)?;
@@ -422,6 +722,48 @@ impl MessageDocument {
             });
         }
 
+        Ok(lines)
+    }
+
+    pub async fn resolve(
+        &self,
+        ipfs: &Ipfs,
+        keypair: &Keypair,
+        local: bool,
+        key: Either<&DID, &Keystore>,
+    ) -> Result<Message, Error> {
+        self.verify()?;
+
+        let lines = self.message(keypair, key)?;
+        let mut message = Message::default();
+        message.set_id(self.id);
+        message.set_message_type(self.message_type);
+        message.set_conversation_id(self.conversation_id);
+        message.set_sender(self.sender.to_did());
+        message.set_date(self.date);
+        if let Some(date) = self.modified {
+            message.set_modified(date);
+        }
+        message.set_pinned(self.pinned);
+        message.set_replied(self.replied);
+
+        let attachments = self.attachments();
+
+        let attachments = attachments.collect::<Vec<_>>();
+
+        let files = FuturesUnordered::from_iter(
+            attachments
+                .into_iter()
+                .map(|document| document.resolve_to_file(ipfs, local).into_future()),
+        )
+        .filter_map(|result| async move { result.ok() })
+        .collect::<Vec<_>>()
+        .await;
+
+        message.set_attachment(files);
+
+        message.set_reactions(self.reactions.clone());
+
         message.set_lines(lines);
 
         Ok(message)
@@ -430,9 +772,12 @@ impl MessageDocument {
     fn sign(mut self, keypair: &Keypair) -> Result<MessageDocument, Error> {
         let did = &keypair.to_did()?;
         let sender = self.sender.to_did();
+
         if !sender.eq(did) {
             return Err(Error::PublicKeyInvalid);
         }
+
+        self.modified = Some(Utc::now());
 
         let attachments_hash = sha256_iter(
             self.attachments

--- a/extensions/warp-ipfs/src/store/conversation/message.rs
+++ b/extensions/warp-ipfs/src/store/conversation/message.rs
@@ -734,7 +734,6 @@ impl MessageDocument {
     ) -> Result<Message, Error> {
         self.verify()?;
 
-        let lines = self.message(keypair, key)?;
         let mut message = Message::default();
         message.set_id(self.id);
         message.set_message_type(self.message_type);
@@ -764,7 +763,13 @@ impl MessageDocument {
 
         message.set_reactions(self.reactions.clone());
 
-        message.set_lines(lines);
+        match self.message(keypair, key) {
+            Ok(lines) => {
+                message.set_lines(lines);
+            }
+            Err(_) if self.message_type == MessageType::Attachment => {}
+            Err(e) => return Err(e),
+        }
 
         Ok(message)
     }

--- a/extensions/warp-ipfs/src/store/conversation/message.rs
+++ b/extensions/warp-ipfs/src/store/conversation/message.rs
@@ -275,97 +275,6 @@ impl<'a> MessageDocumentBuilder<'a> {
 }
 
 impl MessageDocument {
-    // pub fn new(
-    //     keypair: &Keypair,
-    //     message: Message,
-    //     key: Either<&DID, &Keystore>,
-    // ) -> Result<Self, Error> {
-    //     let id = message.id();
-    //     let message_type = message.message_type();
-    //     let conversation_id = message.conversation_id();
-    //     let date = message.date();
-    //     let sender = message.sender();
-    //     let pinned = message.pinned();
-    //     let modified = message.modified();
-    //     let replied = message.replied();
-    //     let lines = message.lines();
-    //     let reactions = message.reactions().to_owned();
-    //     let attachments = message.attachments();
-    //
-    //     if attachments.len() > MAX_ATTACHMENT {
-    //         return Err(Error::InvalidLength {
-    //             context: "attachments".into(),
-    //             current: attachments.len(),
-    //             minimum: None,
-    //             maximum: Some(MAX_ATTACHMENT),
-    //         });
-    //     }
-    //
-    //     if reactions.len() > MAX_REACTIONS {
-    //         return Err(Error::InvalidLength {
-    //             context: "reactions".into(),
-    //             current: reactions.len(),
-    //             minimum: None,
-    //             maximum: Some(MAX_REACTIONS),
-    //         });
-    //     }
-    //
-    //     let attachments = attachments
-    //         .iter()
-    //         .filter_map(|file| FileAttachmentDocument::new(file).ok())
-    //         .collect::<Vec<_>>();
-    //
-    //     if !lines.is_empty() {
-    //         let lines_value_length: usize = lines
-    //             .iter()
-    //             .filter(|s| !s.is_empty())
-    //             .map(|s| s.trim())
-    //             .map(|s| s.chars().count())
-    //             .sum();
-    //
-    //         if lines_value_length > MAX_MESSAGE_SIZE {
-    //             return Err(Error::InvalidLength {
-    //                 context: "message".into(),
-    //                 current: lines_value_length,
-    //                 minimum: None,
-    //                 maximum: Some(MAX_MESSAGE_SIZE),
-    //             });
-    //         }
-    //     }
-    //
-    //     let bytes = serde_json::to_vec(&lines)?;
-    //
-    //     let data = match key {
-    //         Either::Right(keystore) => {
-    //             let key = keystore.get_latest(keypair, sender)?;
-    //             Cipher::direct_encrypt(&bytes, &key)?.into()
-    //         }
-    //         Either::Left(key) => ecdh_encrypt(keypair, Some(key), &bytes)?.into(),
-    //     };
-    //
-    //     let message = Some(data);
-    //
-    //     let sender = DIDEd25519Reference::from_did(sender);
-    //
-    //     let document = MessageDocument {
-    //         id,
-    //         message_type,
-    //         sender,
-    //         conversation_id,
-    //         version: MessageVersion::default(),
-    //         date,
-    //         reactions,
-    //         attachments,
-    //         message,
-    //         pinned,
-    //         modified,
-    //         replied,
-    //         signature: None,
-    //     };
-    //
-    //     document.sign(keypair)
-    // }
-
     pub fn set_message_type(mut self, message_type: MessageType) -> Self {
         self.message_type = message_type;
         self
@@ -516,37 +425,6 @@ impl MessageDocument {
         let sender = self.sender.to_did();
 
         self.modified = Some(modified);
-
-        //
-        // if !message.is_empty() {
-        //     let lines_value_length: usize = message
-        //         .iter()
-        //         .filter(|s| !s.is_empty())
-        //         .map(|s| s.trim())
-        //         .map(|s| s.chars().count())
-        //         .sum();
-        //
-        //     if lines_value_length > MAX_MESSAGE_SIZE {
-        //         return Err(Error::InvalidLength {
-        //             context: "message".into(),
-        //             current: lines_value_length,
-        //             minimum: None,
-        //             maximum: Some(MAX_MESSAGE_SIZE),
-        //         });
-        //     }
-        // }
-        //
-        // let bytes = serde_json::to_vec(&message)?;
-        //
-        // let data = match keystore {
-        //     Either::Right(keystore) => {
-        //         let key = keystore.get_latest(keypair, &sender)?;
-        //         Cipher::direct_encrypt(&bytes, &key)?.into()
-        //     }
-        //     Either::Left(key) => ecdh_encrypt(keypair, Some(key), &bytes)?.into(),
-        // };
-        //
-        // self.message = Some(data);
 
         if !message.is_empty() {
             let lines_value_length: usize = message

--- a/extensions/warp-ipfs/src/store/conversation/reference.rs
+++ b/extensions/warp-ipfs/src/store/conversation/reference.rs
@@ -169,10 +169,11 @@ impl MessageReferenceList {
         if let Ok(message_document) = ipfs
             .get_dag(path)
             .timeout(Duration::from_secs(10))
-            .deserialized()
+            .deserialized::<MessageDocument>()
             .await
         {
             //We can ignore the error
+            message_document.verify()?;
             return Ok(message_document);
         }
 
@@ -184,7 +185,7 @@ impl MessageReferenceList {
             .deserialized::<MessageReferenceList>()
             .await?;
 
-        return refs_list.get(ipfs, message_id).await;
+        refs_list.get(ipfs, message_id).await
     }
 
     #[async_recursion::async_recursion]

--- a/extensions/warp-ipfs/src/store/document.rs
+++ b/extensions/warp-ipfs/src/store/document.rs
@@ -10,6 +10,7 @@ use pollable_map::futures::FutureMap;
 use rust_ipfs as ipfs;
 use serde::{Deserialize, Serialize};
 use std::future::IntoFuture;
+use std::hash::{Hash, Hasher};
 use std::{collections::BTreeMap, path::Path, str::FromStr, time::Duration};
 use uuid::Uuid;
 
@@ -498,9 +499,20 @@ pub struct FileAttachmentDocument {
     pub data: String,
 }
 
+impl Hash for FileAttachmentDocument {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.name.hash(state);
+        self.size.hash(state);
+        self.creation.hash(state);
+        self.thumbnail.hash(state);
+        self.data.hash(state);
+    }
+}
+
 impl FileAttachmentDocument {
-    pub fn new(file: &File) -> Result<Self, Error> {
-        let file_document = FileDocument::new(file);
+    pub fn new(file: impl Into<FileDocument>) -> Result<Self, Error> {
+        let file_document = file.into();
         file_document.to_attachment()
     }
 

--- a/extensions/warp-ipfs/src/store/document/files.rs
+++ b/extensions/warp-ipfs/src/store/document/files.rs
@@ -189,6 +189,18 @@ pub struct FileDocument {
     pub hash: Hash,
 }
 
+impl From<File> for FileDocument {
+    fn from(file: File) -> Self {
+        Self::new(&file)
+    }
+}
+
+impl From<&File> for FileDocument {
+    fn from(file: &File) -> Self {
+        Self::new(file)
+    }
+}
+
 impl FileDocument {
     pub fn new(file: &File) -> FileDocument {
         let mut document = FileDocument {

--- a/extensions/warp-ipfs/src/store/message/community_task.rs
+++ b/extensions/warp-ipfs/src/store/message/community_task.rs
@@ -37,7 +37,7 @@ use web_time::Instant;
 use crate::store::community::{
     CommunityChannelDocument, CommunityDocument, CommunityInviteDocument, CommunityRoleDocument,
 };
-use crate::store::conversation::message::MessageDocument;
+use crate::store::conversation::message::{MessageDocument, MessageDocumentBuilder};
 use crate::store::discovery::Discovery;
 use crate::store::document::files::FileDocument;
 use crate::store::document::image_dag::ImageDag;
@@ -47,7 +47,7 @@ use crate::store::topics::PeerTopic;
 use crate::store::{
     CommunityUpdateKind, ConversationEvents, ConversationImageType, MAX_COMMUNITY_CHANNELS,
     MAX_COMMUNITY_DESCRIPTION, MAX_CONVERSATION_BANNER_SIZE, MAX_CONVERSATION_ICON_SIZE,
-    MAX_MESSAGE_SIZE, MAX_REACTIONS, MIN_MESSAGE_SIZE,
+    MAX_MESSAGE_SIZE, MIN_MESSAGE_SIZE,
 };
 use crate::utils::{ByteCollection, ExtensionType};
 use crate::{
@@ -2836,15 +2836,15 @@ impl CommunityTask {
         let keypair = self.root.keypair();
         let own_did = self.identity.did_key();
 
-        let mut message = warp::raygun::Message::default();
-        message.set_conversation_id(channel_id);
-        message.set_sender(own_did.clone());
-        message.set_lines(messages.clone());
-
-        let message_id = message.id();
         let keystore = pubkey_or_keystore(&*self)?;
 
-        let message = MessageDocument::new(keypair, message, keystore.as_ref())?;
+        let message = MessageDocumentBuilder::new(keypair, keystore.as_ref())
+            .set_conversation_id(channel_id)
+            .set_sender(own_did.clone())
+            .set_message(messages.clone())?
+            .build()?;
+
+        let message_id = message.id;
 
         let channel = match self.document.channels.get_mut(&channel_id.to_string()) {
             Some(c) => c,
@@ -2952,24 +2952,10 @@ impl CommunityTask {
 
         let mut message_document = channel.get_message_document(&self.ipfs, message_id).await?;
 
-        let mut message = message_document
-            .resolve(&self.ipfs, keypair, true, keystore.as_ref())
-            .await?;
-
-        let sender = message.sender();
-
-        let own_did = &self.identity.did_key();
-
-        if sender.ne(own_did) {
+        if message_document.sender() != self.identity.did_key() {
             return Err(Error::InvalidMessage);
         }
-
-        message.lines_mut().clone_from(&messages);
-        message.set_modified(Utc::now());
-
-        message_document
-            .update(&self.ipfs, keypair, message, None, keystore.as_ref(), None)
-            .await?;
+        message_document = message_document.set_message(keypair, keystore.as_ref(), &messages)?;
 
         let nonce = message_document.nonce_from_message()?;
         let signature = message_document.signature.expect("message to be signed");
@@ -3064,15 +3050,14 @@ impl CommunityTask {
 
         let own_did = self.identity.did_key();
 
-        let mut message = warp::raygun::Message::default();
-        message.set_conversation_id(channel_id);
-        message.set_sender(own_did.clone());
-        message.set_lines(messages);
-        message.set_replied(Some(message_id));
-
         let keystore = pubkey_or_keystore(&*self)?;
 
-        let message = MessageDocument::new(keypair, message, keystore.as_ref())?;
+        let message = MessageDocumentBuilder::new(keypair, keystore.as_ref())
+            .set_conversation_id(channel_id)
+            .set_sender(own_did.clone())
+            .set_replied(message_id)
+            .set_message(messages)?
+            .build()?;
 
         let message_id = message.id;
 
@@ -3195,10 +3180,7 @@ impl CommunityTask {
 
         let tx = self.event_broadcast.clone();
 
-        let keypair = self.root.keypair();
         let own_did = self.identity.did_key();
-
-        let keystore = pubkey_or_keystore(&*self)?;
 
         let channel = match self.document.channels.get_mut(&channel_id.to_string()) {
             Some(c) => c,
@@ -3207,16 +3189,12 @@ impl CommunityTask {
 
         let mut message_document = channel.get_message_document(&self.ipfs, message_id).await?;
 
-        let mut message = message_document
-            .resolve(&self.ipfs, keypair, true, keystore.as_ref())
-            .await?;
-
         let event = match state {
             PinState::Pin => {
-                if message.pinned() {
+                if message_document.pinned() {
                     return Ok(());
                 }
-                *message.pinned_mut() = true;
+                message_document = message_document.set_pin(true);
                 MessageEventKind::CommunityMessagePinned {
                     community_id: self.community_id,
                     channel_id,
@@ -3224,10 +3202,10 @@ impl CommunityTask {
                 }
             }
             PinState::Unpin => {
-                if !message.pinned() {
+                if !message_document.pinned() {
                     return Ok(());
                 }
-                *message.pinned_mut() = false;
+                message_document = message_document.set_pin(false);
                 MessageEventKind::CommunityMessageUnpinned {
                     community_id: self.community_id,
                     channel_id,
@@ -3235,10 +3213,6 @@ impl CommunityTask {
                 }
             }
         };
-
-        message_document
-            .update(&self.ipfs, keypair, message, None, keystore.as_ref(), None)
-            .await?;
 
         let _message_cid = channel
             .update_message_document(&self.ipfs, &message_document)
@@ -3296,11 +3270,7 @@ impl CommunityTask {
 
         let tx = self.event_broadcast.clone();
 
-        let keypair = self.root.keypair();
-
         let own_did = self.identity.did_key();
-
-        let keystore = pubkey_or_keystore(&*self)?;
 
         // let recipients = self.document.participants();
 
@@ -3311,36 +3281,11 @@ impl CommunityTask {
 
         let mut message_document = channel.get_message_document(&self.ipfs, message_id).await?;
 
-        let mut message = message_document
-            .resolve(&self.ipfs, keypair, true, keystore.as_ref())
-            .await?;
-
-        let reactions = message.reactions_mut();
-
         let message_cid;
 
         match state {
             ReactionState::Add => {
-                if reactions.len() >= MAX_REACTIONS {
-                    return Err(Error::InvalidLength {
-                        context: "reactions".into(),
-                        current: reactions.len(),
-                        minimum: None,
-                        maximum: Some(MAX_REACTIONS),
-                    });
-                }
-
-                let entry = reactions.entry(emoji.clone()).or_default();
-
-                if entry.contains(&own_did) {
-                    return Err(Error::ReactionExist);
-                }
-
-                entry.push(own_did.clone());
-
-                message_document
-                    .update(&self.ipfs, keypair, message, None, keystore.as_ref(), None)
-                    .await?;
+                message_document = message_document.add_reaction(&emoji, own_did.clone())?;
 
                 message_cid = channel
                     .update_message_document(&self.ipfs, &message_document)
@@ -3356,25 +3301,7 @@ impl CommunityTask {
                 });
             }
             ReactionState::Remove => {
-                match reactions.entry(emoji.clone()) {
-                    indexmap::map::Entry::Occupied(mut e) => {
-                        let list = e.get_mut();
-
-                        if !list.contains(&own_did) {
-                            return Err(Error::ReactionDoesntExist);
-                        }
-
-                        list.retain(|did| did != &own_did);
-                        if list.is_empty() {
-                            e.swap_remove();
-                        }
-                    }
-                    indexmap::map::Entry::Vacant(_) => return Err(Error::ReactionDoesntExist),
-                };
-
-                message_document
-                    .update(&self.ipfs, keypair, message, None, keystore.as_ref(), None)
-                    .await?;
+                message_document = message_document.remove_reaction(&emoji, own_did.clone())?;
 
                 message_cid = channel
                     .update_message_document(&self.ipfs, &message_document)
@@ -3537,7 +3464,6 @@ impl CommunityTask {
 
         let attachment = message
             .attachments()
-            .iter()
             .find(|attachment| attachment.name == file)
             .ok_or(Error::FileNotFound)?;
 
@@ -3580,7 +3506,6 @@ impl CommunityTask {
 
         let attachment = message
             .attachments()
-            .iter()
             .find(|attachment| attachment.name == file)
             .ok_or(Error::FileNotFound)?;
 
@@ -3774,7 +3699,7 @@ impl CommunityTask {
 
 async fn message_event(
     this: &mut CommunityTask,
-    _sender: &DID,
+    sender: &DID,
     events: CommunityMessagingEvents,
 ) -> Result<(), Error> {
     let community_id = this.community_id;
@@ -3790,9 +3715,7 @@ async fn message_event(
             channel_id,
             message,
         } => {
-            if !message.verify() {
-                return Err(Error::InvalidMessage);
-            }
+            message.verify()?;
 
             let message_id = message.id;
 
@@ -3871,9 +3794,7 @@ async fn message_event(
 
             let mut message_document = channel.get_message_document(&this.ipfs, message_id).await?;
 
-            let mut message = message_document
-                .resolve(&this.ipfs, keypair, true, keystore.as_ref())
-                .await?;
+            message_document.verify()?;
 
             let lines_value_length: usize = lines
                 .iter()
@@ -3896,21 +3817,14 @@ async fn message_event(
                 });
             }
 
-            *message.lines_mut() = lines;
-            message.set_modified(modified);
-
-            let sender = message.sender().to_owned();
-
-            message_document
-                .update(
-                    &this.ipfs,
-                    keypair,
-                    message,
-                    (!signature.is_empty() && sender.ne(&own_did)).then_some(signature),
-                    keystore.as_ref(),
-                    Some(nonce.as_slice()),
-                )
-                .await?;
+            message_document = message_document.set_message_with_nonce(
+                keypair,
+                keystore.as_ref(),
+                modified,
+                lines,
+                (!signature.is_empty() && sender.ne(&own_did)).then_some(signature),
+                Some(nonce.as_slice()),
+            )?;
 
             channel
                 .update_message_document(&this.ipfs, &message_document)
@@ -3982,16 +3896,12 @@ async fn message_event(
 
             let mut message_document = channel.get_message_document(&this.ipfs, message_id).await?;
 
-            let mut message = message_document
-                .resolve(&this.ipfs, keypair, true, keystore.as_ref())
-                .await?;
-
             let event = match state {
                 PinState::Pin => {
-                    if message.pinned() {
+                    if message_document.pinned() {
                         return Ok(());
                     }
-                    *message.pinned_mut() = true;
+                    message_document = message_document.set_pin(true);
                     MessageEventKind::CommunityMessagePinned {
                         community_id,
                         channel_id,
@@ -3999,10 +3909,10 @@ async fn message_event(
                     }
                 }
                 PinState::Unpin => {
-                    if !message.pinned() {
+                    if !message_document.pinned() {
                         return Ok(());
                     }
-                    *message.pinned_mut() = false;
+                    message_document = message_document.set_pin(false);
                     MessageEventKind::CommunityMessageUnpinned {
                         community_id,
                         channel_id,
@@ -4010,10 +3920,6 @@ async fn message_event(
                     }
                 }
             };
-
-            message_document
-                .update(&this.ipfs, keypair, message, None, keystore.as_ref(), None)
-                .await?;
 
             channel
                 .update_message_document(&this.ipfs, &message_document)
@@ -4040,34 +3946,9 @@ async fn message_event(
 
             let mut message_document = channel.get_message_document(&this.ipfs, message_id).await?;
 
-            let mut message = message_document
-                .resolve(&this.ipfs, keypair, true, keystore.as_ref())
-                .await?;
-
-            let reactions = message.reactions_mut();
-
             match state {
                 ReactionState::Add => {
-                    if reactions.len() >= MAX_REACTIONS {
-                        return Err(Error::InvalidLength {
-                            context: "reactions".into(),
-                            current: reactions.len(),
-                            minimum: None,
-                            maximum: Some(MAX_REACTIONS),
-                        });
-                    }
-
-                    let entry = reactions.entry(emoji.clone()).or_default();
-
-                    if entry.contains(&reactor) {
-                        return Err(Error::ReactionExist);
-                    }
-
-                    entry.push(reactor.clone());
-
-                    message_document
-                        .update(&this.ipfs, keypair, message, None, keystore.as_ref(), None)
-                        .await?;
+                    message_document = message_document.add_reaction(&emoji, reactor.clone())?;
 
                     channel
                         .update_message_document(&this.ipfs, &message_document)
@@ -4089,25 +3970,7 @@ async fn message_event(
                     }
                 }
                 ReactionState::Remove => {
-                    match reactions.entry(emoji.clone()) {
-                        indexmap::map::Entry::Occupied(mut e) => {
-                            let list = e.get_mut();
-
-                            if !list.contains(&reactor) {
-                                return Err(Error::ReactionDoesntExist);
-                            }
-
-                            list.retain(|did| did != &reactor);
-                            if list.is_empty() {
-                                e.swap_remove();
-                            }
-                        }
-                        indexmap::map::Entry::Vacant(_) => return Err(Error::ReactionDoesntExist),
-                    };
-
-                    message_document
-                        .update(&this.ipfs, keypair, message, None, keystore.as_ref(), None)
-                        .await?;
+                    message_document = message_document.remove_reaction(&emoji, own_did.clone())?;
 
                     channel
                         .update_message_document(&this.ipfs, &message_document)

--- a/extensions/warp-ipfs/src/store/message/community_task.rs
+++ b/extensions/warp-ipfs/src/store/message/community_task.rs
@@ -2955,7 +2955,7 @@ impl CommunityTask {
         if message_document.sender() != self.identity.did_key() {
             return Err(Error::InvalidMessage);
         }
-        message_document = message_document.set_message(keypair, keystore.as_ref(), &messages)?;
+        message_document.set_message(keypair, keystore.as_ref(), &messages)?;
 
         let nonce = message_document.nonce_from_message()?;
         let signature = message_document.signature.expect("message to be signed");
@@ -3817,7 +3817,7 @@ async fn message_event(
                 });
             }
 
-            message_document = message_document.set_message_with_nonce(
+            message_document.set_message_with_nonce(
                 keypair,
                 keystore.as_ref(),
                 modified,

--- a/extensions/warp-ipfs/src/store/message/community_task.rs
+++ b/extensions/warp-ipfs/src/store/message/community_task.rs
@@ -3194,7 +3194,7 @@ impl CommunityTask {
                 if message_document.pinned() {
                     return Ok(());
                 }
-                message_document = message_document.set_pin(true);
+                message_document.set_pin(true);
                 MessageEventKind::CommunityMessagePinned {
                     community_id: self.community_id,
                     channel_id,
@@ -3205,7 +3205,7 @@ impl CommunityTask {
                 if !message_document.pinned() {
                     return Ok(());
                 }
-                message_document = message_document.set_pin(false);
+                message_document.set_pin(false);
                 MessageEventKind::CommunityMessageUnpinned {
                     community_id: self.community_id,
                     channel_id,
@@ -3285,7 +3285,7 @@ impl CommunityTask {
 
         match state {
             ReactionState::Add => {
-                message_document = message_document.add_reaction(&emoji, own_did.clone())?;
+                message_document.add_reaction(&emoji, own_did.clone())?;
 
                 message_cid = channel
                     .update_message_document(&self.ipfs, &message_document)
@@ -3301,7 +3301,7 @@ impl CommunityTask {
                 });
             }
             ReactionState::Remove => {
-                message_document = message_document.remove_reaction(&emoji, own_did.clone())?;
+                message_document.remove_reaction(&emoji, own_did.clone())?;
 
                 message_cid = channel
                     .update_message_document(&self.ipfs, &message_document)
@@ -3901,7 +3901,7 @@ async fn message_event(
                     if message_document.pinned() {
                         return Ok(());
                     }
-                    message_document = message_document.set_pin(true);
+                    message_document.set_pin(true);
                     MessageEventKind::CommunityMessagePinned {
                         community_id,
                         channel_id,
@@ -3912,7 +3912,7 @@ async fn message_event(
                     if !message_document.pinned() {
                         return Ok(());
                     }
-                    message_document = message_document.set_pin(false);
+                    message_document.set_pin(false);
                     MessageEventKind::CommunityMessageUnpinned {
                         community_id,
                         channel_id,
@@ -3948,7 +3948,7 @@ async fn message_event(
 
             match state {
                 ReactionState::Add => {
-                    message_document = message_document.add_reaction(&emoji, reactor.clone())?;
+                    message_document.add_reaction(&emoji, reactor.clone())?;
 
                     channel
                         .update_message_document(&this.ipfs, &message_document)
@@ -3970,7 +3970,7 @@ async fn message_event(
                     }
                 }
                 ReactionState::Remove => {
-                    message_document = message_document.remove_reaction(&emoji, own_did.clone())?;
+                    message_document.remove_reaction(&emoji, own_did.clone())?;
 
                     channel
                         .update_message_document(&this.ipfs, &message_document)

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -1418,7 +1418,7 @@ impl ConversationTask {
             return Err(Error::InvalidMessage);
         }
 
-        message_document = message_document.set_message(keypair, keystore.as_ref(), &messages)?;
+        message_document.set_message(keypair, keystore.as_ref(), &messages)?;
 
         let nonce = message_document.nonce_from_message()?;
         let signature = message_document.signature.expect("message to be signed");
@@ -2799,7 +2799,7 @@ async fn message_event(
                 });
             }
 
-            message_document = message_document.set_message_with_nonce(
+            message_document.set_message_with_nonce(
                 keypair,
                 keystore.as_ref(),
                 modified,

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -2929,7 +2929,7 @@ async fn message_event(
                     }
                 }
                 ReactionState::Remove => {
-                    message_document = message_document.remove_reaction(&emoji, own_did.clone())?;
+                    message_document = message_document.remove_reaction(&emoji, reactor.clone())?;
 
                     this.document
                         .update_message_document(&this.ipfs, &message_document)

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -1608,7 +1608,7 @@ impl ConversationTask {
                 if message_document.pinned() {
                     return Ok(());
                 }
-                message_document = message_document.set_pin(true);
+                message_document.set_pin(true);
                 MessageEventKind::MessagePinned {
                     conversation_id: self.conversation_id,
                     message_id,
@@ -1618,7 +1618,7 @@ impl ConversationTask {
                 if !message_document.pinned() {
                     return Ok(());
                 }
-                message_document = message_document.set_pin(false);
+                message_document.set_pin(false);
                 MessageEventKind::MessageUnpinned {
                     conversation_id: self.conversation_id,
                     message_id,
@@ -1686,7 +1686,7 @@ impl ConversationTask {
 
         match state {
             ReactionState::Add => {
-                message_document = message_document.add_reaction(&emoji, own_did.clone())?;
+                message_document.add_reaction(&emoji, own_did.clone())?;
 
                 _message_cid = self
                     .document
@@ -1703,7 +1703,7 @@ impl ConversationTask {
                 });
             }
             ReactionState::Remove => {
-                message_document = message_document.remove_reaction(&emoji, own_did.clone())?;
+                message_document.remove_reaction(&emoji, own_did.clone())?;
 
                 _message_cid = self
                     .document
@@ -2866,7 +2866,7 @@ async fn message_event(
                     if message_document.pinned() {
                         return Ok(());
                     }
-                    message_document = message_document.set_pin(true);
+                    message_document.set_pin(true);
                     MessageEventKind::MessagePinned {
                         conversation_id,
                         message_id,
@@ -2876,7 +2876,7 @@ async fn message_event(
                     if !message_document.pinned() {
                         return Ok(());
                     }
-                    message_document = message_document.set_pin(false);
+                    message_document.set_pin(false);
                     MessageEventKind::MessageUnpinned {
                         conversation_id,
                         message_id,
@@ -2908,7 +2908,7 @@ async fn message_event(
 
             match state {
                 ReactionState::Add => {
-                    message_document = message_document.add_reaction(&emoji, reactor.clone())?;
+                    message_document.add_reaction(&emoji, reactor.clone())?;
 
                     this.document
                         .update_message_document(&this.ipfs, &message_document)
@@ -2929,7 +2929,7 @@ async fn message_event(
                     }
                 }
                 ReactionState::Remove => {
-                    message_document = message_document.remove_reaction(&emoji, reactor.clone())?;
+                    message_document.remove_reaction(&emoji, reactor.clone())?;
 
                     this.document
                         .update_message_document(&this.ipfs, &message_document)

--- a/warp/src/raygun/mod.rs
+++ b/warp/src/raygun/mod.rs
@@ -1098,7 +1098,7 @@ pub struct Message {
     pinned: bool,
 
     /// List of the reactions for the `Message`
-    reactions: IndexMap<String, Vec<DID>>,
+    reactions: IndexMap<String, IndexSet<DID>>,
 
     /// List of users public keys mentioned in this message
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -1187,7 +1187,7 @@ impl Message {
         self.pinned
     }
 
-    pub fn reactions(&self) -> &IndexMap<String, Vec<DID>> {
+    pub fn reactions(&self) -> &IndexMap<String, IndexSet<DID>> {
         &self.reactions
     }
 
@@ -1241,7 +1241,7 @@ impl Message {
         self.pinned = pin
     }
 
-    pub fn set_reactions(&mut self, reaction: IndexMap<String, Vec<DID>>) {
+    pub fn set_reactions(&mut self, reaction: IndexMap<String, IndexSet<DID>>) {
         self.reactions = reaction
     }
 
@@ -1272,7 +1272,7 @@ impl Message {
         &mut self.pinned
     }
 
-    pub fn reactions_mut(&mut self) -> &mut IndexMap<String, Vec<DID>> {
+    pub fn reactions_mut(&mut self) -> &mut IndexMap<String, IndexSet<DID>> {
         &mut self.reactions
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Add `MessageDocumentBuilder` to be able to build the message document rather than performing redundant conversions
- Remove `MessageDocument::new`
- Add setters, moving additional logic into them to reduce duplication of code.
 - Use `IndexSet` in reactions map. 
 - Return a `Result` in `MessageDocument::verify`

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- Previously, we would build out a `Message` and perform a conversion into `MessageDocument`, but this could be seen as redundant in many cases as we are converting back and forth between the two in different areas when this should not be the case. With this PR, we remove that redundant factor by adding a builder to construct the `MessageDocument` for later use. Additionally, we add setters, which would allow us to reduce duplicated code in other parts of the code case, and be able to simplify logic all around. 