### PR TITLE
chore: shift to using CommunicationTask

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ futures-timeout = "0.1.0"
 async-trait = { version = "0.1" }
 async-stream = "0.3"
 async-broadcast = "0.5"
-pollable-map = "0.1.0-alpha.1"
+pollable-map = "0.1.0"
 tokio = { version = "1", features = [
     "macros",
     "fs",

--- a/extensions/warp-ipfs/Cargo.toml
+++ b/extensions/warp-ipfs/Cargo.toml
@@ -38,7 +38,7 @@ image = { workspace = true }
 derive_more.workspace = true
 mediatype.workspace = true
 
-async-rt = "0.1.4"
+async-rt = "0.1.5"
 
 bincode.workspace = true
 bytes.workspace = true

--- a/extensions/warp-ipfs/src/store/message.rs
+++ b/extensions/warp-ipfs/src/store/message.rs
@@ -52,7 +52,6 @@ use crate::store::{
 
 use crate::store::community::CommunityDocument;
 use chrono::{DateTime, Utc};
-use futures::channel::mpsc::Receiver;
 use warp::raygun::community::{
     Community, CommunityChannel, CommunityChannelPermission, CommunityChannelType, CommunityInvite,
     CommunityPermission, CommunityRole, RoleId,
@@ -2164,13 +2163,11 @@ impl ConversationInner {
         )
         .await?;
 
-        let conversation_task = async_rt::task::spawn_coroutine_with_context(
-            task,
-            move |mut fut, rx: Receiver<ConversationTaskCommand>| async move {
+        let conversation_task =
+            async_rt::task::spawn_coroutine_with_context(task, move |mut fut, rx| async move {
                 fut.set_receiver(rx);
                 fut.run().await;
-            },
-        );
+            });
 
         tracing::info!(%conversation_id, "started conversation");
 

--- a/extensions/warp-ipfs/src/store/message/task.rs
+++ b/extensions/warp-ipfs/src/store/message/task.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 use either::Either;
 use futures::channel::oneshot;
 use futures::stream::BoxStream;
-use futures::{StreamExt, TryFutureExt};
+use futures::{Stream, StreamExt, TryFutureExt};
 use futures_timer::Delay;
 use indexmap::{IndexMap, IndexSet};
 use ipld_core::cid::Cid;
@@ -225,6 +225,9 @@ pub enum ConversationTaskCommand {
     },
 }
 
+unsafe impl Send for ConversationTaskCommand {}
+unsafe impl Sync for ConversationTaskCommand {}
+
 pub struct ConversationTask {
     conversation_id: Uuid,
     ipfs: Ipfs,
@@ -245,13 +248,16 @@ pub struct ConversationTask {
     event_broadcast: tokio::sync::broadcast::Sender<MessageEventKind>,
     event_subscription: EventSubscription<RayGunEventKind>,
 
-    command_rx: futures::channel::mpsc::Receiver<ConversationTaskCommand>,
+    command_rx: BoxStream<'static, ConversationTaskCommand>,
 
     //TODO: replace queue
     queue: HashMap<DID, Vec<QueueItem>>,
 
     terminate: ConversationTermination,
 }
+
+unsafe impl Send for ConversationTask {}
+unsafe impl Sync for ConversationTask {}
 
 #[derive(Default, Debug)]
 struct ConversationTermination {
@@ -289,7 +295,6 @@ impl ConversationTask {
         identity: &IdentityStore,
         file: &FileStore,
         discovery: &Discovery,
-        command_rx: futures::channel::mpsc::Receiver<ConversationTaskCommand>,
         event_subscription: EventSubscription<RayGunEventKind>,
     ) -> Result<Self, Error> {
         let document = root.get_conversation_document(conversation_id).await?;
@@ -324,7 +329,7 @@ impl ConversationTask {
             attachment_rx: arx,
             event_broadcast: btx,
             event_subscription,
-            command_rx,
+            command_rx: futures::stream::empty().boxed(),
             queue: Default::default(),
             terminate: ConversationTermination::default(),
         };
@@ -378,6 +383,13 @@ impl ConversationTask {
 
         tracing::info!(%conversation_id, "conversation task created");
         Ok(task)
+    }
+
+    pub fn set_receiver(
+        &mut self,
+        st: impl Stream<Item = ConversationTaskCommand> + 'static + Send,
+    ) {
+        self.command_rx = Box::pin(st);
     }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
If this is your first time, please read our contributor guidelines: https://github.com/Satellite-im/Core-PWA/wiki/Contributing
-->

**What this PR does** 📖
- Use `CommunicationTask` to handle communication with conversation tasks.
- Use `OptionalStream` for the receiver

**Which issue(s) this PR fixes** 🔨

<!--AP-X-->

**Special notes for reviewers** 🗒️

**Additional comments** 🎤
- This change will make it cleaner to handle and communicate with the task without exposing additional channels.